### PR TITLE
Improve backlog apply UX and align pre-commit/CI tox quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,23 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  pre-commit-hooks:
+    if: hashFiles('.pre-commit-config.yaml') != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit
+      - name: Run non-tox pre-commit hooks
+        env:
+          SKIP: tox-suite
+        run: pre-commit run --all-files --show-diff-on-failure
+
   tox:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,25 +3,6 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install pre-commit
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pre-commit
-
-      - name: Run pre-commit
-        run: pre-commit run --all-files --show-diff-on-failure
-
   tox:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,43 +3,25 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  pre-commit-hooks:
-    if: hashFiles('.pre-commit-config.yaml') != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install pre-commit
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pre-commit
-      - name: Run non-tox pre-commit hooks
-        env:
-          SKIP: tox-suite
-        run: pre-commit run --all-files --show-diff-on-failure
-
-  tox:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        env: [lint, type, test]
-
+        tox-env: [lint, type, test]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
+      - name: Install Poetry
+        run: pip install poetry
 
-      - name: Run tox (${{ matrix.env }})
-        run: tox -e ${{ matrix.env }}
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run tox (${{ matrix.tox-env }})
+        run: poetry run tox -e ${{ matrix.tox-env }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,17 @@ repos:
     rev: v4.6.0
     hooks:
       - id: check-merge-conflict
+      - id: check-added-large-files
       - id: check-yaml
       - id: check-toml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+  - repo: local
     hooks:
-      - id: ruff
-        args: [--fix]
-      - id: ruff-format
+      - id: tox-suite
+        name: run tox suite (lint, type, test-fast)
+        entry: poetry run tox
+        language: system
+        pass_filenames: false
+        args: ["-e", "precommit", "-vv"]
+        verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - repo: local
     hooks:
       - id: tox-suite
-        name: run tox suite (lint, type, test-fast)
+        name: run tox suite (format, lint, type, test-fast)
         entry: poetry run tox
         language: system
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,10 @@ repos:
     hooks:
       - id: tox-suite
         name: run tox suite (format, lint, type, test-fast)
-        entry: poetry run tox
-        language: system
+        entry: tox
+        language: python
+        additional_dependencies:
+          - tox>=4.20.0
         pass_filenames: false
         args: ["-e", "precommit", "-vv"]
         verbose: true

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Workflow model:
 ## Install
 
 ```bash
-poetry install --with dev
+poetry install
 ```
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ poetry run pre-commit install
 poetry run pre-commit run --all-files
 ```
 
-`pre-commit` runs a local tox gate (`lint`, `type`, `test-fast`) via the `tox-suite` hook.
+`pre-commit` runs a local tox gate via the `tox-suite` hook: auto-format first, then `lint`, `type`, and `test-fast`.
 
 Tox workflow (lint, type, test):
 

--- a/README.md
+++ b/README.md
@@ -343,10 +343,18 @@ poetry run pre-commit install
 poetry run pre-commit run --all-files
 ```
 
+`pre-commit` runs a local tox gate (`lint`, `type`, `test-fast`) via the `tox-suite` hook.
+
 Tox workflow (lint, type, test):
 
 ```bash
 tox -e lint,type,test
+```
+
+Fast tox gate used by pre-commit:
+
+```bash
+tox -e precommit
 ```
 
 Auto-fix Python formatting/lint issues:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Subcommands:
 - `templates`: apply `.github` PR/issue templates, issue config, and `CODEOWNERS`
 - `ci --languages <list>`: apply `.github/workflows/ci.yml`
 - `dependabot [--low-noise]`: apply `.github/dependabot.yml`
-- `backlog --repo owner/repo [--file backlog/issues.json] [--dry-run] [--auth-check] [--with-project] [--project-number N | --project-title T] [--project-owner O]`: bulk-create milestones/issues using `gh`
+- `backlog --repo owner/repo [--file PATH] [--dry-run] [--auth-check] [--with-project] [--project-number N | --project-title T] [--project-owner O]`: bulk-create milestones/issues using `gh`
 - `rules [--repo owner/repo] [--apply]`: print or apply recommended `gh api` repo rules
 
 ### `delete`
@@ -142,6 +142,7 @@ Per-file output labels:
 - falls back to `gh auth status` / `gh auth login`
 - supports `--auth-check` to validate token/session (`gh api /user`) before writing anything
 - ticket bodies prepend an `Epic: #<number>` link to the created/found epic issue
+- summary output splits epic issue counts and ticket issue counts (plus total issue counts)
 - `--with-project` enables project integration with zero extra args
   if no project is specified, default project title is `<repo-name> Roadmap`
   optional env override: `GITHUB_PROJECT_TITLE` or `GITHUB_PROJECT_TITLE_TEMPLATE` (supports `{repo}`)
@@ -196,7 +197,10 @@ poetry run repo-scaffold apply backlog --path /path/to/repo --repo OWNER/REPO --
 
 ## Backlog JSON format
 
-Backlog input is JSON only. Default path: `backlog/issues.json`.
+Backlog input is JSON only. If `--file` is omitted, fallback order is:
+1. `local/backlog/issues.json` (when present in the current working directory)
+2. `<repo-path>/backlog/issues.json` (where `--path` defaults to `.`)
+
 Completed sample file: `examples/backlog/issues.sample.json`.
 Workspace-local private path in this repo: `local/backlog/issues.json` (git-ignored).
 
@@ -282,7 +286,7 @@ Edit these source templates to customize generated `.github` markdown:
 - `src/repo_scaffold/templates/github/ISSUE_TEMPLATE/epic.md`
 - `src/repo_scaffold/templates/github/ISSUE_TEMPLATE/ticket.md`
 
-`init` does not create a backlog file by default. Keep backlog JSON in this toolkit repo (for example `local/backlog/issues.json`) and pass it with `apply backlog --file`.
+`init` does not create a backlog file by default. Keep backlog JSON in this toolkit repo (for example `local/backlog/issues.json`); `apply backlog` now picks it up automatically when `--file` is omitted.
 
 ## PR Creation Workflow
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -446,4 +446,4 @@ typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "498c98f23f572383ee88d109f41e9017cbe074cbe735136058d35b1ba4140b53"
+content-hash = "38bc2617dfb6b85c19e72be437cb99979bff60b366db8920911e0e67a48783be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,6 @@ include = ["src/repo_scaffold/templates/**/*"]
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 
-[tool.poetry.group.dev]
-optional = true
-
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"
 pre-commit = ">=3.8.0"

--- a/src/repo_scaffold/backlog_ops.py
+++ b/src/repo_scaffold/backlog_ops.py
@@ -18,6 +18,10 @@ class BacklogApplySummary:
     issues_created: int
     issues_skipped: int
     failures: int
+    epic_issues_created: int = 0
+    epic_issues_skipped: int = 0
+    ticket_issues_created: int = 0
+    ticket_issues_skipped: int = 0
     project_created: bool = False
     project_items_added: int = 0
     project_items_skipped: int = 0
@@ -103,9 +107,19 @@ def _list_projects(repo_dir: Path, owner: str) -> list[dict[str, object]]:
         detail = cp.stderr.strip() or cp.stdout.strip() or "Failed listing projects."
         raise RuntimeError(_project_scope_hint(detail))
     data = json.loads(cp.stdout or "[]")
-    if not isinstance(data, list):
+    if isinstance(data, list):
+        projects = data
+    elif isinstance(data, dict):
+        projects = data.get("projects")
+        if not isinstance(projects, list):
+            projects = data.get("items")
+        if not isinstance(projects, list):
+            projects = data.get("nodes")
+        if not isinstance(projects, list):
+            raise RuntimeError("Unexpected response from gh project list.")
+    else:
         raise RuntimeError("Unexpected response from gh project list.")
-    return [item for item in data if isinstance(item, dict)]
+    return [item for item in projects if isinstance(item, dict)]
 
 
 def _project_title_for_number(repo_dir: Path, owner: str, number: int) -> str:
@@ -610,6 +624,10 @@ def apply_backlog(
     issues_created = 0
     issues_skipped = 0
     failures = 0
+    epic_issues_created = 0
+    epic_issues_skipped = 0
+    ticket_issues_created = 0
+    ticket_issues_skipped = 0
     project_items_added = 0
     project_items_skipped = 0
 
@@ -715,6 +733,7 @@ def apply_backlog(
         number = _find_issue_number(repo_dir, repo, epic_title)
         if number is not None:
             issues_skipped += 1
+            epic_issues_skipped += 1
             epic_numbers[epic_title] = number
             out(f"Skip issue (exists): {epic_title}")
             if project is not None:
@@ -734,6 +753,7 @@ def apply_backlog(
         else:
             if dry_run:
                 issues_created += 1
+                epic_issues_created += 1
                 epic_numbers[epic_title] = None
                 out(f"[dry-run] create issue: {epic_title}")
                 if project is not None:
@@ -763,6 +783,7 @@ def apply_backlog(
                     )
                     epic_numbers[epic_title] = number
                     issues_created += 1
+                    epic_issues_created += 1
                     out(f"Created issue: {epic_title}")
                     if project is not None:
                         added, skipped, failed = _add_issue_to_project(
@@ -812,6 +833,7 @@ def apply_backlog(
             existing_number = _find_issue_number(repo_dir, repo, title)
             if existing_number is not None:
                 issues_skipped += 1
+                ticket_issues_skipped += 1
                 out(f"Skip issue (exists): {title}")
                 if project is not None:
                     added, skipped, failed = _add_issue_to_project(
@@ -844,6 +866,7 @@ def apply_backlog(
 
             if dry_run:
                 issues_created += 1
+                ticket_issues_created += 1
                 out(f"[dry-run] create issue: {title}")
                 if project is not None:
                     added, skipped, failed = _add_issue_to_project(
@@ -872,6 +895,7 @@ def apply_backlog(
                     epic_title,
                 )
                 issues_created += 1
+                ticket_issues_created += 1
                 out(f"Created issue: {title}")
                 if project is not None:
                     added, skipped, failed = _add_issue_to_project(
@@ -897,6 +921,10 @@ def apply_backlog(
         issues_created=issues_created,
         issues_skipped=issues_skipped,
         failures=failures,
+        epic_issues_created=epic_issues_created,
+        epic_issues_skipped=epic_issues_skipped,
+        ticket_issues_created=ticket_issues_created,
+        ticket_issues_skipped=ticket_issues_skipped,
         project_created=project_created,
         project_items_added=project_items_added,
         project_items_skipped=project_items_skipped,

--- a/src/repo_scaffold/backlog_ops.py
+++ b/src/repo_scaffold/backlog_ops.py
@@ -107,19 +107,21 @@ def _list_projects(repo_dir: Path, owner: str) -> list[dict[str, object]]:
         detail = cp.stderr.strip() or cp.stdout.strip() or "Failed listing projects."
         raise RuntimeError(_project_scope_hint(detail))
     data = json.loads(cp.stdout or "[]")
+    projects_obj: object
     if isinstance(data, list):
-        projects = data
+        projects_obj = data
     elif isinstance(data, dict):
-        projects = data.get("projects")
-        if not isinstance(projects, list):
-            projects = data.get("items")
-        if not isinstance(projects, list):
-            projects = data.get("nodes")
-        if not isinstance(projects, list):
+        projects_obj = data.get("projects")
+        if not isinstance(projects_obj, list):
+            projects_obj = data.get("items")
+        if not isinstance(projects_obj, list):
+            projects_obj = data.get("nodes")
+        if not isinstance(projects_obj, list):
             raise RuntimeError("Unexpected response from gh project list.")
     else:
         raise RuntimeError("Unexpected response from gh project list.")
-    return [item for item in projects if isinstance(item, dict)]
+
+    return [item for item in projects_obj if isinstance(item, dict)]
 
 
 def _project_title_for_number(repo_dir: Path, owner: str, number: int) -> str:

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -31,6 +31,8 @@ from .overwrite_policy import ApplySummary, OverwritePolicy, apply_files
 
 DEFAULT_INIT_NAME_PREFIX = "repo-scaffold-e2e"
 DEFAULT_INIT_LANGUAGES = "go,python,react"
+DEFAULT_BACKLOG_REL_PATH = "backlog/issues.json"
+DEFAULT_LOCAL_BACKLOG_REL_PATH = "local/backlog/issues.json"
 
 
 def _repo_name_from_repo_ref(raw: str | None) -> str | None:
@@ -144,6 +146,17 @@ def _resolve_repo_from_args_or_env(
         None,
         "Error: could not resolve target repo. Pass --repo owner/repo or set GH_REPO (or GITHUB_ORG + GITHUB_REPO) in .env.",
     )
+
+
+def _resolve_backlog_file_path(*, repo_dir: Path, file_arg: str | None) -> Path:
+    if file_arg:
+        backlog_file = Path(file_arg)
+        return backlog_file if backlog_file.is_absolute() else (repo_dir / backlog_file)
+
+    local_backlog = Path.cwd() / DEFAULT_LOCAL_BACKLOG_REL_PATH
+    if local_backlog.exists():
+        return local_backlog
+    return repo_dir / DEFAULT_BACKLOG_REL_PATH
 
 
 def _seed_env_for_parsed_mode(ns: argparse.Namespace) -> None:
@@ -356,8 +369,10 @@ def build_parser() -> argparse.ArgumentParser:
     apply_backlog_cmd.add_argument("--repo", help="Target GitHub repo (owner/repo)")
     apply_backlog_cmd.add_argument(
         "--file",
-        default="backlog/issues.json",
-        help="Backlog JSON path (default: backlog/issues.json)",
+        help=(
+            "Backlog JSON path. If omitted, uses ./local/backlog/issues.json when present, "
+            "otherwise <repo-path>/backlog/issues.json"
+        ),
     )
     apply_backlog_cmd.add_argument(
         "--with-project",
@@ -783,9 +798,7 @@ def main(argv: list[str] | None = None) -> int:
             if project_target is not None:
                 print(f"GitHub project access OK: {project_target}")
             return 0
-        backlog_file = Path(ns.file)
-        if not backlog_file.is_absolute():
-            backlog_file = repo_dir / backlog_file
+        backlog_file = _resolve_backlog_file_path(repo_dir=repo_dir, file_arg=ns.file)
         try:
             backlog_summary: BacklogApplySummary = apply_backlog(
                 repo_dir=repo_dir,
@@ -808,8 +821,12 @@ def main(argv: list[str] | None = None) -> int:
             print("  mode: dry-run")
         print(f"  milestones created: {backlog_summary.milestones_created}")
         print(f"  milestones skipped: {backlog_summary.milestones_skipped}")
-        print(f"  issues created: {backlog_summary.issues_created}")
-        print(f"  issues skipped: {backlog_summary.issues_skipped}")
+        print(f"  epic issues created: {backlog_summary.epic_issues_created}")
+        print(f"  epic issues skipped: {backlog_summary.epic_issues_skipped}")
+        print(f"  ticket issues created: {backlog_summary.ticket_issues_created}")
+        print(f"  ticket issues skipped: {backlog_summary.ticket_issues_skipped}")
+        print(f"  issues created (total): {backlog_summary.issues_created}")
+        print(f"  issues skipped (total): {backlog_summary.issues_skipped}")
         if effective_project_number is not None or effective_project_title:
             print(f"  project created: {backlog_summary.project_created}")
             print(f"  project items added: {backlog_summary.project_items_added}")

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -190,21 +190,6 @@ env:
   LANGUAGES: "{joined}"
 
 jobs:
-  pre-commit:
-    if: hashFiles('.pre-commit-config.yaml') != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install pre-commit
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pre-commit
-      - name: Run pre-commit
-        run: pre-commit run --all-files --show-diff-on-failure
-
   go:
     if: contains(env.LANGUAGES, 'go') && hashFiles('go.mod') != ''
     runs-on: ubuntu-latest
@@ -570,6 +555,8 @@ def _render_repo_readme(config: ScaffoldConfig) -> str:
             "pre-commit run --all-files",
             "```",
             "",
+            "For parity with CI quality gates, pre-commit also runs `tox -e precommit`.",
+            "",
         ]
     )
 
@@ -587,6 +574,7 @@ def _render_repo_readme(config: ScaffoldConfig) -> str:
                 "mypy src",
                 "pytest",
                 "tox -e lint,type,test",
+                "tox -e precommit",
                 "```",
                 "",
                 "CI runs the same Python quality matrix via tox (`lint`, `type`, `test`).",
@@ -2214,6 +2202,20 @@ commands =
 deps = -e .[dev]
 commands =
     pytest -q {posargs:tests}
+
+[testenv:test-fast]
+deps = -e .[dev]
+commands =
+    pytest -q -m "not e2e_github" {posargs:tests}
+
+[testenv:precommit]
+skip_install = true
+depends =
+    lint
+    type
+    test-fast
+commands =
+    python -c "print('tox precommit suite complete')"
 """
 
 
@@ -2233,12 +2235,15 @@ def _render_pre_commit_config(languages: Iterable[str]) -> str:
     if "python" in selected:
         lines.extend(
             [
-                "  - repo: https://github.com/astral-sh/ruff-pre-commit",
-                "    rev: v0.6.9",
+                "  - repo: local",
                 "    hooks:",
-                "      - id: ruff",
-                "        args: [--fix]",
-                "      - id: ruff-format",
+                "      - id: tox-suite",
+                "        name: run tox suite (lint, type, test-fast)",
+                "        entry: poetry run tox",
+                "        language: system",
+                "        pass_filenames: false",
+                "        args: [\"-e\", \"precommit\", \"-vv\"]",
+                "        verbose: true",
             ]
         )
     return "\n".join(lines) + "\n"

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -2191,7 +2191,6 @@ no_implicit_optional = true
 def _render_tox_ini() -> str:
     return """[tox]
 envlist = lint,type,test
-isolated_build = true
 
 [testenv]
 deps = -e .[dev]

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -190,6 +190,23 @@ env:
   LANGUAGES: "{joined}"
 
 jobs:
+  pre-commit-hooks:
+    if: hashFiles('.pre-commit-config.yaml') != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit
+      - name: Run non-tox pre-commit hooks
+        env:
+          SKIP: tox-suite
+        run: pre-commit run --all-files --show-diff-on-failure
+
   go:
     if: contains(env.LANGUAGES, 'go') && hashFiles('go.mod') != ''
     runs-on: ubuntu-latest
@@ -2246,8 +2263,10 @@ def _render_pre_commit_config(languages: Iterable[str]) -> str:
                 "    hooks:",
                 "      - id: tox-suite",
                 "        name: run tox suite (lint, type, test-fast)",
-                "        entry: poetry run tox",
-                "        language: system",
+                "        entry: tox",
+                "        language: python",
+                "        additional_dependencies:",
+                "          - tox>=4.20.0",
                 "        pass_filenames: false",
                 '        args: ["-e", "precommit", "-vv"]',
                 "        verbose: true",

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -2210,12 +2210,19 @@ commands =
 
 [testenv:precommit]
 skip_install = true
-depends =
-    lint
-    type
-    test-fast
+setenv =
+    {[testenv]setenv}
+    PYTHONPATH={toxinidir}/src
+deps =
+    {[testenv:format]deps}
+    {[testenv:lint]deps}
+    {[testenv:type]deps}
+    {[testenv:test-fast]deps}
 commands =
-    python -c "print('tox precommit suite complete')"
+    {[testenv:format]commands}
+    {[testenv:lint]commands}
+    {[testenv:type]commands}
+    {[testenv:test-fast]commands}
 """
 
 
@@ -2242,7 +2249,7 @@ def _render_pre_commit_config(languages: Iterable[str]) -> str:
                 "        entry: poetry run tox",
                 "        language: system",
                 "        pass_filenames: false",
-                "        args: [\"-e\", \"precommit\", \"-vv\"]",
+                '        args: ["-e", "precommit", "-vv"]',
                 "        verbose: true",
             ]
         )

--- a/tests/test_backlog_ops.py
+++ b/tests/test_backlog_ops.py
@@ -114,6 +114,10 @@ def test_apply_backlog_creates_missing_labels(
     assert summary.failures == 0
     assert summary.milestones_created == 1
     assert summary.issues_created == 2
+    assert summary.epic_issues_created == 1
+    assert summary.ticket_issues_created == 1
+    assert summary.epic_issues_skipped == 0
+    assert summary.ticket_issues_skipped == 0
     assert set(created_labels) == {"epic", "ticket", "epic:E2E"}
     assert len(created_issues) == 2
     assert created_issues[0]["title"] == "Epic e2e"
@@ -250,6 +254,26 @@ def test_apply_backlog_project_title_creates_and_adds_items(
     assert summary.project_items_skipped == 0
     assert summary.milestones_created == 1
     assert summary.issues_skipped == 2
+    assert summary.epic_issues_skipped == 1
+    assert summary.ticket_issues_skipped == 1
+
+
+def test_list_projects_supports_wrapped_json_response(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        backlog_ops,
+        "_run_gh",
+        lambda _repo_dir, _args: _cp_ok(
+            '{"projects":[{"number":1,"title":"Roadmap"}]}'
+        ),
+    )
+
+    projects = backlog_ops._list_projects(repo_dir, "acme")
+    assert projects == [{"number": 1, "title": "Roadmap"}]
 
 
 def test_apply_backlog_requires_epic_body_and_key(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,7 +172,9 @@ def test_apply_dependabot_infers_languages_from_repo(tmp_path: Path) -> None:
 
 
 def test_apply_backlog_subcommand_delegates_to_backlog_ops(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir(parents=True)
@@ -207,6 +209,10 @@ def test_apply_backlog_subcommand_delegates_to_backlog_ops(
             issues_created=3,
             issues_skipped=4,
             failures=0,
+            epic_issues_created=1,
+            epic_issues_skipped=1,
+            ticket_issues_created=2,
+            ticket_issues_skipped=3,
         )
 
     monkeypatch.setattr("repo_scaffold.cli.apply_backlog", _fake_apply_backlog)
@@ -232,6 +238,131 @@ def test_apply_backlog_subcommand_delegates_to_backlog_ops(
     assert called["project_number"] is None
     assert called["project_title"] is None
     assert called["project_owner"] is None
+    stdout = capsys.readouterr().out
+    assert "epic issues created: 1" in stdout
+    assert "epic issues skipped: 1" in stdout
+    assert "ticket issues created: 2" in stdout
+    assert "ticket issues skipped: 3" in stdout
+    assert "issues created (total): 3" in stdout
+    assert "issues skipped (total): 4" in stdout
+
+
+def test_apply_backlog_defaults_to_local_backlog_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    local_backlog = workspace / "local" / "backlog"
+    local_backlog.mkdir(parents=True)
+    (local_backlog / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+
+    repo_dir = workspace / "repo"
+    repo_dir.mkdir(parents=True)
+    (repo_dir / "backlog").mkdir(parents=True)
+    (repo_dir / "backlog" / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+
+    monkeypatch.chdir(workspace)
+
+    called: dict[str, object] = {}
+
+    def _fake_apply_backlog(
+        *,
+        repo_dir: Path,
+        repo: str,
+        backlog_file: Path,
+        dry_run: bool,
+        project_number,
+        project_title,
+        project_owner,
+        out,
+        err,
+    ):
+        called["repo_dir"] = repo_dir
+        called["repo"] = repo
+        called["backlog_file"] = backlog_file
+        return BacklogApplySummary(
+            milestones_created=0,
+            milestones_skipped=0,
+            issues_created=0,
+            issues_skipped=0,
+            failures=0,
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.apply_backlog", _fake_apply_backlog)
+
+    rc = main(
+        [
+            "apply",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--repo",
+            "acme/repo",
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    assert called["repo_dir"] == repo_dir
+    assert called["repo"] == "acme/repo"
+    assert called["backlog_file"] == local_backlog / "issues.json"
+
+
+def test_apply_backlog_defaults_to_repo_backlog_when_local_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+
+    repo_dir = workspace / "repo"
+    repo_dir.mkdir(parents=True)
+    repo_backlog = repo_dir / "backlog"
+    repo_backlog.mkdir(parents=True)
+    (repo_backlog / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+
+    monkeypatch.chdir(workspace)
+
+    called: dict[str, object] = {}
+
+    def _fake_apply_backlog(
+        *,
+        repo_dir: Path,
+        repo: str,
+        backlog_file: Path,
+        dry_run: bool,
+        project_number,
+        project_title,
+        project_owner,
+        out,
+        err,
+    ):
+        called["repo_dir"] = repo_dir
+        called["repo"] = repo
+        called["backlog_file"] = backlog_file
+        return BacklogApplySummary(
+            milestones_created=0,
+            milestones_skipped=0,
+            issues_created=0,
+            issues_skipped=0,
+            failures=0,
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.apply_backlog", _fake_apply_backlog)
+
+    rc = main(
+        [
+            "apply",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--repo",
+            "acme/repo",
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    assert called["repo_dir"] == repo_dir
+    assert called["repo"] == "acme/repo"
+    assert called["backlog_file"] == repo_backlog / "issues.json"
 
 
 def test_apply_backlog_auth_check(

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -129,8 +129,13 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "[testenv:test-fast]" in tox_ini
     assert 'pytest -q -m "not e2e_github" {posargs:tests}' in tox_ini
     assert "[testenv:precommit]" in tox_ini
-    assert "depends =" in tox_ini
-    assert "test-fast" in tox_ini
+    assert "skip_install = true" in tox_ini
+    assert "PYTHONPATH={toxinidir}/src" in tox_ini
+    assert "deps =" in tox_ini
+    assert "{[testenv:format]commands}" in tox_ini
+    assert "{[testenv:lint]commands}" in tox_ini
+    assert "{[testenv:type]commands}" in tox_ini
+    assert "{[testenv:test-fast]commands}" in tox_ini
     assert "black src tests" in tox_ini
     assert "ruff check src tests --fix" in tox_ini
     assert "pytest -q {posargs:tests}" in tox_ini

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -83,7 +83,10 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
         encoding="utf-8"
     )
     ci_yaml = (out_dir / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-    assert "pre-commit:" not in ci_yaml
+    assert "pre-commit-hooks:" in ci_yaml
+    assert "name: Install pre-commit" in ci_yaml
+    assert "SKIP: tox-suite" in ci_yaml
+    assert "pre-commit run --all-files --show-diff-on-failure" in ci_yaml
     assert "tox-env: [lint, type, test]" in ci_yaml
     assert "- name: Install tox" in ci_yaml
     assert "run: tox -e ${{ matrix.tox-env }}" in ci_yaml
@@ -141,6 +144,10 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "pytest -q {posargs:tests}" in tox_ini
     pre_commit = (out_dir / ".pre-commit-config.yaml").read_text(encoding="utf-8")
     assert "id: tox-suite" in pre_commit
+    assert "entry: tox" in pre_commit
+    assert "language: python" in pre_commit
+    assert "additional_dependencies:" in pre_commit
+    assert "tox>=4.20.0" in pre_commit
     assert 'args: ["-e", "precommit", "-vv"]' in pre_commit
     web_package = (out_dir / "web/package.json").read_text(encoding="utf-8")
     assert '"lint": "eslint ."' in web_package

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -83,8 +83,7 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
         encoding="utf-8"
     )
     ci_yaml = (out_dir / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-    assert "name: Install pre-commit" in ci_yaml
-    assert "pre-commit run --all-files --show-diff-on-failure" in ci_yaml
+    assert "pre-commit:" not in ci_yaml
     assert "tox-env: [lint, type, test]" in ci_yaml
     assert "- name: Install tox" in ci_yaml
     assert "run: tox -e ${{ matrix.tox-env }}" in ci_yaml
@@ -103,6 +102,7 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "go test ./..." in generated_readme
     assert "npm run build" in generated_readme
     assert "tox -e format" in generated_readme
+    assert "tox -e precommit" in generated_readme
     assert "tox -e lint,type,test" in generated_readme
     assert "make typecheck" in generated_readme
     assert "## Backlog bootstrap" not in generated_readme
@@ -126,9 +126,17 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "black --check src tests" in tox_ini
     assert "ruff check src tests" in tox_ini
     assert "[testenv:format]" in tox_ini
+    assert "[testenv:test-fast]" in tox_ini
+    assert 'pytest -q -m "not e2e_github" {posargs:tests}' in tox_ini
+    assert "[testenv:precommit]" in tox_ini
+    assert "depends =" in tox_ini
+    assert "test-fast" in tox_ini
     assert "black src tests" in tox_ini
     assert "ruff check src tests --fix" in tox_ini
     assert "pytest -q {posargs:tests}" in tox_ini
+    pre_commit = (out_dir / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    assert "id: tox-suite" in pre_commit
+    assert 'args: ["-e", "precommit", "-vv"]' in pre_commit
     web_package = (out_dir / "web/package.json").read_text(encoding="utf-8")
     assert '"lint": "eslint ."' in web_package
     assert '"eslint": "^9.21.0"' in web_package

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,13 @@ deps =
 commands =
     pytest -q {posargs:tests}
 
+[testenv:test-fast]
+description = Run fast unit checks used by pre-commit
+deps =
+    pytest>=8
+commands =
+    pytest -q -m "not e2e_github" {posargs:tests}
+
 [testenv:lint]
 description = Run lint checks
 skip_install = true
@@ -22,7 +29,7 @@ deps =
     ruff>=0.7
 commands =
     black --check src tests
-    ruff check src tests
+    ruff check src tests --fix --exit-non-zero-on-fix
 
 [testenv:format]
 description = Auto-format Python code
@@ -41,3 +48,13 @@ deps =
     mypy>=1.10
 commands =
     mypy src
+
+[testenv:precommit]
+description = Run full pre-commit tox suite
+skip_install = true
+depends =
+    lint
+    type
+    test-fast
+commands =
+    python -c "print('tox precommit suite complete')"

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     ruff>=0.7
 commands =
     black --check src tests
-    ruff check src tests --fix --exit-non-zero-on-fix
+    ruff check src tests
 
 [testenv:format]
 description = Auto-format Python code
@@ -52,9 +52,16 @@ commands =
 [testenv:precommit]
 description = Run full pre-commit tox suite
 skip_install = true
-depends =
-    lint
-    type
-    test-fast
+setenv =
+    {[testenv]setenv}
+    PYTHONPATH={toxinidir}/src
+deps =
+    {[testenv:format]deps}
+    {[testenv:lint]deps}
+    {[testenv:type]deps}
+    {[testenv:test-fast]deps}
 commands =
-    python -c "print('tox precommit suite complete')"
+    {[testenv:format]commands}
+    {[testenv:lint]commands}
+    {[testenv:type]commands}
+    {[testenv:test-fast]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = lint,type,test
-isolated_build = true
 
 [testenv]
 basepython = python3.12


### PR DESCRIPTION
## 🧾 Title
Improve backlog apply UX and align pre-commit/CI tox quality gates

## 🧠 Description
This PR combines two QoL improvements:
1. backlog apply reliability/readability improvements,
2. tox/pre-commit parity fixes so local hooks and CI validate the same quality bar.

Backlog updates:
- smarter default backlog file resolution (`local/backlog/issues.json` first),
- compatibility with wrapped JSON responses from `gh project list`,
- explicit epic vs ticket issue counts in summary output.

Quality-gate updates:
- pre-commit local hook runs tox suite (`precommit`) instead of only ruff hooks,
- `precommit` tox env runs format first, then lint/type/test-fast,
- template generation now emits the same tox/pre-commit behavior for scaffolded repos.

## 🧩 Changes Included
- [x] Added/updated documentation
- [x] Implemented new feature or enhancement
- [x] Refactored existing code
- [x] Improved error handling or logging
- [ ] Updated environment configuration
- [x] Other (expanded tests for backlog parsing/output and generated tox/pre-commit behavior)

## 🎯 Purpose
Make repo-scaffold safer and more predictable in day-to-day use:
- avoid requiring `--file` when working from this toolkit repo
- prevent false failures on `gh project list` response shape differences
- make backlog summary output clearer (epics vs tickets)
- ensure pre-commit and CI checks are functionally aligned through tox

## 🔗 Related Issues / Epics
- **Epic:** N/A
- **Issue:** N/A
- **Closes:** N/A

## 🧪 Testing
1. `poetry run pytest -q tests/test_backlog_ops.py tests/test_cli.py tests/test_generation.py`
2. `poetry run tox -e precommit`
3. `poetry run tox -e lint,type,test`
4. `poetry run pytest -q`

## 🧰 Developer Notes
- `apply backlog` file fallback order is now:
  - `local/backlog/issues.json` (current working directory), then
  - `<repo-path>/backlog/issues.json`
- backlog summary now prints:
  - epic issues created/skipped
  - ticket issues created/skipped
  - total issues created/skipped
- project listing now accepts both list and wrapped object JSON payloads from `gh project list` (`projects` / `items` / `nodes`).
- pre-commit now runs a local `tox-suite` hook.
- tox `precommit` now runs:
  - format (auto-fix)
  - lint (check)
  - type
  - test-fast (`not e2e_github`)
