### PR TITLE
Add coverage enforcement, Codecov integration, and push automated coverage above 80%

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ GITHUB_REPO=YOUR_REPO
 # GITHUB_PROJECT_TITLE=YOUR_FIXED_PROJECT_TITLE
 # GITHUB_PROJECT_TITLE_TEMPLATE={repo} Roadmap
 
+# Optional local Codecov upload token (read automatically by `tox -e codecov-upload`):
+# CODECOV_TOKEN=your_codecov_token
+
 # Test-only GitHub E2E toggles:
 # RUN_GITHUB_E2E=1
 # GITHUB_E2E_REPO_BASENAME=repo-scaffold-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox-env: [lint, type, test]
+        tox-env: [lint, type, coverage]
     steps:
       - uses: actions/checkout@v4
 
@@ -25,3 +25,20 @@ jobs:
 
       - name: Run tox (${{ matrix.tox-env }})
         run: poetry run tox -e ${{ matrix.tox-env }}
+
+      - name: Upload coverage.xml artifact
+        if: matrix.tox-env == 'coverage'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: error
+
+      - name: Upload coverage to Codecov
+        if: matrix.tox-env == 'coverage'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ venv/
 # Build artifacts
 dist/
 build/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
 
 # Environment
 .env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - repo: local
     hooks:
       - id: tox-suite
-        name: run tox suite (format, lint, type, test-fast)
+        name: run tox suite (format, lint, type, coverage)
         entry: tox
         language: python
         additional_dependencies:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # repo-scaffold
 
+[![codecov](https://codecov.io/gh/blairg23/repo-scaffold/graph/badge.svg)](https://codecov.io/gh/blairg23/repo-scaffold)
+
 `repo-scaffold` is a repo operations toolkit with five modes:
 
 - `create`: create/push a GitHub repo from a local folder and apply baseline settings
@@ -40,7 +42,7 @@ Defaults:
 - `--languages` defaults to `go,python,react`
 - output defaults to `./out/<name>`
 - scaffolds include `.pre-commit-config.yaml`
-- Python scaffolds include `tox.ini`; generated CI runs `tox` (`lint`, `type`, `test`)
+- Python scaffolds include `tox.ini`; generated CI runs `tox` (`lint`, `type`, `coverage`)
 
 Fast path (no required flags):
 
@@ -366,26 +368,50 @@ poetry run pre-commit install
 poetry run pre-commit run --all-files
 ```
 
-`pre-commit` runs a local tox gate via the `tox-suite` hook: auto-format first, then `lint`, `type`, and `test-fast`.
+`pre-commit` runs a local tox gate via the `tox-suite` hook: auto-format first, then `lint`, `type`, and a fast branch-coverage gate.
 If formatting or fixers changed tracked files, the hook exits non-zero so you can review, re-stage, and rerun the commit intentionally.
 
-Tox workflow (lint, type, test):
+Tox workflow (lint, type, coverage):
 
 ```bash
-tox -e lint,type,test
+poetry run tox
+```
+
+Generate coverage reports locally (`coverage.xml` + `htmlcov/`) and enforce the 70% threshold:
+
+```bash
+poetry run tox -e coverage
 ```
 
 Fast tox gate used by pre-commit:
 
 ```bash
-tox -e precommit
+poetry run tox -e precommit
 ```
 
 Auto-fix Python formatting/lint issues:
 
 ```bash
-tox -e format
+poetry run tox -e format
 ```
+
+Optional local Codecov upload after generating `coverage.xml`:
+
+If `CODECOV_TOKEN` is already in `.env`, this is enough:
+
+```bash
+poetry run tox -e codecov-upload
+```
+
+If you prefer an explicit shell export:
+
+```bash
+export CODECOV_TOKEN=your_codecov_token
+poetry run tox -e codecov-upload
+```
+
+CI uploads `coverage.xml` as an artifact and attempts a Codecov upload when `CODECOV_TOKEN` is configured in GitHub Actions secrets.
+The current minimum coverage gate is 70%.
 
 If `tox` is not installed locally:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,28 @@ testpaths = ["tests"]
 markers = [
   "e2e_github: runs live GitHub end-to-end validation (opt-in, remote side effects)",
 ]
+
+[tool.coverage.run]
+branch = true
+source = ["repo_scaffold"]
+
+[tool.coverage.report]
+fail_under = 70
+show_missing = true
+skip_covered = false
+omit = [
+  "src/repo_scaffold/__init__.py",
+  "src/repo_scaffold/__main__.py",
+]
+exclude_also = [
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+  "if __name__ == .__main__.:",
+  "raise NotImplementedError",
+]
+
+[tool.coverage.xml]
+output = "coverage.xml"
+
+[tool.coverage.html]
+directory = "htmlcov"

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -236,7 +236,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox-env: [lint, type, test]
+        tox-env: [lint, type, coverage]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -248,6 +248,21 @@ jobs:
           python -m pip install tox
       - name: Run tox (${{{{ matrix.tox-env }}}})
         run: tox -e ${{{{ matrix.tox-env }}}}
+      - name: Upload coverage.xml artifact
+        if: matrix.tox-env == 'coverage'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: error
+      - name: Upload coverage to Codecov
+        if: matrix.tox-env == 'coverage'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{{{ secrets.CODECOV_TOKEN }}}}
 
   react:
     if: contains(env.LANGUAGES, 'react') && hashFiles('web/package.json') != ''
@@ -414,6 +429,7 @@ def _render_gitignore(languages: Iterable[str]) -> str:
                 ".tox/",
                 ".coverage",
                 ".coverage.*",
+                "coverage.xml",
                 "htmlcov/",
                 ".venv/",
                 "venv/",
@@ -512,8 +528,15 @@ def _render_backlog_issues_json() -> str:
 
 
 def _render_repo_readme(config: ScaffoldConfig) -> str:
+    badge_owner = config.owner or "OWNER"
+    coverage_badge = (
+        f"[![codecov](https://codecov.io/gh/{badge_owner}/{config.name}/graph/badge.svg)]"
+        f"(https://codecov.io/gh/{badge_owner}/{config.name})"
+    )
     lines: list[str] = [
         f"# {config.name}",
+        "",
+        coverage_badge,
         "",
         "Created by [repo-scaffold](https://github.com/your-org/repo-scaffold).",
         "",
@@ -574,6 +597,7 @@ def _render_repo_readme(config: ScaffoldConfig) -> str:
             "",
             "For parity with CI quality gates, pre-commit also runs `tox -e precommit`.",
             "If formatters or fixers change tracked files, the hook exits non-zero so you can re-stage and rerun the commit intentionally.",
+            "The fast pre-commit gate also enforces the Python coverage threshold when Python is enabled.",
             "",
         ]
     )
@@ -591,11 +615,19 @@ def _render_repo_readme(config: ScaffoldConfig) -> str:
                 "black --check .",
                 "mypy src",
                 "pytest",
-                "tox -e lint,type,test",
+                "tox -e lint,type,coverage",
+                "tox -e coverage",
                 "tox -e precommit",
+                "tox -e codecov-upload",
+                "export CODECOV_TOKEN=your_codecov_token",
+                "tox -e codecov-upload",
                 "```",
                 "",
-                "CI runs the same Python quality matrix via tox (`lint`, `type`, `test`).",
+                "CI runs the same Python quality matrix via tox (`lint`, `type`, `coverage`).",
+                "Run `tox -e coverage` to generate `coverage.xml` and `htmlcov/` locally.",
+                "The current minimum coverage gate is 70%.",
+                "If `CODECOV_TOKEN` is already present in `.env`, you can run `tox -e codecov-upload` directly.",
+                "If you prefer an explicit shell export, set `CODECOV_TOKEN` and then run `tox -e codecov-upload`.",
                 "",
             ]
         )
@@ -663,6 +695,9 @@ GITHUB_REPO={name}
 # Optional backlog project naming defaults (used with --with-project):
 # GITHUB_PROJECT_TITLE=YOUR_FIXED_PROJECT_TITLE
 # GITHUB_PROJECT_TITLE_TEMPLATE={{repo}} Roadmap
+
+# Optional local Codecov upload token (read automatically by `tox -e codecov-upload`):
+# CODECOV_TOKEN=your_codecov_token
 
 # Legacy lowercase aliases are still supported:
 # github_token=...
@@ -2221,6 +2256,31 @@ where = ["src"]
 addopts = "-q -s"
 testpaths = ["tests"]
 
+[tool.coverage.run]
+branch = true
+source = ["src"]
+
+[tool.coverage.report]
+fail_under = 70
+show_missing = true
+skip_covered = false
+omit = [
+  "src/*/__init__.py",
+  "src/*/__main__.py",
+]
+exclude_also = [
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+  "if __name__ == .__main__.:",
+  "raise NotImplementedError",
+]
+
+[tool.coverage.xml]
+output = "coverage.xml"
+
+[tool.coverage.html]
+directory = "htmlcov"
+
 [tool.black]
 line-length = 100
 target-version = ["py310"]
@@ -2247,7 +2307,7 @@ no_implicit_optional = true
 
 def _render_tox_ini() -> str:
     return """[tox]
-envlist = lint,type,test
+envlist = lint,type,coverage
 
 [testenv]
 deps = -e .[dev]
@@ -2281,6 +2341,32 @@ deps = -e .[dev]
 commands =
     pytest -q -m "not e2e_github" {posargs:tests}
 
+[testenv:coverage]
+deps =
+    -e .[dev]
+    pytest-cov>=6
+setenv =
+    COVERAGE_FILE={toxworkdir}/.coverage.{envname}
+commands =
+    pytest -q -m "not e2e_github" --cov=src --cov-branch --cov-report=term-missing --cov-report=xml --cov-report=html {posargs:tests}
+
+[testenv:coverage-fast]
+deps =
+    {[testenv:coverage]deps}
+setenv =
+    {[testenv:coverage]setenv}
+commands =
+    pytest -q -m "not e2e_github" --cov=src --cov-branch --cov-report=term-missing {posargs:tests}
+
+[testenv:codecov-upload]
+skip_install = true
+passenv =
+    CODECOV_TOKEN
+deps =
+    codecov-cli>=11
+commands =
+    python -c 'import os, subprocess; from pathlib import Path; env=os.environ.copy(); p=Path(".env"); raws=p.read_text(encoding="utf-8").splitlines() if (not env.get("CODECOV_TOKEN") and p.exists()) else []; clean=[r.strip() for r in raws]; pairs=[(line[7:] if line.startswith("export ") else line).split("=", 1) for line in clean if line and not line.startswith("#") and "=" in line]; [env.setdefault(k.strip(), v.strip().rstrip("\\r").strip(chr(34)).strip(chr(39))) for k, v in pairs if k.strip() == "CODECOV_TOKEN"]; subprocess.run(["codecovcli", "do-upload", "--file", "coverage.xml"], check=True, env=env)'
+
 [testenv:precommit]
 skip_install = true
 allowlist_externals =
@@ -2292,12 +2378,12 @@ deps =
     {[testenv:format]deps}
     {[testenv:lint]deps}
     {[testenv:type]deps}
-    {[testenv:test-fast]deps}
+    {[testenv:coverage-fast]deps}
 commands =
     {[testenv:format]commands}
     {[testenv:lint]commands}
     {[testenv:type]commands}
-    {[testenv:test-fast]commands}
+    {[testenv:coverage-fast]commands}
     git diff --exit-code -- src tests
 """
 
@@ -2321,7 +2407,7 @@ def _render_pre_commit_config(languages: Iterable[str]) -> str:
                 "  - repo: local",
                 "    hooks:",
                 "      - id: tox-suite",
-                "        name: run tox suite (lint, type, test-fast)",
+                "        name: run tox suite (format, lint, type, coverage)",
                 "        entry: tox",
                 "        language: python",
                 "        additional_dependencies:",

--- a/tests/test_backlog_ops.py
+++ b/tests/test_backlog_ops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -178,6 +179,65 @@ def test_resolve_authenticated_login_returns_login(
     assert backlog_ops.resolve_authenticated_login(repo_dir) == "octocat"
 
 
+def test_backlog_helper_parsers_and_label_merging() -> None:
+    assert (
+        backlog_ops._project_scope_hint("missing required token scopes")
+        != "missing required token scopes"
+    )
+    assert backlog_ops._project_scope_hint("plain error") == "plain error"
+    assert backlog_ops._parse_repo_owner("acme/repo") == "acme"
+    with pytest.raises(RuntimeError, match="owner/repo"):
+        backlog_ops._parse_repo_owner("broken")
+
+    merged = backlog_ops._merge_labels(
+        backlog_ops._normalize_labels([" epic ", "", "epic", 1]),
+        ["ticket", "epic", " ticket "],
+    )
+    assert merged == ["epic", "ticket"]
+
+    raw = '[{"title":"one"}]\n [{"title":"two"}, 1]\n'
+    assert backlog_ops._parse_concatenated_json_arrays(raw) == [
+        {"title": "one"},
+        {"title": "two"},
+    ]
+    assert len(backlog_ops._label_color("epic")) == 6
+
+
+def test_load_token_from_env_file_and_ensure_gh_auth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    env_file = repo_dir / ".env"
+    env_file.write_text('export github_token="token-from-env"\n', encoding="utf-8")
+
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    backlog_ops._load_token_from_env_file(env_file)
+    assert os.environ["GH_TOKEN"] == "token-from-env"
+
+    monkeypatch.setattr(
+        backlog_ops.shutil,
+        "which",
+        lambda tool: "/usr/bin/gh" if tool == "gh" else None,
+    )
+    monkeypatch.setattr(backlog_ops.subprocess, "run", lambda *args, **kwargs: _cp_ok())
+    backlog_ops._ensure_gh_auth(repo_dir)
+
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    clean_repo_dir = tmp_path / "clean-repo"
+    clean_repo_dir.mkdir()
+    monkeypatch.chdir(clean_repo_dir)
+    monkeypatch.setattr(
+        backlog_ops.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=["gh", "auth", "status"], returncode=1, stdout="", stderr=""
+        ),
+    )
+    with pytest.raises(RuntimeError, match="Authenticate first"):
+        backlog_ops._ensure_gh_auth(clean_repo_dir)
+
+
 def test_find_issue_number_uses_repo_issues_api_exact_match(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -212,6 +272,185 @@ def test_find_issue_number_uses_repo_issues_api_exact_match(
     assert (
         backlog_ops._find_issue_number(repo_dir, "acme/repo", "Missing issue") is None
     )
+
+
+def test_resolve_project_target_variants_and_project_linking(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+    lines: list[str] = []
+    errors: list[str] = []
+
+    monkeypatch.setattr(
+        backlog_ops,
+        "_list_projects",
+        lambda *_args, **_kwargs: [{"title": "Roadmap", "number": 7}],
+    )
+    monkeypatch.setattr(
+        backlog_ops,
+        "_project_title_for_number",
+        lambda *_args, **_kwargs: "Exact Project",
+    )
+
+    target = backlog_ops._resolve_project_target(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        project_number=7,
+        project_title=None,
+        project_owner=None,
+        dry_run=False,
+        out=lines.append,
+    )
+    assert target == backlog_ops._ProjectTarget(
+        owner="acme", number=7, title="Exact Project", created=False
+    )
+
+    target = backlog_ops._resolve_project_target(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        project_number=None,
+        project_title="Roadmap",
+        project_owner=None,
+        dry_run=False,
+        out=lines.append,
+    )
+    assert target == backlog_ops._ProjectTarget(
+        owner="acme", number=7, title="Roadmap", created=False
+    )
+
+    target = backlog_ops._resolve_project_target(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        project_number=None,
+        project_title="New Roadmap",
+        project_owner="octo-org",
+        dry_run=True,
+        out=lines.append,
+    )
+    assert target == backlog_ops._ProjectTarget(
+        owner="octo-org", number=None, title="New Roadmap", created=True
+    )
+
+    with pytest.raises(
+        RuntimeError, match="only one of --project-number or --project-title"
+    ):
+        backlog_ops._resolve_project_target(
+            repo_dir=repo_dir,
+            repo="acme/repo",
+            project_number=1,
+            project_title="dup",
+            project_owner=None,
+            dry_run=False,
+            out=lines.append,
+        )
+
+    monkeypatch.setattr(
+        backlog_ops,
+        "_run_gh",
+        lambda _repo_dir, args: (
+            _cp_ok()
+            if args[:2] == ["project", "link"]
+            else subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="already linked"
+            )
+        ),
+    )
+
+    assert (
+        backlog_ops._link_project_to_repo(
+            repo_dir=repo_dir,
+            repo="acme/repo",
+            project=backlog_ops._ProjectTarget(
+                owner="acme", number=None, title="New Roadmap", created=True
+            ),
+            dry_run=True,
+            out=lines.append,
+            emit_err=errors.append,
+        )
+        == 0
+    )
+    assert (
+        backlog_ops._link_project_to_repo(
+            repo_dir=repo_dir,
+            repo="acme/repo",
+            project=backlog_ops._ProjectTarget(
+                owner="acme", number=7, title="Roadmap", created=False
+            ),
+            dry_run=False,
+            out=lines.append,
+            emit_err=errors.append,
+        )
+        == 0
+    )
+
+
+def test_add_issue_to_project_handles_dry_run_existing_missing_number_and_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+    lines: list[str] = []
+    errors: list[str] = []
+    project = backlog_ops._ProjectTarget(
+        owner="acme", number=7, title="Roadmap", created=False
+    )
+
+    assert backlog_ops._add_issue_to_project(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        project=project,
+        issue_title="A1",
+        issue_number=None,
+        dry_run=True,
+        out=lines.append,
+        emit_err=errors.append,
+    ) == (1, 0, 0)
+
+    assert backlog_ops._add_issue_to_project(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        project=project,
+        issue_title="A1",
+        issue_number=None,
+        dry_run=False,
+        out=lines.append,
+        emit_err=errors.append,
+    ) == (0, 0, 1)
+
+    states = iter(
+        [
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="already added"
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="boom"
+            ),
+        ]
+    )
+    monkeypatch.setattr(backlog_ops, "_run_gh", lambda *_args, **_kwargs: next(states))
+
+    assert backlog_ops._add_issue_to_project(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        project=project,
+        issue_title="A1",
+        issue_number=11,
+        dry_run=False,
+        out=lines.append,
+        emit_err=errors.append,
+    ) == (0, 1, 0)
+    assert backlog_ops._add_issue_to_project(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        project=project,
+        issue_title="A2",
+        issue_number=12,
+        dry_run=False,
+        out=lines.append,
+        emit_err=errors.append,
+    ) == (0, 0, 1)
+    assert any("Failed to add issue to project" in line for line in errors)
 
 
 def test_wait_for_issue_titles_visible_retries_until_present(

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -40,6 +40,59 @@ def test_resolve_repo_accepts_host_owner_repo_from_env() -> None:
     assert resolved == "acme/demo"
 
 
+def test_load_env_file_and_build_env_support_aliases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cwd = tmp_path / "cwd"
+    repo_dir = tmp_path / "repo"
+    cwd.mkdir()
+    repo_dir.mkdir()
+    (cwd / ".env").write_text(
+        "\n".join(
+            [
+                "export github_token=legacy-token",
+                "github_org=legacy-org",
+                "GH_REPO=from/cwd",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (repo_dir / ".env").write_text(
+        "\n".join(
+            [
+                'GITHUB_TOKEN="repo-token"',
+                "GITHUB_REPO=repo-name",
+                "GITHUB_ORG=repo-org",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(cwd)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_ORG", raising=False)
+    monkeypatch.delenv("GITHUB_REPO", raising=False)
+    monkeypatch.delenv("GH_REPO", raising=False)
+    monkeypatch.delenv("github_token", raising=False)
+    monkeypatch.delenv("github_org", raising=False)
+    monkeypatch.delenv("github_repo", raising=False)
+
+    env = create_ops._build_env(repo_dir)
+
+    assert env["GH_TOKEN"] == "repo-token"
+    assert env["GITHUB_ORG"] == "repo-org"
+    assert env["GITHUB_REPO"] == "repo-name"
+    assert env["GH_REPO"] == "from/cwd"
+
+
+def test_load_json_invalid_raises_runtime_error() -> None:
+    with pytest.raises(RuntimeError, match="bad json"):
+        create_ops._load_json("not-json", error_message="bad json")
+
+
 def test_default_branch_ruleset_payload_uses_zero_review_baseline() -> None:
     payload = json.loads(create_ops._default_branch_ruleset_payload())
     assert payload["name"] == "repo-scaffold default-branch ruleset"
@@ -60,6 +113,482 @@ def test_branch_protection_endpoint_url_encodes_branch_name() -> None:
         )
         == "/repos/acme/repo/branches/release%2F2026/protection"
     )
+
+
+def test_compare_ruleset_against_baseline_reports_multiple_drifts() -> None:
+    drifts = create_ops._compare_ruleset_against_baseline(
+        [
+            {
+                "name": "repo-scaffold default-branch ruleset",
+                "target": "tag",
+                "enforcement": "evaluate",
+                "conditions": {
+                    "ref_name": {
+                        "include": ["refs/heads/dev"],
+                        "exclude": ["refs/heads/tmp"],
+                    }
+                },
+                "rules": [
+                    {"type": "deletion"},
+                    {
+                        "type": "pull_request",
+                        "parameters": {
+                            "allowed_merge_methods": ["merge"],
+                            "dismiss_stale_reviews_on_push": True,
+                            "require_code_owner_review": True,
+                            "require_last_push_approval": True,
+                            "required_approving_review_count": 2,
+                            "required_review_thread_resolution": False,
+                        },
+                    },
+                ],
+            },
+            {
+                "name": "repo-scaffold default-branch ruleset",
+                "target": "branch",
+                "enforcement": "active",
+                "conditions": {
+                    "ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}
+                },
+                "rules": [],
+            },
+        ],
+        default_branch="main",
+    )
+
+    assert "multiple managed default-branch rulesets found" in drifts
+    assert "target expected 'branch' got 'tag'" in drifts
+    assert "enforcement expected 'active' got 'evaluate'" in drifts
+    assert any("conditions.ref_name.include expected one of" in item for item in drifts)
+    assert "conditions.ref_name.exclude expected [] got ['refs/heads/tmp']" in drifts
+    assert "missing rule: non_fast_forward" in drifts
+    assert "missing rule: required_linear_history" in drifts
+    assert "pull_request.required_approving_review_count expected 0 got 2" in drifts
+    assert any("pull_request.allowed_merge_methods" in item for item in drifts)
+
+
+def test_repo_metadata_and_ruleset_loaders_cover_success_and_error_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = iter(
+        [
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout='{"default_branch":"main"}', stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout='[{"id":1}]', stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout='{"id":1}', stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="boom"
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="{}", stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="[]", stderr=""
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(create_ops, "_api", lambda **_: next(responses))
+
+    assert create_ops._get_repo_info(
+        repo_dir=Path("/tmp/repo"), env={}, repo="acme/repo"
+    ) == {"default_branch": "main"}
+    assert create_ops._list_repo_rulesets(
+        repo_dir=Path("/tmp/repo"), env={}, repo="acme/repo"
+    ) == [{"id": 1}]
+    assert create_ops._get_repo_ruleset(
+        repo_dir=Path("/tmp/repo"), env={}, repo="acme/repo", ruleset_id=1
+    ) == {"id": 1}
+
+    with pytest.raises(RuntimeError, match="boom"):
+        create_ops._list_repo_rulesets(
+            repo_dir=Path("/tmp/repo"), env={}, repo="acme/repo"
+        )
+    with pytest.raises(RuntimeError, match="Unexpected rulesets response"):
+        create_ops._list_repo_rulesets(
+            repo_dir=Path("/tmp/repo"), env={}, repo="acme/repo"
+        )
+    with pytest.raises(RuntimeError, match="Unexpected ruleset response"):
+        create_ops._get_repo_ruleset(
+            repo_dir=Path("/tmp/repo"), env={}, repo="acme/repo", ruleset_id=1
+        )
+
+
+def test_security_feature_status_and_optional_endpoint_feature_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_info = {
+        "security_and_analysis": {
+            "secret_scanning": {"status": "enabled"},
+            "other": {"status": "disabled"},
+        }
+    }
+    assert (
+        create_ops._security_feature_status(repo_info, "secret_scanning") == "enabled"
+    )
+    assert create_ops._security_feature_status(repo_info, "missing") is None
+    assert create_ops._security_feature_status({}, "secret_scanning") is None
+
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **kwargs: subprocess.CompletedProcess(
+            args=["gh", "api"],
+            returncode=1 if kwargs["endpoint"].endswith("/disabled") else 0,
+            stdout="",
+            stderr="not enabled" if kwargs["endpoint"].endswith("/disabled") else "",
+        ),
+    )
+
+    assert create_ops._optional_endpoint_feature_enabled(
+        repo_dir=Path("/tmp/repo"), env={}, endpoint="/repos/acme/repo/enabled"
+    ) == (True, "enabled")
+    assert create_ops._optional_endpoint_feature_enabled(
+        repo_dir=Path("/tmp/repo"), env={}, endpoint="/repos/acme/repo/disabled"
+    ) == (False, "not enabled")
+
+
+def test_ruleset_and_legacy_branch_helpers_cover_error_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+    api_responses = iter(
+        [
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="", stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="branch not protected"
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="boom"
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="", stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="not found"
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="boom"
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="warn"
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="warn"
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **kwargs: (
+            calls.append((kwargs["method"], kwargs["endpoint"])) or next(api_responses)
+        ),
+    )
+
+    create_ops._clear_legacy_branch_protection(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        default_branch="main",
+        out=lambda _line: None,
+    )
+    create_ops._clear_legacy_branch_protection(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        default_branch="main",
+        out=lambda _line: None,
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        create_ops._clear_legacy_branch_protection(
+            repo_dir=Path("/tmp/repo"),
+            env={},
+            repo="acme/repo",
+            default_branch="main",
+            out=lambda _line: None,
+        )
+
+    assert create_ops._legacy_branch_protection_exists(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        default_branch="main",
+    )
+    assert (
+        create_ops._legacy_branch_protection_exists(
+            repo_dir=Path("/tmp/repo"),
+            env={},
+            repo="acme/repo",
+            default_branch="main",
+        )
+        is False
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        create_ops._legacy_branch_protection_exists(
+            repo_dir=Path("/tmp/repo"),
+            env={},
+            repo="acme/repo",
+            default_branch="main",
+        )
+
+    warnings: list[str] = []
+    create_ops._enable_security_and_analysis_feature(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        feature_name="Secret scanning",
+        feature_key="secret_scanning",
+        out=lambda _line: None,
+        warn=warnings.append,
+    )
+    create_ops._enable_optional_endpoint_feature(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        endpoint="/repos/acme/repo/private-vulnerability-reporting",
+        feature_name="Private vulnerability reporting",
+        out=lambda _line: None,
+        warn=warnings.append,
+    )
+    assert any("could not enable secret scanning" in item.lower() for item in warnings)
+    assert any(
+        "could not enable private vulnerability reporting" in item.lower()
+        for item in warnings
+    )
+    assert any(endpoint.endswith("/protection") for _, endpoint in calls)
+
+
+def test_sync_ruleset_covers_update_create_missing_id_and_api_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lines: list[str] = []
+
+    monkeypatch.setattr(
+        create_ops,
+        "_list_repo_rulesets",
+        lambda **_: [{"name": "repo-scaffold default-branch ruleset", "id": 9}],
+    )
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **kwargs: (
+            subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="", stderr="")
+            if kwargs["method"] == "PUT"
+            else subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="", stderr=""
+            )
+        ),
+    )
+    create_ops._sync_default_branch_ruleset(
+        repo_dir=Path("/tmp/repo"), env={}, repo="acme/repo", out=lines.append
+    )
+    assert any("Updated ruleset" in line for line in lines)
+
+    monkeypatch.setattr(create_ops, "_list_repo_rulesets", lambda **_: [])
+    lines.clear()
+    create_ops._sync_default_branch_ruleset(
+        repo_dir=Path("/tmp/repo"), env={}, repo="acme/repo", out=lines.append
+    )
+    assert any("Created ruleset" in line for line in lines)
+
+    monkeypatch.setattr(
+        create_ops,
+        "_list_repo_rulesets",
+        lambda **_: [{"name": "repo-scaffold default-branch ruleset", "id": "bad"}],
+    )
+    with pytest.raises(RuntimeError, match="missing a numeric id"):
+        create_ops._sync_default_branch_ruleset(
+            repo_dir=Path("/tmp/repo"), env={}, repo="acme/repo", out=lambda _line: None
+        )
+
+    monkeypatch.setattr(create_ops, "_list_repo_rulesets", lambda **_: [])
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **_: subprocess.CompletedProcess(
+            args=["gh"], returncode=1, stdout="", stderr="failed"
+        ),
+    )
+    with pytest.raises(RuntimeError, match="failed"):
+        create_ops._sync_default_branch_ruleset(
+            repo_dir=Path("/tmp/repo"), env={}, repo="acme/repo", out=lambda _line: None
+        )
+
+
+def test_tool_auth_remote_and_push_helpers_cover_common_error_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    monkeypatch.setattr(
+        create_ops.shutil,
+        "which",
+        lambda tool: None if tool == "gh" else "/usr/bin/git",
+    )
+    with pytest.raises(RuntimeError, match="GitHub CLI"):
+        create_ops._ensure_tools()
+
+    monkeypatch.setattr(
+        create_ops.shutil, "which", lambda tool: "/usr/bin/gh" if tool == "gh" else None
+    )
+    with pytest.raises(RuntimeError, match="git is required"):
+        create_ops._ensure_tools()
+
+    monkeypatch.setattr(create_ops.shutil, "which", lambda _tool: "/usr/bin/tool")
+    create_ops._ensure_tools()
+
+    monkeypatch.setattr(
+        create_ops,
+        "_run",
+        lambda args, **kwargs: (
+            subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+            if args[:3] == ["gh", "auth", "status"]
+            else subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="", stderr=""
+            )
+        ),
+    )
+    with pytest.raises(RuntimeError, match="Authenticate first"):
+        create_ops._ensure_gh_auth(repo_dir, {})
+
+    assert create_ops._repo_exists(repo_dir=repo_dir, env={}, repo="acme/repo") is True
+    monkeypatch.setattr(
+        create_ops,
+        "_run",
+        lambda args, **kwargs: subprocess.CompletedProcess(
+            args=args, returncode=1, stdout="", stderr="not found"
+        ),
+    )
+    assert create_ops._repo_exists(repo_dir=repo_dir, env={}, repo="acme/repo") is False
+    monkeypatch.setattr(
+        create_ops,
+        "_run",
+        lambda args, **kwargs: subprocess.CompletedProcess(
+            args=args, returncode=1, stdout="", stderr="boom"
+        ),
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        create_ops._repo_exists(repo_dir=repo_dir, env={}, repo="acme/repo")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        create_ops,
+        "_run",
+        lambda args, **kwargs: (
+            calls.append(args)
+            or subprocess.CompletedProcess(
+                args=args,
+                returncode=(
+                    1 if args[:4] == ["git", "remote", "get-url", "origin"] else 0
+                ),
+                stdout="" if args[:4] == ["git", "remote", "get-url", "origin"] else "",
+                stderr="",
+            )
+        ),
+    )
+    create_ops._ensure_origin_remote(
+        repo_dir=repo_dir,
+        env={},
+        repo="acme/repo",
+        dry_run=False,
+        out=lambda _line: None,
+    )
+    assert [
+        "git",
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/acme/repo.git",
+    ] in calls
+
+    monkeypatch.setattr(
+        create_ops,
+        "_run",
+        lambda args, **kwargs: subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=(
+                "https://github.com/other/repo.git\n"
+                if args[:4] == ["git", "remote", "get-url", "origin"]
+                else ""
+            ),
+            stderr="",
+        ),
+    )
+    create_ops._ensure_origin_remote(
+        repo_dir=repo_dir,
+        env={},
+        repo="acme/repo",
+        dry_run=False,
+        out=lambda _line: None,
+    )
+
+    monkeypatch.setattr(
+        create_ops,
+        "_run",
+        lambda args, **kwargs: subprocess.CompletedProcess(
+            args=args,
+            returncode=0 if args[:3] == ["gh", "auth", "token"] else 1,
+            stdout="gh-token\n" if args[:3] == ["gh", "auth", "token"] else "",
+            stderr="",
+        ),
+    )
+    assert create_ops._resolve_push_token(repo_dir=repo_dir, env={}) == "gh-token"
+    assert "workflow write permission" in create_ops._format_push_failure(
+        "workflow missing scope"
+    )
+
+
+def test_create_or_push_repo_covers_existing_and_create_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    monkeypatch.setattr(create_ops, "_repo_exists", lambda **_: True)
+    monkeypatch.setattr(create_ops, "_ensure_origin_remote", lambda **_: None)
+    monkeypatch.setattr(
+        create_ops, "_push_main", lambda **_: (False, "could not read username")
+    )
+    created, pushed, error = create_ops._create_or_push_repo(
+        repo_dir=repo_dir,
+        env={},
+        repo="acme/repo",
+        visibility="public",
+        dry_run=False,
+        out=lambda _line: None,
+    )
+    assert (created, pushed) == (False, False)
+    assert error and "could not read username" in error
+
+    monkeypatch.setattr(create_ops, "_repo_exists", lambda **_: False)
+    monkeypatch.setattr(
+        create_ops,
+        "_run",
+        lambda args, **kwargs: subprocess.CompletedProcess(
+            args=args, returncode=1, stdout="", stderr="create failed"
+        ),
+    )
+    created, pushed, error = create_ops._create_or_push_repo(
+        repo_dir=repo_dir,
+        env={},
+        repo="acme/repo",
+        visibility="public",
+        dry_run=False,
+        out=lambda _line: None,
+    )
+    assert (created, pushed) == (False, False)
+    assert error == "create failed"
 
 
 def test_apply_settings_dry_run_previews_ruleset_and_security_defaults() -> None:
@@ -490,3 +1019,229 @@ def test_push_main_uses_head_ref_with_token(monkeypatch: pytest.MonkeyPatch) -> 
     assert calls
     push_args = calls[0]
     assert push_args[-4:] == ["push", "-u", "origin", "HEAD:main"]
+
+
+def test_push_main_formats_noninteractive_auth_failure_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(create_ops, "_resolve_push_token", lambda **_: None)
+    monkeypatch.setattr(
+        create_ops,
+        "_run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=["git"],
+            returncode=1,
+            stdout="",
+            stderr="could not read Username for 'https://github.com'",
+        ),
+    )
+
+    pushed, error = create_ops._push_main(repo_dir=Path("/tmp/repo"), env={})
+
+    assert pushed is False
+    assert error is not None
+    assert "Non-interactive auth failed" in error
+
+
+def test_apply_and_check_repository_settings_wrappers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    events: list[str] = []
+
+    monkeypatch.setattr(create_ops, "_ensure_tools", lambda: events.append("tools"))
+    monkeypatch.setattr(create_ops, "_build_env", lambda _repo_dir: {"GH_TOKEN": "x"})
+    monkeypatch.setattr(
+        create_ops,
+        "_ensure_gh_auth",
+        lambda _repo_dir, _env: events.append("auth"),
+    )
+    monkeypatch.setattr(
+        create_ops,
+        "_apply_settings",
+        lambda **kwargs: events.append(
+            f"apply:{kwargs['repo']}:{kwargs['dry_run']}:{kwargs['repo_dir']}"
+        ),
+    )
+    expected_summary = create_ops.SettingsCheckSummary(
+        repo="acme/repo", passed=1, failed=0, skipped=0, drifts=()
+    )
+    monkeypatch.setattr(create_ops, "_check_settings", lambda **_: expected_summary)
+
+    create_ops.apply_repository_settings(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        dry_run=True,
+        out=lambda _line: None,
+    )
+    create_ops.apply_repository_settings(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        dry_run=False,
+        out=lambda _line: None,
+    )
+    summary = create_ops.check_repository_settings(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        out=lambda _line: None,
+    )
+
+    assert summary == expected_summary
+    assert events.count("tools") == 3
+    assert events.count("auth") == 2
+    assert any(
+        item.startswith(f"apply:acme/repo:True:{repo_dir.resolve()}") for item in events
+    )
+    assert any(
+        item.startswith(f"apply:acme/repo:False:{repo_dir.resolve()}")
+        for item in events
+    )
+
+
+def test_apply_settings_covers_dry_run_and_patch_failure_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lines: list[str] = []
+    create_ops._apply_settings(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        dry_run=True,
+        out=lines.append,
+        warn=lambda _line: None,
+    )
+
+    assert "[dry-run] sync repository merge settings" in lines
+    assert any("private vulnerability reporting" in line for line in lines)
+
+    monkeypatch.setattr(
+        create_ops,
+        "_get_repo_info",
+        lambda **_: {"default_branch": "main", "visibility": "public"},
+    )
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **_: subprocess.CompletedProcess(
+            args=["gh"], returncode=1, stdout="", stderr="boom"
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        create_ops._apply_settings(
+            repo_dir=Path("/tmp/repo"),
+            env={},
+            repo="acme/repo",
+            dry_run=False,
+            out=lambda _line: None,
+            warn=lambda _line: None,
+        )
+
+
+def test_create_repository_covers_success_skip_and_error_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    monkeypatch.setattr(create_ops, "_ensure_tools", lambda: None)
+    monkeypatch.setattr(create_ops, "_build_env", lambda _repo_dir: {"GH_TOKEN": "x"})
+    monkeypatch.setattr(create_ops, "_ensure_gh_auth", lambda _repo_dir, _env: None)
+    monkeypatch.setattr(create_ops, "_resolve_repo", lambda **_: "acme/repo")
+    monkeypatch.setattr(create_ops, "_ensure_git_repo", lambda **_: None)
+
+    applied: list[str] = []
+    monkeypatch.setattr(
+        create_ops,
+        "_apply_settings",
+        lambda **kwargs: applied.append(kwargs["repo"]),
+    )
+    monkeypatch.setattr(
+        create_ops,
+        "_create_or_push_repo",
+        lambda **_: (True, True, None),
+    )
+
+    summary = create_ops.create_repository(
+        repo_dir=repo_dir,
+        repo=None,
+        owner=None,
+        name=None,
+        visibility="public",
+        apply_settings=True,
+        dry_run=False,
+        out=lambda _line: None,
+        err=lambda _line: None,
+    )
+
+    assert summary.repo == "acme/repo"
+    assert summary.repo_created is True
+    assert summary.pushed is True
+    assert summary.settings_applied is True
+    assert summary.failures == 0
+    assert applied == ["acme/repo"]
+
+    skipped_lines: list[str] = []
+    monkeypatch.setattr(
+        create_ops,
+        "_create_or_push_repo",
+        lambda **_: (False, False, "push failed"),
+    )
+    errors: list[str] = []
+    skipped = create_ops.create_repository(
+        repo_dir=repo_dir,
+        repo=None,
+        owner=None,
+        name=None,
+        visibility="public",
+        apply_settings=True,
+        dry_run=False,
+        out=skipped_lines.append,
+        err=errors.append,
+    )
+
+    assert skipped.pushed is False
+    assert skipped.settings_applied is False
+    assert skipped.failures == 1
+    assert errors == ["push failed"]
+    assert "Skipping settings apply until main branch is pushed." in skipped_lines
+
+    monkeypatch.setattr(
+        create_ops,
+        "_ensure_git_repo",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("bad repo")),
+    )
+    errors.clear()
+    failed = create_ops.create_repository(
+        repo_dir=repo_dir,
+        repo=None,
+        owner=None,
+        name=None,
+        visibility="public",
+        apply_settings=False,
+        dry_run=False,
+        out=lambda _line: None,
+        err=errors.append,
+    )
+
+    assert failed.failures == 1
+    assert errors == ["bad repo"]
+
+
+def test_create_repository_rejects_invalid_visibility(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    with pytest.raises(RuntimeError, match="Visibility must be one of"):
+        create_ops.create_repository(
+            repo_dir=repo_dir,
+            repo="acme/repo",
+            owner=None,
+            name=None,
+            visibility="friends-only",
+            apply_settings=False,
+            dry_run=True,
+            out=lambda _line: None,
+            err=lambda _line: None,
+        )

--- a/tests/test_delete_ops.py
+++ b/tests/test_delete_ops.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import repo_scaffold.delete_ops as delete_ops
 from repo_scaffold.delete_ops import delete_repositories
 
 
@@ -247,3 +248,208 @@ def test_delete_repositories_cleanup_remote_and_local_dry_run(
     assert any("Matched remote repositories" in line for line in out_lines)
     assert any("Matched local directories" in line for line in out_lines)
     assert err_lines == []
+
+
+def test_delete_helpers_cover_owner_repo_and_root_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert delete_ops._parse_owner_from_repo_ref("acme/repo") == "acme"
+    assert delete_ops._parse_owner_from_repo_ref("github.com/acme/repo") == "acme"
+    assert delete_ops._parse_owner_from_repo_ref("repo-only") is None
+
+    monkeypatch.delenv("GH_REPO", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_ORG", raising=False)
+
+    assert delete_ops._resolve_owner("  acme  ") == "acme"
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", "octo-org/demo")
+    assert delete_ops._resolve_owner(None) == "octo-org"
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    monkeypatch.setenv("GITHUB_ORG", "fallback-org")
+    assert delete_ops._resolve_owner(None) == "fallback-org"
+    monkeypatch.delenv("GITHUB_ORG", raising=False)
+
+    with pytest.raises(RuntimeError, match="Could not resolve owner"):
+        delete_ops._resolve_owner(None)
+
+    with pytest.raises(RuntimeError, match="--prefix must not be empty"):
+        delete_ops._select_matches(repo_names=["demo"], prefix=" ", exact_names=())
+
+    roots = delete_ops._resolve_local_roots(
+        cwd=tmp_path,
+        local_roots=(str(tmp_path / "a"), str(tmp_path / "a"), "relative-root"),
+    )
+    assert roots == [(tmp_path / "a").resolve(), (tmp_path / "relative-root").resolve()]
+
+    with pytest.raises(RuntimeError, match="Refusing local cleanup root '/'"):
+        delete_ops._resolve_local_roots(cwd=tmp_path, local_roots=("/",))
+
+
+def test_delete_helpers_cover_gh_and_repo_list_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(delete_ops.shutil, "which", lambda _name: None)
+    with pytest.raises(RuntimeError, match="GitHub CLI"):
+        delete_ops._ensure_gh_ready(tmp_path)
+
+    monkeypatch.setattr(delete_ops.shutil, "which", lambda _name: "/usr/bin/gh")
+    monkeypatch.setattr(
+        delete_ops,
+        "_run_gh",
+        lambda _cwd, _args: _cp(["gh"], code=1, stderr="auth failed"),
+    )
+    with pytest.raises(RuntimeError, match="Authenticate first"):
+        delete_ops._ensure_gh_ready(tmp_path)
+
+    monkeypatch.setattr(
+        delete_ops,
+        "_run_gh",
+        lambda _cwd, _args: _cp(["gh"], code=1, stderr="boom"),
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        delete_ops._list_repo_names(cwd=tmp_path, owner="acme")
+
+    monkeypatch.setattr(
+        delete_ops,
+        "_run_gh",
+        lambda _cwd, _args: _cp(["gh"], code=0, stdout="{"),
+    )
+    with pytest.raises(
+        RuntimeError, match="Unexpected response while listing repositories"
+    ):
+        delete_ops._list_repo_names(cwd=tmp_path, owner="acme")
+
+    monkeypatch.setattr(
+        delete_ops,
+        "_run_gh",
+        lambda _cwd, _args: _cp(["gh"], code=0, stdout='{"name":"demo"}'),
+    )
+    with pytest.raises(RuntimeError, match="Unexpected repository list response"):
+        delete_ops._list_repo_names(cwd=tmp_path, owner="acme")
+
+
+def test_delete_repositories_covers_no_matches_and_noninteractive_skip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GITHUB_ORG", "acme")
+    monkeypatch.setattr(delete_ops.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    def _fake_run_gh(_cwd: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+        if args == ["auth", "status"]:
+            return _cp(args, code=0)
+        if args == ["repo", "list", "acme", "--limit", "1000", "--json", "name"]:
+            return _cp(args, code=0, stdout='[{"name":"other"}]')
+        raise AssertionError(f"unexpected gh args: {args}")
+
+    monkeypatch.setattr(delete_ops, "_run_gh", _fake_run_gh)
+
+    out_lines: list[str] = []
+    summary = delete_repositories(
+        owner=None,
+        prefix="repo-scaffold-e2e",
+        exact_names=(),
+        include_local=False,
+        delete_local_only=False,
+        local_roots=(),
+        apply=True,
+        assume_yes=False,
+        prompt=lambda _msg: "n",
+        is_tty=False,
+        cwd=tmp_path,
+        out=out_lines.append,
+        err=lambda _line: None,
+    )
+
+    assert summary.matched == 0
+    assert "No matching delete targets found." in out_lines
+
+    local_root = tmp_path / "local-root"
+    local_root.mkdir()
+    (local_root / "repo-scaffold-e2e").mkdir()
+    out_lines.clear()
+    summary = delete_repositories(
+        owner=None,
+        prefix="repo-scaffold-e2e",
+        exact_names=(),
+        include_local=True,
+        delete_local_only=False,
+        local_roots=(str(local_root),),
+        apply=True,
+        assume_yes=False,
+        prompt=lambda _msg: "n",
+        is_tty=False,
+        cwd=tmp_path,
+        out=out_lines.append,
+        err=lambda _line: None,
+    )
+
+    assert summary.remote_skipped == 0
+    assert summary.local_skipped == 1
+    assert any("Non-interactive shell detected" in line for line in out_lines)
+
+
+def test_delete_repositories_covers_abort_and_local_failure_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local_root = tmp_path / "local-root"
+    local_root.mkdir()
+    protected = local_root / "repo-scaffold-e2e"
+    protected.mkdir()
+    broken = local_root / "repo-scaffold-e2e-broken"
+    broken.mkdir()
+
+    out_lines: list[str] = []
+    summary = delete_repositories(
+        owner=None,
+        prefix="repo-scaffold-e2e",
+        exact_names=("repo-scaffold-e2e",),
+        include_local=True,
+        delete_local_only=True,
+        local_roots=(str(local_root),),
+        apply=True,
+        assume_yes=False,
+        prompt=lambda _msg: "n",
+        is_tty=True,
+        cwd=tmp_path,
+        out=out_lines.append,
+        err=lambda _line: None,
+    )
+
+    assert summary.local_skipped == 1
+    assert "Aborted." in out_lines
+
+    monkeypatch.setattr(
+        delete_ops.shutil,
+        "rmtree",
+        lambda path: (
+            (_ for _ in ()).throw(OSError("permission denied"))
+            if Path(path).name == "repo-scaffold-e2e-broken"
+            else None
+        ),
+    )
+
+    err_lines: list[str] = []
+    summary = delete_repositories(
+        owner=None,
+        prefix="repo-scaffold-e2e",
+        exact_names=("repo-scaffold-e2e", "repo-scaffold-e2e-broken"),
+        include_local=True,
+        delete_local_only=True,
+        local_roots=(str(local_root),),
+        apply=True,
+        assume_yes=True,
+        prompt=lambda _msg: "y",
+        is_tty=True,
+        cwd=protected,
+        out=lambda _line: None,
+        err=err_lines.append,
+    )
+
+    assert summary.local_deleted == 0
+    assert summary.local_failures == 2
+    assert any(
+        "refusing to delete current working directory" in line for line in err_lines
+    )
+    assert any("permission denied" in line for line in err_lines)

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -87,13 +87,17 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "name: Install pre-commit" in ci_yaml
     assert "SKIP: tox-suite" in ci_yaml
     assert "pre-commit run --all-files --show-diff-on-failure" in ci_yaml
-    assert "tox-env: [lint, type, test]" in ci_yaml
+    assert "tox-env: [lint, type, coverage]" in ci_yaml
     assert "- name: Install tox" in ci_yaml
     assert "run: tox -e ${{ matrix.tox-env }}" in ci_yaml
+    assert "Upload coverage.xml artifact" in ci_yaml
+    assert "codecov/codecov-action@v5" in ci_yaml
+    assert "CODECOV_TOKEN" in ci_yaml
     assert "language:" in (out_dir / ".github/workflows/codeql.yml").read_text(
         encoding="utf-8"
     )
     generated_readme = (out_dir / "README.md").read_text(encoding="utf-8")
+    assert "[![codecov](" in generated_readme
     assert "Created by [repo-scaffold]" in generated_readme
     assert "## Setup" in generated_readme
     assert "## Git hooks" in generated_readme
@@ -107,7 +111,12 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "tox -e format" in generated_readme
     assert "tox -e precommit" in generated_readme
     assert "the hook exits non-zero" in generated_readme
-    assert "tox -e lint,type,test" in generated_readme
+    assert "tox -e lint,type,coverage" in generated_readme
+    assert "tox -e coverage" in generated_readme
+    assert "tox -e codecov-upload" in generated_readme
+    assert "CODECOV_TOKEN" in generated_readme
+    assert "already present in `.env`" in generated_readme
+    assert "minimum coverage gate is 70%" in generated_readme
     assert "make typecheck" in generated_readme
     assert "## Backlog bootstrap" not in generated_readme
     assert "## GitHub token permissions" not in generated_readme
@@ -118,20 +127,31 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "GH_REPO=" in env_example
     assert "GITHUB_PROJECT_TITLE=" in env_example
     assert "GITHUB_PROJECT_TITLE_TEMPLATE=" in env_example
+    assert "CODECOV_TOKEN=" in env_example
+    assert "read automatically by `tox -e codecov-upload`" in env_example
     pyproject = (out_dir / "pyproject.toml").read_text(encoding="utf-8")
     assert "black>=" in pyproject
     assert "mypy>=" in pyproject
     assert "pre-commit>=" in pyproject
     assert "tox>=" in pyproject
     assert "[tool.mypy]" in pyproject
+    assert "[tool.coverage.run]" in pyproject
+    assert "fail_under = 70" in pyproject
     assert "[tool.tox]" not in pyproject
     tox_ini = (out_dir / "tox.ini").read_text(encoding="utf-8")
-    assert "envlist = lint,type,test" in tox_ini
+    assert "envlist = lint,type,coverage" in tox_ini
     assert "black --check src tests" in tox_ini
     assert "ruff check src tests" in tox_ini
     assert "[testenv:format]" in tox_ini
     assert "[testenv:test-fast]" in tox_ini
     assert 'pytest -q -m "not e2e_github" {posargs:tests}' in tox_ini
+    assert "[testenv:coverage]" in tox_ini
+    assert "[testenv:coverage-fast]" in tox_ini
+    assert "[testenv:codecov-upload]" in tox_ini
+    assert "pytest-cov>=6" in tox_ini
+    assert "codecov-cli>=11" in tox_ini
+    assert "--cov=src --cov-branch" in tox_ini
+    assert "COVERAGE_FILE={toxworkdir}/.coverage.{envname}" in tox_ini
     assert "[testenv:precommit]" in tox_ini
     assert "skip_install = true" in tox_ini
     assert "allowlist_externals =" in tox_ini
@@ -141,7 +161,7 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "{[testenv:format]commands}" in tox_ini
     assert "{[testenv:lint]commands}" in tox_ini
     assert "{[testenv:type]commands}" in tox_ini
-    assert "{[testenv:test-fast]commands}" in tox_ini
+    assert "{[testenv:coverage-fast]commands}" in tox_ini
     assert "git diff --exit-code -- src tests" in tox_ini
     assert "black src tests" in tox_ini
     assert "ruff check src tests --fix" in tox_ini
@@ -153,11 +173,15 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "additional_dependencies:" in pre_commit
     assert "tox>=4.20.0" in pre_commit
     assert 'args: ["-e", "precommit", "-vv"]' in pre_commit
+    assert "run tox suite (format, lint, type, coverage)" in pre_commit
     web_package = (out_dir / "web/package.json").read_text(encoding="utf-8")
     assert '"lint": "eslint ."' in web_package
     assert '"eslint": "^9.21.0"' in web_package
     gitignore = (out_dir / ".gitignore").read_text(encoding="utf-8")
     assert "!.env.example" in gitignore
+    assert ".coverage" in gitignore
+    assert "coverage.xml" in gitignore
+    assert "htmlcov/" in gitignore
     assert ".pre-commit-cache/" in gitignore
     assert not (out_dir / "backlog").exists()
     assert not (out_dir / "scripts").exists()

--- a/tests/test_overwrite_policy.py
+++ b/tests/test_overwrite_policy.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from repo_scaffold.generator import ScaffoldFile
+from repo_scaffold.overwrite_policy import OverwritePolicy, apply_files
+
+
+def test_apply_files_handles_create_skip_prompt_force_backup_and_failures(
+    tmp_path: Path,
+) -> None:
+    create_path = tmp_path / "new.txt"
+    unchanged_path = tmp_path / "same.txt"
+    unchanged_path.write_text("same\n", encoding="utf-8")
+    prompted_path = tmp_path / "prompt.txt"
+    prompted_path.write_text("old\n", encoding="utf-8")
+    forced_path = tmp_path / "forced.sh"
+    forced_path.write_text("echo new\n", encoding="utf-8")
+    forced_path.chmod(0o755)
+    blocked_path = tmp_path / "blocked"
+    blocked_path.mkdir()
+
+    files = [
+        ScaffoldFile(create_path, "created", executable=False),
+        ScaffoldFile(unchanged_path, "same", executable=False),
+        ScaffoldFile(prompted_path, "new", executable=False),
+        ScaffoldFile(forced_path, "echo new", executable=True),
+        ScaffoldFile(blocked_path, "nope", executable=False),
+    ]
+
+    prompted_lines: list[str] = []
+    prompted_errors: list[str] = []
+    prompted = apply_files(
+        files,
+        OverwritePolicy(),
+        prompt=lambda _message: "yes",
+        is_tty=True,
+        out=prompted_lines.append,
+        err=prompted_errors.append,
+    )
+
+    assert prompted.created == 1
+    assert prompted.overwritten == 1
+    assert prompted.skipped == 2
+    assert prompted.failures == 1
+    assert create_path.read_text(encoding="utf-8") == "created\n"
+    assert prompted_path.read_text(encoding="utf-8") == "new\n"
+    assert any(
+        "Error: destination exists and is not a regular file" in line
+        for line in prompted_errors
+    )
+
+    forced_lines: list[str] = []
+    forced = apply_files(
+        [ScaffoldFile(forced_path, "echo newer", executable=True)],
+        OverwritePolicy(force=True, backup=True),
+        out=forced_lines.append,
+    )
+
+    assert forced.created == 0
+    assert forced.overwritten == 1
+    assert forced.skipped == 0
+    assert forced.failures == 0
+    assert forced_path.read_text(encoding="utf-8") == "echo newer\n"
+    assert forced_path.stat().st_mode & 0o111
+    backups = list(tmp_path.glob("forced.sh.bak.*"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == "echo new\n"
+    assert "OVERWRITE" in "\n".join(forced_lines)
+
+
+def test_apply_files_respects_no_and_dry_run(tmp_path: Path) -> None:
+    target = tmp_path / "target.txt"
+    target.write_text("old\n", encoding="utf-8")
+
+    summary_no = apply_files(
+        [ScaffoldFile(target, "new", executable=False)],
+        OverwritePolicy(no=True),
+        is_tty=False,
+        out=lambda _line: None,
+    )
+    assert summary_no.overwritten == 0
+    assert summary_no.skipped == 1
+    assert target.read_text(encoding="utf-8") == "old\n"
+
+    summary_dry = apply_files(
+        [ScaffoldFile(target, "new", executable=False)],
+        OverwritePolicy(dry_run=True),
+        is_tty=False,
+        out=lambda _line: None,
+    )
+    assert summary_dry.overwritten == 1
+    assert target.read_text(encoding="utf-8") == "old\n"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,type,test
+envlist = lint,type,coverage
 
 [testenv]
 basepython = python3.12
@@ -8,6 +8,10 @@ setenv =
 
 [testenv:test]
 description = Run unit test suite
+skip_install = true
+setenv =
+    {[testenv]setenv}
+    PYTHONPATH={toxinidir}/src
 deps =
     pytest>=8
 commands =
@@ -15,10 +19,47 @@ commands =
 
 [testenv:test-fast]
 description = Run fast unit checks used by pre-commit
+skip_install = true
+setenv =
+    {[testenv]setenv}
+    PYTHONPATH={toxinidir}/src
 deps =
     pytest>=8
 commands =
     pytest -q -m "not e2e_github" {posargs:tests}
+
+[testenv:coverage]
+description = Run branch coverage and enforce threshold
+skip_install = true
+setenv =
+    {[testenv]setenv}
+    PYTHONPATH={toxinidir}/src
+    COVERAGE_FILE={toxworkdir}/.coverage.{envname}
+deps =
+    pytest>=8
+    pytest-cov>=6
+commands =
+    pytest -q -m "not e2e_github" --cov=repo_scaffold --cov-branch --cov-report=term-missing --cov-report=xml --cov-report=html {posargs:tests}
+
+[testenv:coverage-fast]
+description = Run fast coverage gate used by pre-commit
+skip_install = true
+setenv =
+    {[testenv:coverage]setenv}
+deps =
+    {[testenv:coverage]deps}
+commands =
+    pytest -q -m "not e2e_github" --cov=repo_scaffold --cov-branch --cov-report=term-missing {posargs:tests}
+
+[testenv:codecov-upload]
+description = Upload coverage.xml to Codecov from a local shell
+skip_install = true
+passenv =
+    CODECOV_TOKEN
+deps =
+    codecov-cli>=11
+commands =
+    python -c 'import os, subprocess; from pathlib import Path; env=os.environ.copy(); p=Path(".env"); raws=p.read_text(encoding="utf-8").splitlines() if (not env.get("CODECOV_TOKEN") and p.exists()) else []; clean=[r.strip() for r in raws]; pairs=[(line[7:] if line.startswith("export ") else line).split("=", 1) for line in clean if line and not line.startswith("#") and "=" in line]; [env.setdefault(k.strip(), v.strip().rstrip("\r").strip(chr(34)).strip(chr(39))) for k, v in pairs if k.strip() == "CODECOV_TOKEN"]; subprocess.run(["codecovcli", "do-upload", "--file", "coverage.xml"], check=True, env=env)'
 
 [testenv:lint]
 description = Run lint checks
@@ -60,10 +101,10 @@ deps =
     {[testenv:format]deps}
     {[testenv:lint]deps}
     {[testenv:type]deps}
-    {[testenv:test-fast]deps}
+    {[testenv:coverage-fast]deps}
 commands =
     {[testenv:format]commands}
     {[testenv:lint]commands}
     {[testenv:type]commands}
-    {[testenv:test-fast]commands}
+    {[testenv:coverage-fast]commands}
     git diff --exit-code -- src tests

--- a/tox.ini
+++ b/tox.ini
@@ -30,10 +30,8 @@ commands =
 
 [testenv:coverage]
 description = Run branch coverage and enforce threshold
-skip_install = true
 setenv =
     {[testenv]setenv}
-    PYTHONPATH={toxinidir}/src
     COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 deps =
     pytest>=8
@@ -45,7 +43,9 @@ commands =
 description = Run fast coverage gate used by pre-commit
 skip_install = true
 setenv =
-    {[testenv:coverage]setenv}
+    {[testenv]setenv}
+    PYTHONPATH={toxinidir}/src
+    COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 deps =
     {[testenv:coverage]deps}
 commands =


### PR DESCRIPTION
## 🧾 Title
Add coverage enforcement, Codecov integration, and push automated coverage above 80%

## 🧠 Description
This PR adds a real Python coverage workflow to `repo-scaffold` and propagates the same setup into generated scaffolds.

It wires branch coverage into:
- local tox commands
- pre-commit
- GitHub Actions CI
- generated Python repos

It also adds Codecov integration, a README badge, local upload support, and enough new unit coverage to bring the repo above the 80% mark.

## 🧩 Changes Included
- [x] Added/updated documentation
- [x] Implemented new feature or enhancement
- [x] Refactored existing code
- [x] Improved error handling or logging
- [x] Updated environment configuration
- [x] Other (expanded automated coverage to 80.67%)

## 🎯 Purpose
Make coverage a first-class quality gate instead of an afterthought:
- enforce branch coverage locally and in CI
- make coverage output easy to inspect (`coverage.xml`, `htmlcov/`)
- support optional Codecov uploads from local dev and CI
- ensure generated repos inherit the same coverage workflow by default

## 🔗 Related Issues / Epics
- **Epic:** N/A
- **Issue:** N/A
- **Closes:** N/A

## 🧪 Testing
1. `poetry run tox -e coverage`
2. `poetry run pytest -q tests/test_create_ops.py tests/test_delete_ops.py tests/test_backlog_ops.py tests/test_generation.py tests/test_cli.py tests/test_overwrite_policy.py`
3. `poetry run python -m compileall -q src tests`

## 🧰 Developer Notes
- Added Codecov badge to the root README and generated READMEs.
- Added coverage config to the root project and generated Python projects.
- Added tox envs:
  - `coverage`
  - `coverage-fast`
  - `codecov-upload`
- `codecov-upload` now reads `CODECOV_TOKEN` from `.env` if it is not already exported in the shell.
- CI now runs `lint`, `type`, and `coverage`, uploads `coverage.xml` as an artifact, and attempts a Codecov upload.
- Pre-commit now runs the fast coverage gate instead of plain `test-fast`.
- Current enforced minimum coverage gate is `70%`.
- Current measured total coverage is `80.67%`.
- Key file coverage after this PR:
  - `create_ops.py`: `84%`
  - `delete_ops.py`: `94%`
  - `generator.py`: `88%`
