### PR TITLE
Import markdown backlog artifacts and tighten managed repo defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ GITHUB_REPO=YOUR_REPO
 # GITHUB_PROJECT_TITLE=YOUR_FIXED_PROJECT_TITLE
 # GITHUB_PROJECT_TITLE_TEMPLATE={repo} Roadmap
 
+# Optional markdown backlog source override for import/apply backlog:
+# GITHUB_TICKETS_DIR=artifacts/tickets
+
 # Optional local Codecov upload token (read automatically by `tox -e codecov-upload`):
 # CODECOV_TOKEN=your_codecov_token
 
@@ -33,3 +36,4 @@ GITHUB_REPO=YOUR_REPO
 # github_full_repo=...
 # github_project_title=...
 # github_project_title_template=...
+# github_tickets_dir=...

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 [![codecov](https://codecov.io/gh/blairg23/repo-scaffold/graph/badge.svg)](https://codecov.io/gh/blairg23/repo-scaffold)
 
-`repo-scaffold` is a repo operations toolkit with five modes:
+`repo-scaffold` is a repo operations toolkit with six modes:
 
 - `create`: create/push a GitHub repo from a local folder and apply baseline settings
 - `init`: generate a new language-first repository scaffold
 - `apply`: apply capabilities safely to an existing repository
+- `import`: convert markdown backlog notes into repo-scaffold JSON
 - `check`: verify GitHub settings drift against the repo-scaffold baseline
 - `delete`: safely clean up GitHub test repositories by prefix or exact name
 
@@ -16,6 +17,7 @@ Workflow model:
 
 - run `init` to generate local repo content
 - run `create` to create/push the remote repository + baseline settings
+- run `import backlog` inside a target repo when you want to turn `artifacts/tickets/*.md` into `artifacts/backlog/issues.json`
 - run `apply ...` from this toolkit repo to manage templates/CI/dependabot/backlog/rules for any target repo
 - run `check ...` from this toolkit repo to verify current GitHub settings against the repo-scaffold baseline
 - run `delete` from this toolkit repo to clean up test repositories
@@ -70,7 +72,7 @@ Defaults:
 - visibility defaults to `public` (override with `--visibility private|internal`)
 - applies merge settings, a managed default-branch ruleset, and security defaults unless `--skip-settings`
 - pushes `HEAD` to remote `main` (`HEAD:main`) and does not rename/switch your local branch
-- default branch policy uses a ruleset baseline: PR required, `0` approvals, conversation resolution, squash-only, linear history, no force-push, no delete
+- default branch policy uses a ruleset baseline: PR required, `0` approvals, conversation resolution, squash-only, linear history, no force-push, no delete, CodeQL merge protection, and automatic Copilot review on new pushes
 - also attempts to enable secret scanning, push protection, Dependabot alerts, automated security updates, and public-repo private vulnerability reporting (best-effort; warnings only if plan/policy blocks them)
 - supports `--dry-run`
 
@@ -93,6 +95,36 @@ Subcommands:
 - `backlog --repo owner/repo [--file PATH] [--dry-run] [--auth-check] [--with-project] [--project-number N | --project-title T] [--project-owner O]`: bulk-create milestones/issues using `gh`
 - `rules [--repo owner/repo] [--apply]`: preview or apply merge settings, the managed default-branch ruleset, and security defaults
 
+### `import`
+
+Convert markdown backlog notes into repo-scaffold backlog JSON.
+
+```bash
+poetry run repo-scaffold import backlog --path /path/to/repo --yes
+```
+
+Behavior:
+
+- defaults source markdown to `<path>/artifacts/tickets`
+- if `<path>/artifacts/tickets` is missing, falls back to `<path>/tickets`
+- if both are missing, falls back to legacy `<path>/.future_tickets`
+- defaults output JSON to `<path>/artifacts/backlog/issues.json`
+- accepts the same overwrite-policy flags as other file-writing commands: `--yes`, `--no`, `--force`, `--dry-run`, `--backup`
+- scans `*.md` recursively under the source directory
+- imports explicit epic markdown files and ticket markdown files
+- creates synthetic epics when tickets do not map to an existing epic
+- merges into an existing backlog JSON file when one is already present
+- skips epics already present by key and tickets already present by exact title
+- produces backlog JSON that can be consumed immediately by `apply backlog`
+
+Typical flow:
+
+```bash
+poetry run repo-scaffold import backlog --path /path/to/repo --yes
+poetry run repo-scaffold apply backlog --path /path/to/repo --repo OWNER/REPO --dry-run
+poetry run repo-scaffold apply backlog --path /path/to/repo --repo OWNER/REPO --with-project
+```
+
 ### `check`
 
 Verify current GitHub settings against the repo-scaffold baseline.
@@ -105,6 +137,7 @@ Behavior:
 
 - checks current merge settings
 - checks the managed default-branch ruleset
+- checks CodeQL merge protection and automatic Copilot review inside that ruleset baseline
 - checks that legacy branch protection has been cleared
 - checks secret scanning and push protection
 - checks Dependabot alerts and Dependabot security updates
@@ -220,11 +253,48 @@ Use default project title from repo name (or env override) with one flag:
 poetry run repo-scaffold apply backlog --path /path/to/repo --repo OWNER/REPO --with-project
 ```
 
-## Backlog JSON format
+If `--file` is omitted and markdown source exists under `<repo-path>/artifacts/tickets` (or fallback source dirs), `apply backlog` auto-imports markdown into backlog JSON before applying. You can also override the markdown source with `GITHUB_TICKETS_DIR`. That means you can use repo-scaffold as the source-of-truth workspace:
 
-Backlog input is JSON only. If `--file` is omitted, fallback order is:
+```bash
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --with-project --dry-run
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --with-project
+```
+
+## Backlog import + JSON format
+
+`apply backlog` still consumes JSON. If your source material is markdown, use `import backlog` first:
+
+```bash
+poetry run repo-scaffold import backlog --path /path/to/repo --yes
+```
+
+Default paths:
+
+1. markdown source: `<repo-path>/artifacts/tickets`
+2. JSON output: `<repo-path>/artifacts/backlog/issues.json`
+
+Env override:
+
+- `GITHUB_TICKETS_DIR=/absolute/or/relative/path`
+- relative paths resolve from `<repo-path>`
+- explicit `--source` still wins over the env var
+
+Legacy fallback:
+
+- if `<repo-path>/artifacts/tickets` does not exist, import tries `<repo-path>/tickets`
+- if `<repo-path>/tickets` also does not exist, import uses `<repo-path>/.future_tickets`
+
+Supported markdown import conventions:
+
+- front matter keys like `name: Epic|Ticket`, `type: epic|ticket`, `key`, `epic`, `epic_key`, `milestone`, `labels`, `assignees`, `priority`
+- `## Title` sections or first markdown heading for issue titles
+- directory grouping for ticket-to-epic mapping
+- `epic:<KEY>` labels for explicit ticket-to-epic association
+
+If you already have JSON, or after import completes, `apply backlog` resolves `--file` with this fallback order:
 1. `local/backlog/issues.json` (when present in the current working directory)
-2. `<repo-path>/backlog/issues.json` (where `--path` defaults to `.`)
+2. `<repo-path>/artifacts/backlog/issues.json` (where `--path` defaults to `.`)
+3. legacy `<repo-path>/backlog/issues.json`
 
 Completed sample file: `examples/backlog/issues.sample.json`.
 Workspace-local private path in this repo: `local/backlog/issues.json` (git-ignored).

--- a/src/repo_scaffold/backlog_import.py
+++ b/src/repo_scaffold/backlog_import.py
@@ -521,6 +521,15 @@ def _parse_front_matter_value(raw: str) -> object:
         try:
             parsed = ast.literal_eval(text)
         except (SyntaxError, ValueError):
+            if text.startswith("[") and text.endswith("]"):
+                inner = text[1:-1].strip()
+                if not inner:
+                    return []
+                return [
+                    _strip_matching_quotes(part)
+                    for part in (piece.strip() for piece in inner.split(","))
+                    if part
+                ]
             return _strip_matching_quotes(text)
         if isinstance(parsed, list):
             return [str(item).strip() for item in parsed if str(item).strip()]
@@ -645,6 +654,10 @@ def _normalize_string_list(raw: object) -> tuple[str, ...]:
             return ()
         if text.startswith("[") and text.endswith("]"):
             parsed = _parse_front_matter_value(text)
+            if parsed == text:
+                return tuple(
+                    part.strip() for part in text[1:-1].split(",") if part.strip()
+                )
             return _normalize_string_list(parsed)
         return tuple(part.strip() for part in text.split(",") if part.strip())
     return ()

--- a/src/repo_scaffold/backlog_import.py
+++ b/src/repo_scaffold/backlog_import.py
@@ -1,0 +1,692 @@
+from __future__ import annotations
+
+import ast
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NotRequired, TypedDict
+
+from .generator import ScaffoldFile
+
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class BacklogImportSummary:
+    source_dir: Path
+    output_file: Path
+    files_scanned: int
+    epics_imported: int
+    tickets_imported: int
+    synthetic_epics: int
+    epics_skipped_existing: int
+    tickets_skipped_existing: int
+
+
+@dataclass(frozen=True)
+class _MarkdownIssue:
+    path: Path
+    relative_parent: Path
+    kind: str
+    title: str
+    body: str
+    labels: tuple[str, ...]
+    assignees: tuple[str, ...]
+    priority: str | None
+    key: str | None
+    epic_key: str | None
+
+
+class _TicketPayload(TypedDict):
+    title: str
+    body: str
+    labels: list[str]
+    assignees: list[str]
+    priority: NotRequired[str]
+
+
+class _EpicPayload(TypedDict):
+    key: str
+    title: str
+    body: str
+    labels: list[str]
+    assignees: list[str]
+    tickets: list[_TicketPayload]
+
+
+class _BacklogPayload(TypedDict):
+    epics: list[_EpicPayload]
+
+
+@dataclass(frozen=True)
+class _MergeSummary:
+    payload: _BacklogPayload
+    epics_imported: int
+    tickets_imported: int
+    synthetic_epics: int
+    epics_skipped_existing: int
+    tickets_skipped_existing: int
+
+
+def build_backlog_import_file(
+    *,
+    source_dir: Path,
+    output_file: Path,
+) -> tuple[ScaffoldFile, BacklogImportSummary]:
+    source_dir = source_dir.resolve()
+    output_file = output_file.resolve()
+
+    if not source_dir.exists() or not source_dir.is_dir():
+        raise RuntimeError(
+            f"Markdown backlog source directory does not exist or is not a directory: {source_dir}"
+        )
+
+    markdown_files = sorted(
+        path
+        for path in source_dir.rglob("*")
+        if path.is_file() and path.suffix.lower() == ".md"
+    )
+    if not markdown_files:
+        raise RuntimeError(f"No markdown files found under: {source_dir}")
+
+    parsed = [
+        _parse_markdown_issue(path=path, source_dir=source_dir)
+        for path in markdown_files
+    ]
+    imported_payload, synthetic_epic_keys = _build_backlog_payload(
+        parsed, source_dir=source_dir
+    )
+    existing_payload = _load_existing_backlog_payload(output_file=output_file)
+    merge_summary = _merge_backlog_payloads(
+        imported_payload=imported_payload,
+        existing_payload=existing_payload,
+        synthetic_epic_keys=synthetic_epic_keys,
+    )
+
+    summary = BacklogImportSummary(
+        source_dir=source_dir,
+        output_file=output_file,
+        files_scanned=len(markdown_files),
+        epics_imported=merge_summary.epics_imported,
+        tickets_imported=merge_summary.tickets_imported,
+        synthetic_epics=merge_summary.synthetic_epics,
+        epics_skipped_existing=merge_summary.epics_skipped_existing,
+        tickets_skipped_existing=merge_summary.tickets_skipped_existing,
+    )
+    return (
+        ScaffoldFile(
+            path=output_file, content=json.dumps(merge_summary.payload, indent=2)
+        ),
+        summary,
+    )
+
+
+def _build_backlog_payload(
+    parsed: list[_MarkdownIssue], *, source_dir: Path
+) -> tuple[_BacklogPayload, set[str]]:
+    epics = [item for item in parsed if item.kind == "epic"]
+    tickets = [item for item in parsed if item.kind != "epic"]
+
+    epic_records: dict[str, _EpicPayload] = {}
+    epic_order: list[str] = []
+
+    for epic in epics:
+        epic_key = epic.key or _derive_key(epic.title or epic.path.stem)
+        if epic_key in epic_records:
+            raise RuntimeError(f"Duplicate epic key detected during import: {epic_key}")
+        epic_records[epic_key] = {
+            "key": epic_key,
+            "title": epic.title,
+            "body": epic.body,
+            "labels": _merge_labels(("epic",), epic.labels),
+            "assignees": list(epic.assignees),
+            "tickets": [],
+        }
+        epic_order.append(epic_key)
+
+    directory_defaults = _directory_default_epics(epics)
+    synthetic_epic_titles: dict[str, str] = {}
+    root_key = _derive_key(source_dir.name or "imported")
+    real_epic_keys = {
+        epic.key or _derive_key(epic.title or epic.path.stem) for epic in epics
+    }
+
+    for ticket in tickets:
+        epic_key = ticket.epic_key or _resolve_ticket_epic_key(
+            ticket=ticket,
+            directory_defaults=directory_defaults,
+            root_key=root_key,
+        )
+        if epic_key not in epic_records:
+            epic_records[epic_key] = {
+                "key": epic_key,
+                "title": _synthetic_epic_title(
+                    key=epic_key,
+                    title_hint=synthetic_epic_titles.get(epic_key)
+                    or _directory_title_hint(
+                        relative_parent=ticket.relative_parent,
+                        source_dir=source_dir,
+                    ),
+                ),
+                "body": _synthetic_epic_body(source_dir=source_dir, epic_key=epic_key),
+                "labels": ["epic"],
+                "assignees": [],
+                "tickets": [],
+            }
+            epic_order.append(epic_key)
+
+        synthetic_epic_titles.setdefault(
+            epic_key,
+            _directory_title_hint(
+                relative_parent=ticket.relative_parent,
+                source_dir=source_dir,
+            ),
+        )
+        ticket_entry: _TicketPayload = {
+            "title": ticket.title,
+            "body": ticket.body,
+            "labels": _merge_labels(("ticket", f"epic:{epic_key}"), ticket.labels),
+            "assignees": list(ticket.assignees),
+        }
+        if ticket.priority:
+            ticket_entry["priority"] = ticket.priority
+        epic_records[epic_key]["tickets"].append(ticket_entry)
+
+    synthetic_epic_keys = {key for key in epic_order if key not in real_epic_keys}
+    payload: _BacklogPayload = {
+        "epics": [epic_records[key] for key in epic_order],
+    }
+    return payload, synthetic_epic_keys
+
+
+def _load_existing_backlog_payload(*, output_file: Path) -> _BacklogPayload | None:
+    if not output_file.exists():
+        return None
+    try:
+        raw = json.loads(output_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Existing backlog JSON is invalid: {output_file}") from exc
+    return _normalize_existing_backlog_payload(raw, output_file=output_file)
+
+
+def _normalize_existing_backlog_payload(
+    raw: object, *, output_file: Path
+) -> _BacklogPayload:
+    if not isinstance(raw, dict):
+        raise RuntimeError(f"Existing backlog JSON must be an object: {output_file}")
+    epics_raw = raw.get("epics")
+    if not isinstance(epics_raw, list):
+        raise RuntimeError(
+            f"Existing backlog JSON must contain an 'epics' list: {output_file}"
+        )
+
+    epics: list[_EpicPayload] = []
+    for epic_raw in epics_raw:
+        if not isinstance(epic_raw, dict):
+            raise RuntimeError(f"Existing epic entry must be an object: {output_file}")
+        tickets_raw = epic_raw.get("tickets")
+        if not isinstance(tickets_raw, list):
+            raise RuntimeError(
+                f"Existing epic entry must contain a 'tickets' list: {output_file}"
+            )
+
+        tickets: list[_TicketPayload] = []
+        for ticket_raw in tickets_raw:
+            if not isinstance(ticket_raw, dict):
+                raise RuntimeError(
+                    f"Existing ticket entry must be an object: {output_file}"
+                )
+            ticket: _TicketPayload = {
+                "title": _require_string_field(
+                    ticket_raw, field="title", output_file=output_file
+                ),
+                "body": _require_string_field(
+                    ticket_raw, field="body", output_file=output_file
+                ),
+                "labels": list(_normalize_string_list(ticket_raw.get("labels"))),
+                "assignees": list(_normalize_string_list(ticket_raw.get("assignees"))),
+            }
+            priority = ticket_raw.get("priority")
+            if isinstance(priority, str) and priority.strip():
+                ticket["priority"] = priority.strip()
+            tickets.append(ticket)
+
+        epics.append(
+            {
+                "key": _require_string_field(
+                    epic_raw, field="key", output_file=output_file
+                ),
+                "title": _require_string_field(
+                    epic_raw, field="title", output_file=output_file
+                ),
+                "body": _require_string_field(
+                    epic_raw, field="body", output_file=output_file
+                ),
+                "labels": list(_normalize_string_list(epic_raw.get("labels"))),
+                "assignees": list(_normalize_string_list(epic_raw.get("assignees"))),
+                "tickets": tickets,
+            }
+        )
+    return {"epics": epics}
+
+
+def _merge_backlog_payloads(
+    *,
+    imported_payload: _BacklogPayload,
+    existing_payload: _BacklogPayload | None,
+    synthetic_epic_keys: set[str],
+) -> _MergeSummary:
+    if existing_payload is None:
+        return _MergeSummary(
+            payload=imported_payload,
+            epics_imported=len(imported_payload["epics"]),
+            tickets_imported=sum(
+                len(epic["tickets"]) for epic in imported_payload["epics"]
+            ),
+            synthetic_epics=len(synthetic_epic_keys),
+            epics_skipped_existing=0,
+            tickets_skipped_existing=0,
+        )
+
+    merged_epics = [_copy_epic_payload(epic) for epic in existing_payload["epics"]]
+    epic_index = {epic["key"]: epic for epic in merged_epics}
+    existing_ticket_titles = {
+        ticket["title"] for epic in merged_epics for ticket in epic["tickets"]
+    }
+
+    epics_imported = 0
+    tickets_imported = 0
+    synthetic_epics_imported = 0
+    epics_skipped_existing = 0
+    tickets_skipped_existing = 0
+
+    for imported_epic in imported_payload["epics"]:
+        epic_key = imported_epic["key"]
+        new_tickets: list[_TicketPayload] = []
+        for ticket in imported_epic["tickets"]:
+            if ticket["title"] in existing_ticket_titles:
+                tickets_skipped_existing += 1
+                continue
+            new_tickets.append(_copy_ticket_payload(ticket))
+            existing_ticket_titles.add(ticket["title"])
+
+        existing_epic = epic_index.get(epic_key)
+        if existing_epic is not None:
+            epics_skipped_existing += 1
+            existing_epic["tickets"].extend(new_tickets)
+            tickets_imported += len(new_tickets)
+            continue
+
+        if epic_key in synthetic_epic_keys and not new_tickets:
+            continue
+
+        merged_epic = _copy_epic_payload(imported_epic)
+        merged_epic["tickets"] = new_tickets
+        merged_epics.append(merged_epic)
+        epic_index[epic_key] = merged_epic
+        epics_imported += 1
+        tickets_imported += len(new_tickets)
+        if epic_key in synthetic_epic_keys:
+            synthetic_epics_imported += 1
+
+    return _MergeSummary(
+        payload={"epics": merged_epics},
+        epics_imported=epics_imported,
+        tickets_imported=tickets_imported,
+        synthetic_epics=synthetic_epics_imported,
+        epics_skipped_existing=epics_skipped_existing,
+        tickets_skipped_existing=tickets_skipped_existing,
+    )
+
+
+def _copy_ticket_payload(ticket: _TicketPayload) -> _TicketPayload:
+    copied: _TicketPayload = {
+        "title": ticket["title"],
+        "body": ticket["body"],
+        "labels": list(ticket["labels"]),
+        "assignees": list(ticket["assignees"]),
+    }
+    if "priority" in ticket:
+        copied["priority"] = ticket["priority"]
+    return copied
+
+
+def _copy_epic_payload(epic: _EpicPayload) -> _EpicPayload:
+    return {
+        "key": epic["key"],
+        "title": epic["title"],
+        "body": epic["body"],
+        "labels": list(epic["labels"]),
+        "assignees": list(epic["assignees"]),
+        "tickets": [_copy_ticket_payload(ticket) for ticket in epic["tickets"]],
+    }
+
+
+def _require_string_field(
+    raw: dict[str, object], *, field: str, output_file: Path
+) -> str:
+    value = raw.get(field)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    raise RuntimeError(
+        f"Existing backlog JSON field '{field}' must be a non-empty string: {output_file}"
+    )
+
+
+def _directory_default_epics(epics: list[_MarkdownIssue]) -> dict[Path, str]:
+    grouped: dict[Path, list[str]] = {}
+    for epic in epics:
+        key = epic.key or _derive_key(epic.title or epic.path.stem)
+        grouped.setdefault(epic.relative_parent, []).append(key)
+
+    defaults: dict[Path, str] = {}
+    for relative_parent, keys in grouped.items():
+        if len(keys) == 1:
+            defaults[relative_parent] = keys[0]
+
+    if not defaults and len(epics) == 1:
+        defaults[Path(".")] = epics[0].key or _derive_key(
+            epics[0].title or epics[0].path.stem
+        )
+    return defaults
+
+
+def _resolve_ticket_epic_key(
+    *,
+    ticket: _MarkdownIssue,
+    directory_defaults: dict[Path, str],
+    root_key: str,
+) -> str:
+    relative_parent = ticket.relative_parent
+    if relative_parent != Path("."):
+        current = relative_parent
+        while True:
+            if current in directory_defaults:
+                return directory_defaults[current]
+            if current == Path("."):
+                break
+            current = current.parent
+    if Path(".") in directory_defaults:
+        return directory_defaults[Path(".")]
+    if relative_parent != Path("."):
+        return _derive_key(relative_parent.name)
+    return root_key
+
+
+def _directory_title_hint(*, relative_parent: Path, source_dir: Path) -> str:
+    if relative_parent == Path("."):
+        return _humanize_fragment(source_dir.name)
+    return _humanize_fragment(relative_parent.name)
+
+
+def _synthetic_epic_title(*, key: str, title_hint: str | None) -> str:
+    hint = (title_hint or "").strip()
+    if hint:
+        return f"{hint} - Imported backlog"
+    return f"{_humanize_fragment(key)} - Imported backlog"
+
+
+def _synthetic_epic_body(*, source_dir: Path, epic_key: str) -> str:
+    return (
+        "## Summary\n"
+        f"Synthetic epic created during markdown backlog import from `{source_dir.name}`.\n\n"
+        "## Notes\n"
+        f"- Epic key: `{epic_key}`\n"
+        "- Review and refine this epic after import if you want a more specific milestone description.\n"
+    )
+
+
+def _parse_markdown_issue(*, path: Path, source_dir: Path) -> _MarkdownIssue:
+    raw = path.read_text(encoding="utf-8")
+    frontmatter, markdown_body = _split_front_matter(raw)
+    title, cleaned_body = _extract_title_and_body(
+        markdown_body=markdown_body,
+        frontmatter=frontmatter,
+        fallback_title=_humanize_fragment(path.stem),
+    )
+    kind = _infer_issue_kind(path=path, frontmatter=frontmatter, title=title)
+    labels = _normalize_string_list(frontmatter.get("labels"))
+    assignees = _normalize_string_list(frontmatter.get("assignees"))
+    priority = _first_string(frontmatter, ("priority",))
+    key = _first_string(frontmatter, ("key", "epic_key"))
+    epic_key = _first_string(
+        frontmatter, ("epic", "epic_key", "milestone")
+    ) or _label_epic_key(labels)
+    relative_parent = path.relative_to(source_dir).parent
+
+    return _MarkdownIssue(
+        path=path,
+        relative_parent=relative_parent,
+        kind=kind,
+        title=title,
+        body=cleaned_body,
+        labels=labels,
+        assignees=assignees,
+        priority=priority,
+        key=_derive_key(key) if key else None,
+        epic_key=_derive_key(epic_key) if epic_key else None,
+    )
+
+
+def _split_front_matter(raw: str) -> tuple[dict[str, object], str]:
+    lines = raw.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, raw
+
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            frontmatter = "\n".join(lines[1:index])
+            body = "\n".join(lines[index + 1 :])
+            return _parse_front_matter(frontmatter), body
+    return {}, raw
+
+
+def _parse_front_matter(raw: str) -> dict[str, object]:
+    loaded: dict[str, object] = {}
+    list_key: str | None = None
+    for raw_line in raw.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if list_key is not None and stripped.startswith("- "):
+            current = loaded.setdefault(list_key, [])
+            if isinstance(current, list):
+                current.append(_strip_matching_quotes(stripped[2:].strip()))
+            continue
+
+        list_key = None
+        if ":" not in raw_line:
+            continue
+
+        key, value = raw_line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if not value:
+            loaded[key] = []
+            list_key = key
+            continue
+        loaded[key] = _parse_front_matter_value(value)
+    return loaded
+
+
+def _parse_front_matter_value(raw: str) -> object:
+    text = raw.strip()
+    if not text:
+        return ""
+    if text[0] in {'"', "'", "["}:
+        try:
+            parsed = ast.literal_eval(text)
+        except (SyntaxError, ValueError):
+            return _strip_matching_quotes(text)
+        if isinstance(parsed, list):
+            return [str(item).strip() for item in parsed if str(item).strip()]
+        return parsed
+    lowered = text.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    return _strip_matching_quotes(text)
+
+
+def _extract_title_and_body(
+    *, markdown_body: str, frontmatter: dict[str, object], fallback_title: str
+) -> tuple[str, str]:
+    content = _HTML_COMMENT_RE.sub("", markdown_body).strip()
+    frontmatter_title = _sanitize_title(_first_string(frontmatter, ("title",)))
+    title = frontmatter_title or None
+    body = content
+
+    for match in _HEADING_RE.finditer(content):
+        heading = _normalize_heading(match.group(2))
+        if heading != "title":
+            continue
+        next_match = _next_heading(content, start=match.end())
+        block_end = next_match.start() if next_match is not None else len(content)
+        section_body = content[match.end() : block_end]
+        extracted = _first_meaningful_line(section_body)
+        if extracted:
+            title = _sanitize_title(extracted)
+        body = f"{content[: match.start()].rstrip()}\n\n{content[block_end:].lstrip()}".strip()
+        break
+
+    if title is None:
+        first_heading = _HEADING_RE.search(content)
+        if first_heading is not None:
+            title = _sanitize_title(first_heading.group(2))
+            body = f"{content[: first_heading.start()].rstrip()}\n\n{content[first_heading.end() :].lstrip()}".strip()
+
+    resolved_title = title or fallback_title
+    resolved_body = body or f"## Summary\nImported from `{fallback_title}`.\n"
+    return resolved_title, _normalize_markdown(resolved_body)
+
+
+def _normalize_markdown(raw: str) -> str:
+    compact = re.sub(r"\n{3,}", "\n\n", raw.strip())
+    return compact + "\n"
+
+
+def _next_heading(text: str, *, start: int) -> re.Match[str] | None:
+    return _HEADING_RE.search(text, pos=start)
+
+
+def _first_meaningful_line(raw: str) -> str | None:
+    for line in raw.splitlines():
+        candidate = line.strip()
+        if candidate:
+            return candidate
+    return None
+
+
+def _infer_issue_kind(*, path: Path, frontmatter: dict[str, object], title: str) -> str:
+    for key in ("type", "name"):
+        value = _first_string(frontmatter, (key,))
+        if value:
+            lowered = value.lower()
+            if "epic" in lowered:
+                return "epic"
+            if "ticket" in lowered:
+                return "ticket"
+
+    labels = {
+        label.lower() for label in _normalize_string_list(frontmatter.get("labels"))
+    }
+    if "epic" in labels:
+        return "epic"
+    if "ticket" in labels:
+        return "ticket"
+
+    raw_title = (_first_string(frontmatter, ("title",)) or title).lower()
+    if raw_title.startswith("[epic]"):
+        return "epic"
+    if raw_title.startswith("[ticket]"):
+        return "ticket"
+
+    if "epic" in path.stem.lower():
+        return "epic"
+    return "ticket"
+
+
+def _merge_labels(defaults: tuple[str, ...], extras: tuple[str, ...]) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for label in (*defaults, *extras):
+        normalized = label.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        ordered.append(normalized)
+    return ordered
+
+
+def _label_epic_key(labels: tuple[str, ...]) -> str | None:
+    for label in labels:
+        if label.lower().startswith("epic:"):
+            return label.split(":", 1)[1].strip()
+    return None
+
+
+def _normalize_string_list(raw: object) -> tuple[str, ...]:
+    if isinstance(raw, list):
+        return tuple(
+            item.strip() for item in (str(value) for value in raw) if item.strip()
+        )
+    if isinstance(raw, tuple):
+        return tuple(
+            item.strip() for item in (str(value) for value in raw) if item.strip()
+        )
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return ()
+        if text.startswith("[") and text.endswith("]"):
+            parsed = _parse_front_matter_value(text)
+            return _normalize_string_list(parsed)
+        return tuple(part.strip() for part in text.split(",") if part.strip())
+    return ()
+
+
+def _sanitize_title(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    title = raw.strip()
+    if not title:
+        return None
+    for prefix in ("[EPIC]", "[Ticket]", "[TICKET]"):
+        if title.startswith(prefix):
+            title = title[len(prefix) :].strip()
+    return title or None
+
+
+def _derive_key(raw: str) -> str:
+    parts = re.findall(r"[A-Za-z0-9]+", raw.upper())
+    key = "_".join(parts).strip("_")
+    return key[:48] or "IMPORTED"
+
+
+def _normalize_heading(raw: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", raw.lower()).strip()
+
+
+def _humanize_fragment(raw: str) -> str:
+    text = raw.lstrip(".").replace("_", " ").replace("-", " ").strip()
+    return re.sub(r"\s+", " ", text).title() or "Imported Backlog"
+
+
+def _first_string(frontmatter: dict[str, object], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = frontmatter.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _strip_matching_quotes(raw: str) -> str:
+    value = raw.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -221,7 +221,7 @@ def _seed_env_for_parsed_mode(ns: argparse.Namespace) -> None:
     _seed_env_from_dotenv(Path.cwd() / ".env")
     if ns.mode == "create" and getattr(ns, "path", None):
         _seed_env_from_dotenv(Path(ns.path) / ".env")
-    if ns.mode == "apply" and hasattr(ns, "path"):
+    if ns.mode in {"apply", "import"} and hasattr(ns, "path"):
         _seed_env_from_dotenv(Path(ns.path) / ".env")
 
 

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -13,6 +13,7 @@ from .backlog_ops import (
     resolve_authenticated_login,
     resolve_project_target_for_auth_check,
 )
+from .backlog_import import build_backlog_import_file
 from .create_ops import (
     CreateSummary,
     SettingsCheckSummary,
@@ -36,8 +37,13 @@ from .overwrite_policy import ApplySummary, OverwritePolicy, apply_files
 
 DEFAULT_INIT_NAME_PREFIX = "repo-scaffold-e2e"
 DEFAULT_INIT_LANGUAGES = "go,python,react"
-DEFAULT_BACKLOG_REL_PATH = "backlog/issues.json"
+DEFAULT_BACKLOG_REL_PATH = "artifacts/backlog/issues.json"
+LEGACY_DEFAULT_BACKLOG_REL_PATH = "backlog/issues.json"
 DEFAULT_LOCAL_BACKLOG_REL_PATH = "local/backlog/issues.json"
+DEFAULT_MARKDOWN_BACKLOG_REL_DIR = "artifacts/tickets"
+FALLBACK_MARKDOWN_BACKLOG_REL_DIR = "tickets"
+LEGACY_MARKDOWN_BACKLOG_REL_DIR = ".future_tickets"
+BACKLOG_TICKETS_DIR_ENV = "GITHUB_TICKETS_DIR"
 
 
 def _repo_name_from_repo_ref(raw: str | None) -> str | None:
@@ -114,6 +120,10 @@ def _seed_env_from_dotenv(path: Path) -> None:
         os.environ["GITHUB_PROJECT_TITLE_TEMPLATE"] = os.environ[
             "github_project_title_template"
         ]
+    if not os.environ.get(BACKLOG_TICKETS_DIR_ENV) and os.environ.get(
+        "github_tickets_dir"
+    ):
+        os.environ[BACKLOG_TICKETS_DIR_ENV] = os.environ["github_tickets_dir"]
 
 
 def _normalize_owner_repo(raw: str, *, allow_host_prefix: bool) -> str | None:
@@ -161,7 +171,50 @@ def _resolve_backlog_file_path(*, repo_dir: Path, file_arg: str | None) -> Path:
     local_backlog = Path.cwd() / DEFAULT_LOCAL_BACKLOG_REL_PATH
     if local_backlog.exists():
         return local_backlog
-    return repo_dir / DEFAULT_BACKLOG_REL_PATH
+    default_backlog = repo_dir / DEFAULT_BACKLOG_REL_PATH
+    if default_backlog.exists():
+        return default_backlog
+    return repo_dir / LEGACY_DEFAULT_BACKLOG_REL_PATH
+
+
+def _resolve_markdown_source_dir(*, repo_dir: Path, source_arg: str | None) -> Path:
+    source_value = source_arg or (os.environ.get(BACKLOG_TICKETS_DIR_ENV) or "").strip()
+    if source_value:
+        source_dir = Path(source_value)
+        return source_dir if source_dir.is_absolute() else (repo_dir / source_dir)
+
+    default_source = repo_dir / DEFAULT_MARKDOWN_BACKLOG_REL_DIR
+    fallback_source = repo_dir / FALLBACK_MARKDOWN_BACKLOG_REL_DIR
+    legacy_source = repo_dir / LEGACY_MARKDOWN_BACKLOG_REL_DIR
+    if default_source.exists():
+        return default_source
+    if fallback_source.exists():
+        return fallback_source
+    if legacy_source.exists():
+        return legacy_source
+    return default_source
+
+
+def _find_existing_markdown_source_dir(repo_dir: Path) -> Path | None:
+    env_source = (os.environ.get(BACKLOG_TICKETS_DIR_ENV) or "").strip()
+    if env_source:
+        candidate = Path(env_source)
+        resolved = candidate if candidate.is_absolute() else (repo_dir / candidate)
+        if resolved.exists():
+            return resolved
+        raise RuntimeError(
+            f"Error: {BACKLOG_TICKETS_DIR_ENV} points to a missing markdown source directory: {resolved}"
+        )
+
+    for relative_dir in (
+        DEFAULT_MARKDOWN_BACKLOG_REL_DIR,
+        FALLBACK_MARKDOWN_BACKLOG_REL_DIR,
+        LEGACY_MARKDOWN_BACKLOG_REL_DIR,
+    ):
+        candidate = repo_dir / relative_dir
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def _seed_env_for_parsed_mode(ns: argparse.Namespace) -> None:
@@ -366,7 +419,12 @@ def build_parser() -> argparse.ArgumentParser:
     apply_backlog_cmd = apply_sub.add_parser(
         "backlog",
         parents=[apply_parent],
-        help="Create milestones/issues in GitHub from backlog/issues.json",
+        help="Create milestones/issues in GitHub from backlog JSON",
+    )
+    apply_backlog_cmd.add_argument(
+        "repo_ref",
+        nargs="?",
+        help="Target GitHub repo (owner/repo). Shorthand for --repo.",
     )
     apply_backlog_cmd.add_argument(
         "--path", default=".", help="Repo path containing backlog data (default: .)"
@@ -375,8 +433,11 @@ def build_parser() -> argparse.ArgumentParser:
     apply_backlog_cmd.add_argument(
         "--file",
         help=(
-            "Backlog JSON path. If omitted, uses ./local/backlog/issues.json when present, "
-            "otherwise <repo-path>/backlog/issues.json"
+            "Backlog JSON path. If omitted, auto-imports from markdown when "
+            "<repo-path>/artifacts/tickets (or fallback source dirs) exists; otherwise uses "
+            "./local/backlog/issues.json when present, "
+            "otherwise <repo-path>/artifacts/backlog/issues.json, "
+            "then legacy <repo-path>/backlog/issues.json"
         ),
     )
     apply_backlog_cmd.add_argument(
@@ -428,6 +489,34 @@ def build_parser() -> argparse.ArgumentParser:
     )
     check_rules.add_argument("--repo", help="Target GitHub repo (owner/repo)")
 
+    import_cmd = subparsers.add_parser(
+        "import",
+        help="Import markdown artifacts into repo-scaffold formats",
+    )
+    import_sub = import_cmd.add_subparsers(dest="import_command", required=True)
+    import_backlog = import_sub.add_parser(
+        "backlog",
+        parents=[apply_parent],
+        help="Import markdown backlog files into artifacts/backlog/issues.json",
+    )
+    import_backlog.add_argument(
+        "--path",
+        default=".",
+        help="Target repository path containing markdown backlog notes (default: .)",
+    )
+    import_backlog.add_argument(
+        "--source",
+        help=(
+            "Markdown source directory "
+            "(default: <path>/artifacts/tickets, fallback to <path>/tickets, "
+            "then legacy <path>/.future_tickets; env override: GITHUB_TICKETS_DIR)"
+        ),
+    )
+    import_backlog.add_argument(
+        "--out",
+        help="Backlog JSON output path (default: <path>/artifacts/backlog/issues.json)",
+    )
+
     return parser
 
 
@@ -435,7 +524,7 @@ def _normalize_argv(argv: list[str] | None) -> list[str]:
     raw = list(sys.argv[1:] if argv is None else argv)
     if raw and raw[0] in {"-h", "--help"}:
         return raw
-    if raw and raw[0] in {"create", "init", "apply", "check", "delete"}:
+    if raw and raw[0] in {"create", "init", "apply", "check", "delete", "import"}:
         return raw
     # Backward-compatible behavior: previous root command maps to init.
     return ["init", *raw]
@@ -717,8 +806,14 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 2
+        if ns.repo and ns.repo_ref and ns.repo != ns.repo_ref:
+            print(
+                "Error: positional repo and --repo disagree. Use only one target repo.",
+                file=sys.stderr,
+            )
+            return 2
         target_repo, repo_error = _resolve_repo_from_args_or_env(
-            repo=ns.repo, fallback_name=repo_dir.name
+            repo=ns.repo or ns.repo_ref, fallback_name=repo_dir.name
         )
         if repo_error:
             print(repo_error, file=sys.stderr)
@@ -761,7 +856,62 @@ def main(argv: list[str] | None = None) -> int:
             if project_target is not None:
                 print(f"GitHub project access OK: {project_target}")
             return 0
-        backlog_file = _resolve_backlog_file_path(repo_dir=repo_dir, file_arg=ns.file)
+        backlog_file: Path
+        if ns.file:
+            backlog_file = _resolve_backlog_file_path(
+                repo_dir=repo_dir, file_arg=ns.file
+            )
+        else:
+            try:
+                markdown_source_dir = _find_existing_markdown_source_dir(repo_dir)
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+                return 2
+            if markdown_source_dir is not None:
+                try:
+                    imported_backlog_file, import_summary = build_backlog_import_file(
+                        source_dir=markdown_source_dir,
+                        output_file=repo_dir / DEFAULT_BACKLOG_REL_PATH,
+                    )
+                except RuntimeError as exc:
+                    print(str(exc), file=sys.stderr)
+                    return 1
+
+                if ns.dry_run:
+                    temp_dir = Path(tempfile.mkdtemp(prefix="repo-scaffold-backlog-"))
+                    backlog_file = temp_dir / "issues.json"
+                    backlog_file.write_text(
+                        imported_backlog_file.content, encoding="utf-8"
+                    )
+                    print(
+                        f"[dry-run] auto-imported backlog JSON from {import_summary.source_dir}"
+                    )
+                else:
+                    import_apply_summary = apply_files(
+                        [imported_backlog_file],
+                        _policy_from_ns(ns),
+                        prompt=input,
+                        is_tty=sys.stdin.isatty(),
+                    )
+                    if import_apply_summary.failures > 0:
+                        return 1
+                    if (
+                        import_apply_summary.skipped > 0
+                        and not imported_backlog_file.path.exists()
+                    ):
+                        print(
+                            "Error: auto-imported backlog JSON was skipped and no existing output file is available.",
+                            file=sys.stderr,
+                        )
+                        return 1
+                    backlog_file = imported_backlog_file.path
+                    print(
+                        f"Auto-imported backlog JSON from {import_summary.source_dir}"
+                    )
+            else:
+                backlog_file = _resolve_backlog_file_path(
+                    repo_dir=repo_dir, file_arg=None
+                )
         try:
             backlog_summary: BacklogApplySummary = apply_backlog(
                 repo_dir=repo_dir,
@@ -853,6 +1003,65 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  checks skipped: {check_summary.skipped}")
         print(f"  drift items: {len(check_summary.drifts)}")
         return 1 if check_summary.failed > 0 else 0
+
+    if ns.mode == "import" and ns.import_command == "backlog":
+        repo_dir = Path(ns.path)
+        if not repo_dir.exists() or not repo_dir.is_dir():
+            print(
+                f"Error: repo path does not exist or is not a directory: {repo_dir}",
+                file=sys.stderr,
+            )
+            return 2
+
+        source_dir = _resolve_markdown_source_dir(
+            repo_dir=repo_dir, source_arg=ns.source
+        )
+        output_file = (
+            Path(ns.out)
+            if ns.out and Path(ns.out).is_absolute()
+            else repo_dir / (ns.out or DEFAULT_BACKLOG_REL_PATH)
+        )
+
+        try:
+            imported_backlog_file, import_summary = build_backlog_import_file(
+                source_dir=source_dir,
+                output_file=output_file,
+            )
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+
+        apply_summary = apply_files(
+            [imported_backlog_file],
+            _policy_from_ns(ns),
+            prompt=input,
+            is_tty=sys.stdin.isatty(),
+        )
+        print("")
+        print("Summary:")
+        if ns.dry_run:
+            print("  mode: dry-run")
+        print(f"  source dir: {import_summary.source_dir}")
+        print(f"  output file: {import_summary.output_file}")
+        print(f"  markdown files scanned: {import_summary.files_scanned}")
+        print(f"  epics imported: {import_summary.epics_imported}")
+        print(
+            f"  epics skipped (already present): {import_summary.epics_skipped_existing}"
+        )
+        print(f"  tickets imported: {import_summary.tickets_imported}")
+        print(
+            f"  tickets skipped (already present): {import_summary.tickets_skipped_existing}"
+        )
+        print(f"  synthetic epics: {import_summary.synthetic_epics}")
+        print(f"  created: {apply_summary.created}")
+        print(f"  overwritten: {apply_summary.overwritten}")
+        print(f"  skipped: {apply_summary.skipped}")
+        print(f"  failures: {apply_summary.failures}")
+        if apply_summary.failures == 0:
+            print(
+                f"{'Dry-run complete for' if ns.dry_run else 'Imported backlog to'}: {output_file}"
+            )
+        return 1 if apply_summary.failures > 0 else 0
 
     parser.error("Unsupported command.")
     return 2

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -30,12 +30,20 @@ class SettingsCheckSummary:
 
 
 _API_VERSION = "2026-03-10"
-_SETTINGS_RULESET_NAME = "repo-scaffold default-branch ruleset"
+_SETTINGS_RULESET_NAME = "repo-scaffold baseline branch rules"
+_LEGACY_SETTINGS_RULESET_NAME = "repo-scaffold default-branch ruleset"
 
 _BEST_EFFORT_SECURITY_FEATURES: tuple[tuple[str, str], ...] = (
     ("Dependabot alerts", "/repos/{repo}/vulnerability-alerts"),
     ("Dependabot security updates", "/repos/{repo}/automated-security-fixes"),
 )
+
+
+def _is_managed_ruleset_name(name: object) -> bool:
+    return isinstance(name, str) and name in {
+        _SETTINGS_RULESET_NAME,
+        _LEGACY_SETTINGS_RULESET_NAME,
+    }
 
 
 def _api_headers() -> list[str]:
@@ -62,6 +70,41 @@ def _repo_patch_payload() -> str:
 
 
 def _default_branch_ruleset_payload() -> str:
+    rules: list[dict[str, object]] = [
+        {"type": "deletion"},
+        {"type": "non_fast_forward"},
+        {"type": "required_linear_history"},
+        {
+            "type": "pull_request",
+            "parameters": {
+                "allowed_merge_methods": ["squash"],
+                "dismiss_stale_reviews_on_push": False,
+                "require_code_owner_review": False,
+                "require_last_push_approval": False,
+                "required_approving_review_count": 0,
+                "required_review_thread_resolution": True,
+            },
+        },
+        {
+            "type": "code_scanning",
+            "parameters": {
+                "code_scanning_tools": [
+                    {
+                        "tool": "CodeQL",
+                        "alerts_threshold": "errors",
+                        "security_alerts_threshold": "high_or_higher",
+                    }
+                ]
+            },
+        },
+        {
+            "type": "copilot_code_review",
+            "parameters": {
+                "review_draft_pull_requests": False,
+                "review_on_push": True,
+            },
+        },
+    ]
     return json.dumps(
         {
             "name": _SETTINGS_RULESET_NAME,
@@ -73,22 +116,7 @@ def _default_branch_ruleset_payload() -> str:
                     "exclude": [],
                 }
             },
-            "rules": [
-                {"type": "deletion"},
-                {"type": "non_fast_forward"},
-                {"type": "required_linear_history"},
-                {
-                    "type": "pull_request",
-                    "parameters": {
-                        "allowed_merge_methods": ["squash"],
-                        "dismiss_stale_reviews_on_push": False,
-                        "require_code_owner_review": False,
-                        "require_last_push_approval": False,
-                        "required_approving_review_count": 0,
-                        "required_review_thread_resolution": True,
-                    },
-                },
-            ],
+            "rules": rules,
         },
         indent=2,
     )
@@ -293,7 +321,7 @@ def _sync_default_branch_ruleset(
     managed_rulesets = [
         item
         for item in _list_repo_rulesets(repo_dir=repo_dir, env=env, repo=repo)
-        if item.get("name") == _SETTINGS_RULESET_NAME
+        if _is_managed_ruleset_name(item.get("name"))
     ]
     payload = _default_branch_ruleset_payload()
 
@@ -432,7 +460,7 @@ def _compare_ruleset_against_baseline(
 ) -> list[str]:
     drifts: list[str] = []
     managed_rulesets = [
-        item for item in rulesets if item.get("name") == _SETTINGS_RULESET_NAME
+        item for item in rulesets if _is_managed_ruleset_name(item.get("name"))
     ]
     if not managed_rulesets:
         return ["managed default-branch ruleset missing"]
@@ -491,6 +519,8 @@ def _compare_ruleset_against_baseline(
         "non_fast_forward",
         "required_linear_history",
         "pull_request",
+        "code_scanning",
+        "copilot_code_review",
     ):
         if required_rule not in rule_map:
             drifts.append(f"missing rule: {required_rule}")
@@ -521,6 +551,43 @@ def _compare_ruleset_against_baseline(
         drifts.append(
             f"pull_request.allowed_merge_methods expected ['squash'] got {actual_methods!r}"
         )
+
+    code_scanning_rule = rule_map.get("code_scanning")
+    if isinstance(code_scanning_rule, dict):
+        code_scanning_parameters = code_scanning_rule.get("parameters")
+        if not isinstance(code_scanning_parameters, dict):
+            drifts.append("code_scanning rule parameters missing or invalid")
+        else:
+            tools = code_scanning_parameters.get("code_scanning_tools")
+            expected_tools = [
+                {
+                    "tool": "CodeQL",
+                    "alerts_threshold": "errors",
+                    "security_alerts_threshold": "high_or_higher",
+                }
+            ]
+            if tools != expected_tools:
+                drifts.append(
+                    "code_scanning.code_scanning_tools expected "
+                    f"{expected_tools!r} got {tools!r}"
+                )
+
+    copilot_code_review_rule = rule_map.get("copilot_code_review")
+    if isinstance(copilot_code_review_rule, dict):
+        copilot_parameters = copilot_code_review_rule.get("parameters")
+        if not isinstance(copilot_parameters, dict):
+            drifts.append("copilot_code_review rule parameters missing or invalid")
+        else:
+            expected_copilot_params = {
+                "review_draft_pull_requests": False,
+                "review_on_push": True,
+            }
+            for key, expected in expected_copilot_params.items():
+                actual = copilot_parameters.get(key)
+                if actual != expected:
+                    drifts.append(
+                        f"copilot_code_review.{key} expected {expected!r} got {actual!r}"
+                    )
 
     return drifts
 
@@ -894,7 +961,8 @@ def _apply_settings(
         out("[dry-run] sync repository merge settings")
         out(
             "[dry-run] sync managed default-branch ruleset "
-            "(pull request required, 0 approvals, squash-only, no force-push, no delete)"
+            "(pull request required, 0 approvals, squash-only, no force-push, no delete, "
+            "CodeQL merge protection, Copilot review on new pushes)"
         )
         out("[dry-run] remove legacy default-branch protection if present")
         out("[dry-run] enable secret scanning")
@@ -1007,7 +1075,7 @@ def _check_settings(
     rulesets = _list_repo_rulesets(repo_dir=repo_dir, env=env, repo=repo)
     detailed_rulesets: list[dict[str, object]] = []
     for ruleset in rulesets:
-        if ruleset.get("name") == _SETTINGS_RULESET_NAME and (
+        if _is_managed_ruleset_name(ruleset.get("name")) and (
             not isinstance(ruleset.get("conditions"), dict)
             or not isinstance(ruleset.get("rules"), list)
         ):

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -2342,6 +2342,7 @@ commands =
     pytest -q -m "not e2e_github" {posargs:tests}
 
 [testenv:coverage]
+package = editable
 deps =
     -e .[dev]
     pytest-cov>=6
@@ -2351,6 +2352,7 @@ commands =
     pytest -q -m "not e2e_github" --cov=src --cov-branch --cov-report=term-missing --cov-report=xml --cov-report=html {posargs:tests}
 
 [testenv:coverage-fast]
+package = editable
 deps =
     {[testenv:coverage]deps}
 setenv =

--- a/tests/test_backlog_import.py
+++ b/tests/test_backlog_import.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from repo_scaffold.backlog_import import build_backlog_import_file
+
+
+def test_build_backlog_import_file_parses_epics_and_tickets(tmp_path: Path) -> None:
+    source_dir = tmp_path / "tickets" / "platform"
+    source_dir.mkdir(parents=True)
+
+    (source_dir / "epic.md").write_text(
+        """---
+name: Epic
+key: PLATFORM
+labels: ["epic", "needs-triage"]
+assignees: ["blairg23"]
+---
+
+## 🧾 Title
+
+Platform foundation
+
+## 🧠 Summary
+
+Establish baseline workflows and repository defaults.
+""",
+        encoding="utf-8",
+    )
+    (source_dir / "ticket-ci.md").write_text(
+        """---
+name: Ticket
+labels: ["needs-triage"]
+assignees: ["blairg23"]
+priority: P1
+---
+
+## 🧾 Title
+
+Add CI pipeline
+
+## 🧠 Summary
+
+Run formatting, typing, and tests in CI.
+""",
+        encoding="utf-8",
+    )
+
+    output_file = tmp_path / "backlog" / "issues.json"
+    scaffold_file, summary = build_backlog_import_file(
+        source_dir=source_dir.parent,
+        output_file=output_file,
+    )
+
+    payload = json.loads(scaffold_file.content)
+    assert summary.files_scanned == 2
+    assert summary.epics_imported == 1
+    assert summary.tickets_imported == 1
+    assert summary.synthetic_epics == 0
+    assert summary.epics_skipped_existing == 0
+    assert summary.tickets_skipped_existing == 0
+    assert scaffold_file.path == output_file.resolve()
+    assert payload["epics"][0]["key"] == "PLATFORM"
+    assert payload["epics"][0]["title"] == "Platform foundation"
+    assert payload["epics"][0]["assignees"] == ["blairg23"]
+    assert "Establish baseline workflows" in payload["epics"][0]["body"]
+    assert payload["epics"][0]["tickets"][0]["title"] == "Add CI pipeline"
+    assert payload["epics"][0]["tickets"][0]["priority"] == "P1"
+    assert payload["epics"][0]["tickets"][0]["labels"] == [
+        "ticket",
+        "epic:PLATFORM",
+        "needs-triage",
+    ]
+
+
+def test_build_backlog_import_file_creates_synthetic_epic_for_unmapped_tickets(
+    tmp_path: Path,
+) -> None:
+    source_dir = tmp_path / "tickets"
+    source_dir.mkdir(parents=True)
+    (source_dir / "backup-db.md").write_text(
+        """# Backup database
+
+## 🧠 Summary
+
+Create a reliable database backup flow.
+""",
+        encoding="utf-8",
+    )
+
+    scaffold_file, summary = build_backlog_import_file(
+        source_dir=source_dir,
+        output_file=tmp_path / "backlog" / "issues.json",
+    )
+
+    payload = json.loads(scaffold_file.content)
+    assert summary.files_scanned == 1
+    assert summary.epics_imported == 1
+    assert summary.tickets_imported == 1
+    assert summary.synthetic_epics == 1
+    assert summary.epics_skipped_existing == 0
+    assert summary.tickets_skipped_existing == 0
+    assert payload["epics"][0]["key"] == "TICKETS"
+    assert payload["epics"][0]["title"] == "Tickets - Imported backlog"
+    assert payload["epics"][0]["tickets"][0]["title"] == "Backup database"
+    assert payload["epics"][0]["tickets"][0]["labels"] == [
+        "ticket",
+        "epic:TICKETS",
+    ]
+
+
+def test_build_backlog_import_file_skips_existing_epics_and_tickets(
+    tmp_path: Path,
+) -> None:
+    source_dir = tmp_path / "tickets" / "platform"
+    source_dir.mkdir(parents=True)
+    (source_dir / "epic.md").write_text(
+        """---
+name: Epic
+key: PLATFORM
+---
+
+## 🧾 Title
+
+Platform foundation
+""",
+        encoding="utf-8",
+    )
+    (source_dir / "ticket-existing.md").write_text(
+        """---
+name: Ticket
+---
+
+## 🧾 Title
+
+Add CI pipeline
+""",
+        encoding="utf-8",
+    )
+    (source_dir / "ticket-new.md").write_text(
+        """---
+name: Ticket
+---
+
+## 🧾 Title
+
+Ship release notes
+""",
+        encoding="utf-8",
+    )
+
+    output_file = tmp_path / "artifacts" / "backlog" / "issues.json"
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text(
+        json.dumps(
+            {
+                "epics": [
+                    {
+                        "key": "PLATFORM",
+                        "title": "Platform foundation",
+                        "body": "## Summary\nExisting epic.\n",
+                        "labels": ["epic"],
+                        "assignees": [],
+                        "tickets": [
+                            {
+                                "title": "Add CI pipeline",
+                                "body": "## Summary\nExisting ticket.\n",
+                                "labels": ["ticket", "epic:PLATFORM"],
+                                "assignees": [],
+                            }
+                        ],
+                    }
+                ]
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    scaffold_file, summary = build_backlog_import_file(
+        source_dir=source_dir.parent,
+        output_file=output_file,
+    )
+
+    payload = json.loads(scaffold_file.content)
+    assert summary.epics_imported == 0
+    assert summary.tickets_imported == 1
+    assert summary.synthetic_epics == 0
+    assert summary.epics_skipped_existing == 1
+    assert summary.tickets_skipped_existing == 1
+    assert len(payload["epics"]) == 1
+    assert [ticket["title"] for ticket in payload["epics"][0]["tickets"]] == [
+        "Add CI pipeline",
+        "Ship release notes",
+    ]

--- a/tests/test_backlog_import.py
+++ b/tests/test_backlog_import.py
@@ -74,6 +74,55 @@ Run formatting, typing, and tests in CI.
     ]
 
 
+def test_build_backlog_import_file_parses_unquoted_bracket_front_matter_lists(
+    tmp_path: Path,
+) -> None:
+    source_dir = tmp_path / "tickets" / "platform"
+    source_dir.mkdir(parents=True)
+
+    (source_dir / "epic.md").write_text(
+        """---
+name: Epic
+key: PLATFORM
+labels: [epic, needs-triage]
+assignees: [blairg23]
+---
+
+# Platform foundation
+""",
+        encoding="utf-8",
+    )
+    (source_dir / "ticket.md").write_text(
+        """---
+name: Ticket
+labels: [needs-triage]
+assignees: [blairg23]
+priority: P1
+---
+
+# Add CI pipeline
+""",
+        encoding="utf-8",
+    )
+
+    scaffold_file, summary = build_backlog_import_file(
+        source_dir=source_dir.parent,
+        output_file=tmp_path / "artifacts" / "backlog" / "issues.json",
+    )
+
+    payload = json.loads(scaffold_file.content)
+    assert summary.epics_imported == 1
+    assert summary.tickets_imported == 1
+    assert payload["epics"][0]["labels"] == ["epic", "needs-triage"]
+    assert payload["epics"][0]["assignees"] == ["blairg23"]
+    assert payload["epics"][0]["tickets"][0]["labels"] == [
+        "ticket",
+        "epic:PLATFORM",
+        "needs-triage",
+    ]
+    assert payload["epics"][0]["tickets"][0]["assignees"] == ["blairg23"]
+
+
 def test_build_backlog_import_file_creates_synthetic_epic_for_unmapped_tickets(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,9 +12,10 @@ from repo_scaffold.delete_ops import DeleteSummary
 
 
 @pytest.fixture(autouse=True)
-def _isolate_ticket_dir_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("GITHUB_TICKETS_DIR", "")
-    monkeypatch.setenv("github_tickets_dir", "")
+def _isolate_cli_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("GITHUB_TICKETS_DIR", raising=False)
+    monkeypatch.delenv("github_tickets_dir", raising=False)
+    monkeypatch.chdir(tmp_path)
 
 
 def test_init_mode_supports_legacy_root_invocation(tmp_path: Path) -> None:
@@ -289,6 +290,42 @@ def test_import_backlog_uses_env_ticket_dir_override(
         encoding="utf-8"
     )
     assert "Env Ticket" in payload
+
+
+def test_import_backlog_uses_repo_local_dotenv_ticket_dir_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+    source_dir = tmp_path / "shared-tickets"
+    source_dir.mkdir(parents=True)
+    (source_dir / "ticket.md").write_text(
+        "# Repo Local Env Ticket\n\n## Summary\n\nImported from repo-local .env override.\n",
+        encoding="utf-8",
+    )
+    (repo_dir / ".env").write_text(
+        f"GITHUB_TICKETS_DIR={source_dir}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    rc = main(
+        [
+            "import",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--yes",
+        ]
+    )
+
+    assert rc == 0
+    payload = (repo_dir / "artifacts" / "backlog" / "issues.json").read_text(
+        encoding="utf-8"
+    )
+    assert "Repo Local Env Ticket" in payload
 
 
 def test_import_backlog_falls_back_to_legacy_future_tickets(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,12 @@ from repo_scaffold.cli import main
 from repo_scaffold.delete_ops import DeleteSummary
 
 
+@pytest.fixture(autouse=True)
+def _isolate_ticket_dir_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_TICKETS_DIR", "")
+    monkeypatch.setenv("github_tickets_dir", "")
+
+
 def test_init_mode_supports_legacy_root_invocation(tmp_path: Path) -> None:
     out_dir = tmp_path / "demo"
     rc = main(
@@ -38,6 +44,7 @@ def test_root_help_shows_all_modes(capsys: pytest.CaptureFixture[str]) -> None:
     assert "apply" in stdout
     assert "check" in stdout
     assert "delete" in stdout
+    assert "import" in stdout
 
 
 def test_init_defaults_name_and_languages(
@@ -172,6 +179,144 @@ def test_apply_dependabot_infers_languages_from_repo(tmp_path: Path) -> None:
     assert 'package-ecosystem: "npm"' not in dependabot
 
 
+def test_import_backlog_writes_json_from_markdown(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    source_dir = repo_dir / "artifacts" / "tickets"
+    source_dir.mkdir(parents=True)
+    (source_dir / "ticket.md").write_text(
+        """## 🧾 Title
+
+Document import flow
+
+## 🧠 Summary
+
+Turn markdown backlog notes into JSON.
+""",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "import",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--yes",
+        ]
+    )
+
+    assert rc == 0
+    output_file = repo_dir / "artifacts" / "backlog" / "issues.json"
+    assert output_file.exists()
+    payload = output_file.read_text(encoding="utf-8")
+    assert "Document import flow" in payload
+
+
+def test_import_backlog_dry_run_does_not_write(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    source_dir = repo_dir / "artifacts" / "tickets"
+    source_dir.mkdir(parents=True)
+    (source_dir / "ticket.md").write_text(
+        "# Dry Run Ticket\n\n## Summary\n\nPreview only.\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "import",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 0
+    assert not (repo_dir / "artifacts" / "backlog" / "issues.json").exists()
+
+
+def test_import_backlog_falls_back_to_repo_tickets(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    source_dir = repo_dir / "tickets"
+    source_dir.mkdir(parents=True)
+    (source_dir / "ticket.md").write_text(
+        "# Repo Ticket\n\n## Summary\n\nImported from repo tickets path.\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "import",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--yes",
+        ]
+    )
+
+    assert rc == 0
+    payload = (repo_dir / "artifacts" / "backlog" / "issues.json").read_text(
+        encoding="utf-8"
+    )
+    assert "Repo Ticket" in payload
+
+
+def test_import_backlog_uses_env_ticket_dir_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+    source_dir = tmp_path / "shared-tickets"
+    source_dir.mkdir(parents=True)
+    (source_dir / "ticket.md").write_text(
+        "# Env Ticket\n\n## Summary\n\nImported from env override.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GITHUB_TICKETS_DIR", str(source_dir))
+
+    rc = main(
+        [
+            "import",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--yes",
+        ]
+    )
+
+    assert rc == 0
+    payload = (repo_dir / "artifacts" / "backlog" / "issues.json").read_text(
+        encoding="utf-8"
+    )
+    assert "Env Ticket" in payload
+
+
+def test_import_backlog_falls_back_to_legacy_future_tickets(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    source_dir = repo_dir / ".future_tickets"
+    source_dir.mkdir(parents=True)
+    (source_dir / "ticket.md").write_text(
+        "# Legacy Ticket\n\n## Summary\n\nImported from legacy path.\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "import",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--yes",
+        ]
+    )
+
+    assert rc == 0
+    payload = (repo_dir / "artifacts" / "backlog" / "issues.json").read_text(
+        encoding="utf-8"
+    )
+    assert "Legacy Ticket" in payload
+
+
 def test_apply_backlog_subcommand_delegates_to_backlog_ops(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -248,6 +393,187 @@ def test_apply_backlog_subcommand_delegates_to_backlog_ops(
     assert "issues skipped (total): 4" in stdout
 
 
+def test_apply_backlog_auto_imports_markdown_when_no_file_is_provided(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    source_dir = repo_dir / "artifacts" / "tickets"
+    source_dir.mkdir(parents=True)
+    (source_dir / "ticket.md").write_text(
+        "# Imported Ticket\n\n## Summary\n\nImported automatically before apply.\n",
+        encoding="utf-8",
+    )
+
+    called: dict[str, object] = {}
+
+    def _fake_apply_backlog(
+        *,
+        repo_dir: Path,
+        repo: str,
+        backlog_file: Path,
+        dry_run: bool,
+        project_number,
+        project_title,
+        project_owner,
+        out,
+        err,
+    ):
+        called["repo_dir"] = repo_dir
+        called["repo"] = repo
+        called["backlog_file"] = backlog_file
+        called["dry_run"] = dry_run
+        called["backlog_payload"] = backlog_file.read_text(encoding="utf-8")
+        return BacklogApplySummary(
+            milestones_created=0,
+            milestones_skipped=0,
+            issues_created=0,
+            issues_skipped=0,
+            failures=0,
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.apply_backlog", _fake_apply_backlog)
+
+    rc = main(
+        [
+            "apply",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--repo",
+            "acme/repo",
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 0
+    assert called["repo_dir"] == repo_dir
+    assert called["repo"] == "acme/repo"
+    assert Path(str(called["backlog_file"])).exists()
+    assert "Imported Ticket" in str(called["backlog_payload"])
+    stdout = capsys.readouterr().out
+    assert "[dry-run] auto-imported backlog JSON from" in stdout
+
+
+def test_apply_backlog_auto_imports_markdown_from_env_ticket_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+    source_dir = tmp_path / "workspace-artifacts" / "tickets"
+    source_dir.mkdir(parents=True)
+    (source_dir / "ticket.md").write_text(
+        "# Imported From Env\n\n## Summary\n\nImported automatically from env.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GITHUB_TICKETS_DIR", str(source_dir))
+
+    called: dict[str, object] = {}
+
+    def _fake_apply_backlog(
+        *,
+        repo_dir: Path,
+        repo: str,
+        backlog_file: Path,
+        dry_run: bool,
+        project_number,
+        project_title,
+        project_owner,
+        out,
+        err,
+    ):
+        called["repo_dir"] = repo_dir
+        called["repo"] = repo
+        called["backlog_file"] = backlog_file
+        called["backlog_payload"] = backlog_file.read_text(encoding="utf-8")
+        return BacklogApplySummary(
+            milestones_created=0,
+            milestones_skipped=0,
+            issues_created=0,
+            issues_skipped=0,
+            failures=0,
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.apply_backlog", _fake_apply_backlog)
+
+    rc = main(
+        [
+            "apply",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--repo",
+            "acme/repo",
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 0
+    assert called["repo_dir"] == repo_dir
+    assert called["repo"] == "acme/repo"
+    assert "Imported From Env" in str(called["backlog_payload"])
+    stdout = capsys.readouterr().out
+    assert "[dry-run] auto-imported backlog JSON from" in stdout
+
+
+def test_apply_backlog_accepts_positional_repo_ref(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+    backlog = repo_dir / "artifacts" / "backlog"
+    backlog.mkdir(parents=True)
+    (backlog / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+    monkeypatch.chdir(workspace)
+
+    called: dict[str, object] = {}
+
+    def _fake_apply_backlog(
+        *,
+        repo_dir: Path,
+        repo: str,
+        backlog_file: Path,
+        dry_run: bool,
+        project_number,
+        project_title,
+        project_owner,
+        out,
+        err,
+    ):
+        called["repo"] = repo
+        called["backlog_file"] = backlog_file
+        return BacklogApplySummary(
+            milestones_created=0,
+            milestones_skipped=0,
+            issues_created=0,
+            issues_skipped=0,
+            failures=0,
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.apply_backlog", _fake_apply_backlog)
+
+    rc = main(
+        [
+            "apply",
+            "backlog",
+            "acme/repo",
+            "--path",
+            str(repo_dir),
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 0
+    assert called["repo"] == "acme/repo"
+    assert called["backlog_file"] == backlog / "issues.json"
+
+
 def test_apply_backlog_defaults_to_local_backlog_when_present(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -259,8 +585,10 @@ def test_apply_backlog_defaults_to_local_backlog_when_present(
 
     repo_dir = workspace / "repo"
     repo_dir.mkdir(parents=True)
-    (repo_dir / "backlog").mkdir(parents=True)
-    (repo_dir / "backlog" / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+    (repo_dir / "artifacts" / "backlog").mkdir(parents=True)
+    (repo_dir / "artifacts" / "backlog" / "issues.json").write_text(
+        '{"epics":[]}', encoding="utf-8"
+    )
 
     monkeypatch.chdir(workspace)
 
@@ -308,7 +636,7 @@ def test_apply_backlog_defaults_to_local_backlog_when_present(
     assert called["backlog_file"] == local_backlog / "issues.json"
 
 
-def test_apply_backlog_defaults_to_repo_backlog_when_local_missing(
+def test_apply_backlog_defaults_to_repo_artifacts_backlog_when_local_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace = tmp_path / "workspace"
@@ -316,7 +644,7 @@ def test_apply_backlog_defaults_to_repo_backlog_when_local_missing(
 
     repo_dir = workspace / "repo"
     repo_dir.mkdir(parents=True)
-    repo_backlog = repo_dir / "backlog"
+    repo_backlog = repo_dir / "artifacts" / "backlog"
     repo_backlog.mkdir(parents=True)
     (repo_backlog / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
 
@@ -364,6 +692,60 @@ def test_apply_backlog_defaults_to_repo_backlog_when_local_missing(
     assert called["repo_dir"] == repo_dir
     assert called["repo"] == "acme/repo"
     assert called["backlog_file"] == repo_backlog / "issues.json"
+
+
+def test_apply_backlog_falls_back_to_legacy_repo_backlog_when_artifacts_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+
+    repo_dir = workspace / "repo"
+    repo_dir.mkdir(parents=True)
+    legacy_backlog = repo_dir / "backlog"
+    legacy_backlog.mkdir(parents=True)
+    (legacy_backlog / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+
+    monkeypatch.chdir(workspace)
+
+    called: dict[str, object] = {}
+
+    def _fake_apply_backlog(
+        *,
+        repo_dir: Path,
+        repo: str,
+        backlog_file: Path,
+        dry_run: bool,
+        project_number,
+        project_title,
+        project_owner,
+        out,
+        err,
+    ):
+        called["backlog_file"] = backlog_file
+        return BacklogApplySummary(
+            milestones_created=0,
+            milestones_skipped=0,
+            issues_created=0,
+            issues_skipped=0,
+            failures=0,
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.apply_backlog", _fake_apply_backlog)
+
+    rc = main(
+        [
+            "apply",
+            "backlog",
+            "--path",
+            str(repo_dir),
+            "--repo",
+            "acme/repo",
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    assert called["backlog_file"] == legacy_backlog / "issues.json"
 
 
 def test_apply_backlog_auth_check(

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -95,14 +95,29 @@ def test_load_json_invalid_raises_runtime_error() -> None:
 
 def test_default_branch_ruleset_payload_uses_zero_review_baseline() -> None:
     payload = json.loads(create_ops._default_branch_ruleset_payload())
-    assert payload["name"] == "repo-scaffold default-branch ruleset"
+    assert payload["name"] == "repo-scaffold baseline branch rules"
     assert payload["conditions"]["ref_name"]["include"] == ["~DEFAULT_BRANCH"]
     pull_request_rule = next(
         rule for rule in payload["rules"] if rule["type"] == "pull_request"
     )
+    code_scanning_rule = next(
+        rule for rule in payload["rules"] if rule["type"] == "code_scanning"
+    )
+    copilot_code_review_rule = next(
+        rule for rule in payload["rules"] if rule["type"] == "copilot_code_review"
+    )
     assert pull_request_rule["parameters"]["required_approving_review_count"] == 0
     assert pull_request_rule["parameters"]["allowed_merge_methods"] == ["squash"]
     assert pull_request_rule["parameters"]["required_review_thread_resolution"] is True
+    assert code_scanning_rule["parameters"]["code_scanning_tools"] == [
+        {
+            "tool": "CodeQL",
+            "alerts_threshold": "errors",
+            "security_alerts_threshold": "high_or_higher",
+        }
+    ]
+    assert copilot_code_review_rule["parameters"]["review_draft_pull_requests"] is False
+    assert copilot_code_review_rule["parameters"]["review_on_push"] is True
 
 
 def test_branch_protection_endpoint_url_encodes_branch_name() -> None:
@@ -115,11 +130,17 @@ def test_branch_protection_endpoint_url_encodes_branch_name() -> None:
     )
 
 
+def test_is_managed_ruleset_name_accepts_new_and_legacy_names() -> None:
+    assert create_ops._is_managed_ruleset_name("repo-scaffold baseline branch rules")
+    assert create_ops._is_managed_ruleset_name("repo-scaffold default-branch ruleset")
+    assert create_ops._is_managed_ruleset_name("something else") is False
+
+
 def test_compare_ruleset_against_baseline_reports_multiple_drifts() -> None:
     drifts = create_ops._compare_ruleset_against_baseline(
         [
             {
-                "name": "repo-scaffold default-branch ruleset",
+                "name": "repo-scaffold baseline branch rules",
                 "target": "tag",
                 "enforcement": "evaluate",
                 "conditions": {
@@ -139,6 +160,25 @@ def test_compare_ruleset_against_baseline_reports_multiple_drifts() -> None:
                             "require_last_push_approval": True,
                             "required_approving_review_count": 2,
                             "required_review_thread_resolution": False,
+                        },
+                    },
+                    {
+                        "type": "code_scanning",
+                        "parameters": {
+                            "code_scanning_tools": [
+                                {
+                                    "tool": "CodeQL",
+                                    "alerts_threshold": "all",
+                                    "security_alerts_threshold": "all",
+                                }
+                            ]
+                        },
+                    },
+                    {
+                        "type": "copilot_code_review",
+                        "parameters": {
+                            "review_draft_pull_requests": True,
+                            "review_on_push": False,
                         },
                     },
                 ],
@@ -165,6 +205,12 @@ def test_compare_ruleset_against_baseline_reports_multiple_drifts() -> None:
     assert "missing rule: required_linear_history" in drifts
     assert "pull_request.required_approving_review_count expected 0 got 2" in drifts
     assert any("pull_request.allowed_merge_methods" in item for item in drifts)
+    assert any("code_scanning.code_scanning_tools" in item for item in drifts)
+    assert (
+        "copilot_code_review.review_draft_pull_requests expected False got True"
+        in drifts
+    )
+    assert "copilot_code_review.review_on_push expected True got False" in drifts
 
 
 def test_repo_metadata_and_ruleset_loaders_cover_success_and_error_paths(
@@ -402,7 +448,7 @@ def test_sync_ruleset_covers_update_create_missing_id_and_api_failure(
     monkeypatch.setattr(
         create_ops,
         "_list_repo_rulesets",
-        lambda **_: [{"name": "repo-scaffold default-branch ruleset", "id": "bad"}],
+        lambda **_: [{"name": "repo-scaffold baseline branch rules", "id": "bad"}],
     )
     with pytest.raises(RuntimeError, match="missing a numeric id"):
         create_ops._sync_default_branch_ruleset(
@@ -773,7 +819,7 @@ def test_check_settings_fetches_ruleset_details_and_accepts_expanded_default_bra
         lambda **_: [
             {
                 "id": 123,
-                "name": "repo-scaffold default-branch ruleset",
+                "name": "repo-scaffold baseline branch rules",
                 "target": "branch",
                 "enforcement": "active",
             }

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -148,6 +148,7 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "[testenv:coverage]" in tox_ini
     assert "[testenv:coverage-fast]" in tox_ini
     assert "[testenv:codecov-upload]" in tox_ini
+    assert "package = editable" in tox_ini
     assert "pytest-cov>=6" in tox_ini
     assert "codecov-cli>=11" in tox_ini
     assert "--cov=src --cov-branch" in tox_ini


### PR DESCRIPTION
## 🧾 Title
Import markdown backlog artifacts and tighten managed repo defaults

## 🧠 Description
This PR turns repo-scaffold into a markdown-first backlog workspace while also carrying two baseline management fixes that were already in this branch:

- add a first-class `import backlog` flow that converts markdown ticket notes into repo-scaffold backlog JSON
- let `apply backlog` auto-import markdown and apply it directly to GitHub Projects/issues without extra file flags
- expand the managed branch ruleset baseline with CodeQL merge protection and automatic Copilot review
- fix generated coverage tox envs so scaffolded repos measure the editable package instead of missing coverage data

## 🧩 Changes Included
- [x] Added/updated documentation
- [x] Implemented new feature or enhancement
- [x] Improved error handling or logging
- [x] Updated environment configuration
- [x] Refactored existing code
- [x] Other (ruleset baseline update and generated coverage fix)

## 🎯 Purpose
Make backlog/project management fit the actual workflow:
- keep planning notes as markdown under `artifacts/tickets`
- convert them into `artifacts/backlog/issues.json`
- let `apply backlog OWNER/REPO --with-project` use that workspace directly
- keep the managed GitHub baseline aligned with desired protections and review automation

## 🔗 Related Issues / Epics
- **Epic:** N/A
- **Issue:** N/A
- **Closes:** N/A

## 🧪 Testing
1. `poetry run pytest -q tests/test_cli.py tests/test_backlog_import.py`
2. `poetry run pytest -q tests/test_create_ops.py tests/test_generation.py`
3. `poetry run tox -e type`
4. Manual validation: `poetry run repo-scaffold apply backlog blairg23/mobile-backup --with-project`

## 🧰 Developer Notes
Backlog workflow changes:
- added new importer module: `src/repo_scaffold/backlog_import.py`
- added new CLI mode/subcommand: `repo-scaffold import backlog`
- default markdown source order is now:
  - `<repo-path>/artifacts/tickets`
  - `<repo-path>/tickets`
  - legacy `<repo-path>/.future_tickets`
- default backlog JSON output is now `<repo-path>/artifacts/backlog/issues.json`
- `apply backlog` now:
  - accepts positional `owner/repo` shorthand
  - auto-imports markdown when `--file` is omitted and a markdown source exists
  - supports `GITHUB_TICKETS_DIR` as an env override for the markdown source
  - merges into existing backlog JSON and skips duplicate epics by key and duplicate tickets by exact title

GitHub settings / scaffold follow-ups included in this branch:
- managed ruleset display name is now `repo-scaffold baseline branch rules`
- legacy managed ruleset name is still recognized and updated in place on next apply
- ruleset baseline now includes:
  - CodeQL code-scanning merge protection
  - automatic Copilot review on new pushes
- generated repo `coverage` / `coverage-fast` tox envs now use `package = editable`
