### PR TITLE
Add guarded GitHub Project management with backup and undo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 [![codecov](https://codecov.io/gh/blairg23/repo-scaffold/graph/badge.svg)](https://codecov.io/gh/blairg23/repo-scaffold)
 
-`repo-scaffold` is a repo operations toolkit with six modes:
+`repo-scaffold` is a repo operations toolkit with seven modes:
 
 - `create`: create/push a GitHub repo from a local folder and apply baseline settings
 - `init`: generate a new language-first repository scaffold
 - `apply`: apply capabilities safely to an existing repository
 - `import`: convert markdown backlog notes into repo-scaffold JSON
 - `check`: verify GitHub settings drift against the repo-scaffold baseline
+- `project`: manage GitHub Projects with explicit destructive-op guards
 - `delete`: safely clean up GitHub test repositories by prefix or exact name
 
 Supported languages: `go`, `python`, `react`.
@@ -20,6 +21,7 @@ Workflow model:
 - run `import backlog` inside a target repo when you want to turn `artifacts/tickets/*.md` into `artifacts/backlog/issues.json`
 - run `apply ...` from this toolkit repo to manage templates/CI/dependabot/backlog/rules for any target repo
 - run `check ...` from this toolkit repo to verify current GitHub settings against the repo-scaffold baseline
+- run `project ...` from this toolkit repo when you need to inspect or manage GitHub Projects directly
 - run `delete` from this toolkit repo to clean up test repositories
 
 ## Install
@@ -145,6 +147,45 @@ Behavior:
 - returns non-zero when drift is found
 
 If `--repo` is omitted, resolves from `GH_REPO` or `GITHUB_ORG` + `GITHUB_REPO` from env/`.env`.
+
+### `project`
+
+Manage GitHub Projects directly.
+
+```bash
+poetry run repo-scaffold project list --project-owner acme
+```
+
+Subcommands:
+
+- `list [--project-owner OWNER]`: list projects for an owner
+- `view (--project-number N | --project-title T) [--project-owner OWNER]`: show project metadata
+- `items (--project-number N | --project-title T) [--project-owner OWNER] [--limit N]`: list the contents of a project
+- `create --project-title T [--project-owner OWNER] [--description TEXT] [--readme MD] [--visibility PUBLIC|PRIVATE] [--dry-run]`: create a project
+- `edit (--project-number N | --project-title T) [--project-owner OWNER] [--title T] [--description TEXT] [--readme MD] [--visibility PUBLIC|PRIVATE] [--dry-run]`: update project metadata
+- `delete (--project-number N | --project-title T) [--project-owner OWNER] --danger [--yes] [--dry-run] [--backup-dir PATH]`: delete a project with automatic backup + undo snapshot
+- `item-delete (--project-number N | --project-title T) [--project-owner OWNER] (--item-id ID | --issue-number N) --danger [--yes] [--dry-run] [--backup-dir PATH]`: delete a project item with automatic backup + undo snapshot
+- `undo --backup-file PATH [--dry-run]`: restore a destructive backup snapshot
+
+Behavior:
+
+- owner resolution defaults in this order: `--project-owner`, then repo/env owner, then the authenticated GitHub login
+- GitHub Projects operations require `project` scope (`gh auth refresh -h github.com -s project`)
+- `list`, `view`, and `items` are read-only
+- `create` and `edit` are standard write operations and support `--dry-run`
+- destructive commands (`delete`, `item-delete`) require `--danger`
+- destructive commands still prompt `y/N` unless `--yes` is passed
+- destructive commands write a backup snapshot to `<path>/artifacts/project-backups` by default
+- the summary prints an exact `project undo --backup-file ...` command after a destructive write
+- undo restores project membership and draft items, but does not recreate custom project fields or field values
+
+Typical destructive flow:
+
+```bash
+poetry run repo-scaffold project items --project-owner acme --project-title "Roadmap"
+poetry run repo-scaffold project item-delete --project-owner acme --project-title "Roadmap" --issue-number 42 --danger --yes
+poetry run repo-scaffold project undo --backup-file /path/to/artifacts/project-backups/project-item-delete-acme-4-YYYYMMDDHHMMSS.json
+```
 
 ### `delete`
 

--- a/src/repo_scaffold/backlog_ops.py
+++ b/src/repo_scaffold/backlog_ops.py
@@ -99,10 +99,16 @@ def _parse_repo_owner(repo: str) -> str:
     return repo.split("/", 1)[0]
 
 
-def _list_projects(repo_dir: Path, owner: str) -> list[dict[str, object]]:
+def _list_projects(
+    repo_dir: Path, owner: str, *, include_closed: bool = False
+) -> list[dict[str, object]]:
+    args = ["project", "list", "--owner", owner, "--limit", "100"]
+    if include_closed:
+        args.append("--closed")
+    args.extend(["--format", "json"])
     cp = _run_gh(
         repo_dir,
-        ["project", "list", "--owner", owner, "--limit", "100", "--format", "json"],
+        args,
     )
     if cp.returncode != 0:
         detail = cp.stderr.strip() or cp.stdout.strip() or "Failed listing projects."

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -34,6 +34,20 @@ from .generator import (
     parse_language_csv,
 )
 from .overwrite_policy import ApplySummary, OverwritePolicy, apply_files
+from .project_ops import (
+    DEFAULT_PROJECT_BACKUP_REL_DIR,
+    ProjectItemsSummary,
+    ProjectListSummary,
+    ProjectMutationSummary,
+    create_project,
+    delete_project,
+    delete_project_item,
+    edit_project,
+    list_project_items,
+    list_projects,
+    undo_project_backup,
+    view_project,
+)
 
 DEFAULT_INIT_NAME_PREFIX = "repo-scaffold-e2e"
 DEFAULT_INIT_LANGUAGES = "go,python,react"
@@ -221,7 +235,7 @@ def _seed_env_for_parsed_mode(ns: argparse.Namespace) -> None:
     _seed_env_from_dotenv(Path.cwd() / ".env")
     if ns.mode == "create" and getattr(ns, "path", None):
         _seed_env_from_dotenv(Path(ns.path) / ".env")
-    if ns.mode in {"apply", "import"} and hasattr(ns, "path"):
+    if ns.mode in {"apply", "import", "project"} and hasattr(ns, "path"):
         _seed_env_from_dotenv(Path(ns.path) / ".env")
 
 
@@ -276,6 +290,48 @@ def _add_apply_target_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--owner", help="GitHub owner for generated metadata")
     parser.add_argument(
         "--name", help="Repository name override (defaults to folder name)"
+    )
+
+
+def _add_project_target_args(parser: argparse.ArgumentParser) -> None:
+    project_group = parser.add_mutually_exclusive_group(required=True)
+    project_group.add_argument(
+        "--project-number",
+        type=int,
+        help="GitHub Project number to target",
+    )
+    project_group.add_argument(
+        "--project-title",
+        help="GitHub Project title to target",
+    )
+    parser.add_argument(
+        "--project-owner",
+        help="GitHub login/org owning the project (defaults to env or authenticated login)",
+    )
+
+
+def _add_danger_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--danger",
+        action="store_true",
+        help="Required acknowledgement for destructive project operations",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompt for dangerous project operations",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the dangerous operation without changing state",
+    )
+    parser.add_argument(
+        "--backup-dir",
+        help=(
+            "Backup directory for destructive project operations "
+            f"(default: <path>/{DEFAULT_PROJECT_BACKUP_REL_DIR})"
+        ),
     )
 
 
@@ -489,6 +545,167 @@ def build_parser() -> argparse.ArgumentParser:
     )
     check_rules.add_argument("--repo", help="Target GitHub repo (owner/repo)")
 
+    project_cmd = subparsers.add_parser(
+        "project",
+        help="Manage GitHub Projects with explicit destructive-op guards",
+    )
+    project_sub = project_cmd.add_subparsers(dest="project_command", required=True)
+
+    project_list_cmd = project_sub.add_parser("list", help="List projects for an owner")
+    project_list_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution and backups (default: .)",
+    )
+    project_list_cmd.add_argument(
+        "--project-owner",
+        help="GitHub login/org owning the projects (defaults to env or authenticated login)",
+    )
+
+    project_view_cmd = project_sub.add_parser(
+        "view", help="View metadata for a single project"
+    )
+    project_view_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution and backups (default: .)",
+    )
+    _add_project_target_args(project_view_cmd)
+
+    project_items_cmd = project_sub.add_parser(
+        "items", help="List the contents of a single project"
+    )
+    project_items_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution and backups (default: .)",
+    )
+    _add_project_target_args(project_items_cmd)
+    project_items_cmd.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum number of project items to fetch (default: 100)",
+    )
+
+    project_create_cmd = project_sub.add_parser("create", help="Create a new project")
+    project_create_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution and backups (default: .)",
+    )
+    project_create_cmd.add_argument(
+        "--project-owner",
+        help="GitHub login/org owning the project (defaults to env or authenticated login)",
+    )
+    project_create_cmd.add_argument(
+        "--project-title",
+        required=True,
+        help="Title for the new project",
+    )
+    project_create_cmd.add_argument(
+        "--description",
+        help="Optional project description",
+    )
+    project_create_cmd.add_argument(
+        "--readme",
+        help="Optional project readme markdown",
+    )
+    project_create_cmd.add_argument(
+        "--visibility",
+        choices=["PRIVATE", "PUBLIC", "private", "public"],
+        help="Optional project visibility override",
+    )
+    project_create_cmd.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the project creation without changing state",
+    )
+
+    project_edit_cmd = project_sub.add_parser(
+        "edit", help="Edit metadata for an existing project"
+    )
+    project_edit_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution and backups (default: .)",
+    )
+    _add_project_target_args(project_edit_cmd)
+    project_edit_cmd.add_argument(
+        "--title",
+        help="Rename the project",
+    )
+    project_edit_cmd.add_argument(
+        "--description",
+        help="Set the project description",
+    )
+    project_edit_cmd.add_argument(
+        "--readme",
+        help="Set the project readme markdown",
+    )
+    project_edit_cmd.add_argument(
+        "--visibility",
+        choices=["PRIVATE", "PUBLIC", "private", "public"],
+        help="Set the project visibility",
+    )
+    project_edit_cmd.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the project edit without changing state",
+    )
+
+    project_delete_cmd = project_sub.add_parser(
+        "delete", help="Delete a project (dangerous; backup + confirmation required)"
+    )
+    project_delete_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution and backups (default: .)",
+    )
+    _add_project_target_args(project_delete_cmd)
+    _add_danger_args(project_delete_cmd)
+
+    project_item_delete_cmd = project_sub.add_parser(
+        "item-delete",
+        help="Delete a project item by item id or linked issue number (dangerous)",
+    )
+    project_item_delete_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution and backups (default: .)",
+    )
+    _add_project_target_args(project_item_delete_cmd)
+    item_group = project_item_delete_cmd.add_mutually_exclusive_group(required=True)
+    item_group.add_argument(
+        "--item-id",
+        help="Exact project item id to delete",
+    )
+    item_group.add_argument(
+        "--issue-number",
+        type=int,
+        help="Linked GitHub issue number for the project item to delete",
+    )
+    _add_danger_args(project_item_delete_cmd)
+
+    project_undo_cmd = project_sub.add_parser(
+        "undo", help="Undo a destructive project backup snapshot"
+    )
+    project_undo_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution and backups (default: .)",
+    )
+    project_undo_cmd.add_argument(
+        "--backup-file",
+        required=True,
+        help="Backup snapshot JSON produced by a dangerous project operation",
+    )
+    project_undo_cmd.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the undo without changing state",
+    )
+
     import_cmd = subparsers.add_parser(
         "import",
         help="Import markdown artifacts into repo-scaffold formats",
@@ -524,7 +741,15 @@ def _normalize_argv(argv: list[str] | None) -> list[str]:
     raw = list(sys.argv[1:] if argv is None else argv)
     if raw and raw[0] in {"-h", "--help"}:
         return raw
-    if raw and raw[0] in {"create", "init", "apply", "check", "delete", "import"}:
+    if raw and raw[0] in {
+        "create",
+        "init",
+        "apply",
+        "check",
+        "delete",
+        "import",
+        "project",
+    }:
         return raw
     # Backward-compatible behavior: previous root command maps to init.
     return ["init", *raw]
@@ -1003,6 +1228,188 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  checks skipped: {check_summary.skipped}")
         print(f"  drift items: {len(check_summary.drifts)}")
         return 1 if check_summary.failed > 0 else 0
+
+    if ns.mode == "project":
+        repo_dir = Path(ns.path)
+        if not repo_dir.exists() or not repo_dir.is_dir():
+            print(
+                f"Error: repo path does not exist or is not a directory: {repo_dir}",
+                file=sys.stderr,
+            )
+            return 2
+
+        mutation_summary: ProjectMutationSummary
+        try:
+            if ns.project_command == "list":
+                list_summary: ProjectListSummary = list_projects(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                )
+                print("Projects:")
+                if not list_summary.projects:
+                    print("  (none)")
+                for project in list_summary.projects:
+                    closed_suffix = " [closed]" if project.closed else ""
+                    print(
+                        f"  - {project.owner}/#{project.number} {project.title}{closed_suffix}"
+                    )
+                print("")
+                print("Summary:")
+                print(f"  owner: {list_summary.owner}")
+                print(f"  projects: {len(list_summary.projects)}")
+                return 0
+
+            if ns.project_command == "view":
+                project = view_project(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
+                )
+                print("Project:")
+                print(f"  owner: {project.owner}")
+                print(f"  number: {project.number}")
+                print(f"  title: {project.title}")
+                if project.id:
+                    print(f"  id: {project.id}")
+                if project.closed is not None:
+                    print(f"  closed: {project.closed}")
+                if project.visibility:
+                    print(f"  visibility: {project.visibility}")
+                if project.description:
+                    print(f"  description: {project.description}")
+                if project.readme:
+                    print(f"  readme: {project.readme}")
+                return 0
+
+            if ns.project_command == "items":
+                items_summary: ProjectItemsSummary = list_project_items(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
+                    limit=ns.limit,
+                )
+                print(
+                    f"Project: {items_summary.project.owner}/#{items_summary.project.number} ({items_summary.project.title})"
+                )
+                print("Items:")
+                if not items_summary.items:
+                    print("  (none)")
+                for item in items_summary.items:
+                    number_display = (
+                        f" #{item.issue_number}"
+                        if item.issue_number is not None
+                        else ""
+                    )
+                    print(
+                        f"  - [{item.content_type}] item={item.id}{number_display} {item.title}"
+                    )
+                    if item.repository:
+                        print(f"    repo: {item.repository}")
+                    if item.content_url:
+                        print(f"    url: {item.content_url}")
+                print("")
+                print("Summary:")
+                print(f"  items: {len(items_summary.items)}")
+                return 0
+
+            if ns.project_command == "create":
+                mutation_summary = create_project(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_title=ns.project_title,
+                    description=ns.description,
+                    readme=ns.readme,
+                    visibility=ns.visibility,
+                    dry_run=ns.dry_run,
+                    out=print,
+                )
+            elif ns.project_command == "edit":
+                mutation_summary = edit_project(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
+                    title=ns.title,
+                    description=ns.description,
+                    readme=ns.readme,
+                    visibility=ns.visibility,
+                    dry_run=ns.dry_run,
+                    out=print,
+                )
+            elif ns.project_command == "delete":
+                mutation_summary = delete_project(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
+                    danger=ns.danger,
+                    assume_yes=ns.yes,
+                    dry_run=ns.dry_run,
+                    backup_dir=ns.backup_dir,
+                    prompt=input,
+                    is_tty=sys.stdin.isatty(),
+                    out=print,
+                    err=lambda line: print(line, file=sys.stderr),
+                )
+            elif ns.project_command == "item-delete":
+                mutation_summary = delete_project_item(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
+                    item_id=ns.item_id,
+                    issue_number=ns.issue_number,
+                    danger=ns.danger,
+                    assume_yes=ns.yes,
+                    dry_run=ns.dry_run,
+                    backup_dir=ns.backup_dir,
+                    prompt=input,
+                    is_tty=sys.stdin.isatty(),
+                    out=print,
+                    err=lambda line: print(line, file=sys.stderr),
+                )
+            elif ns.project_command == "undo":
+                backup_file = Path(ns.backup_file)
+                if not backup_file.is_absolute():
+                    backup_file = repo_dir / backup_file
+                mutation_summary = undo_project_backup(
+                    repo_dir=repo_dir,
+                    backup_file=backup_file,
+                    dry_run=ns.dry_run,
+                    out=print,
+                )
+            else:
+                parser.error("Unsupported project command.")
+                return 2
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+
+        print("")
+        print("Summary:")
+        if getattr(ns, "dry_run", False):
+            print("  mode: dry-run")
+        print(f"  action: {mutation_summary.action}")
+        print(f"  owner: {mutation_summary.owner}")
+        if mutation_summary.project_number is not None:
+            print(f"  project number: {mutation_summary.project_number}")
+        if mutation_summary.project_title:
+            print(f"  project title: {mutation_summary.project_title}")
+        print(f"  changed: {mutation_summary.changed}")
+        if mutation_summary.backup_file is not None:
+            print(f"  backup file: {mutation_summary.backup_file}")
+        if mutation_summary.undo_command is not None:
+            print(f"  undo: {mutation_summary.undo_command}")
+        if mutation_summary.restored_project_number is not None:
+            print(
+                f"  restored project number: {mutation_summary.restored_project_number}"
+            )
+        if mutation_summary.restored_item_id is not None:
+            print(f"  restored item id: {mutation_summary.restored_item_id}")
+        print(f"  failures: {mutation_summary.failures}")
+        return 1 if mutation_summary.failures > 0 else 0
 
     if ns.mode == "import" and ns.import_command == "backlog":
         repo_dir = Path(ns.path)

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -4,6 +4,7 @@ import json
 import os
 import shlex
 import sys
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -334,7 +335,7 @@ def _find_existing_project(
     if not wanted_title:
         raise RuntimeError("--project-title must not be empty.")
 
-    for item in _list_projects(repo_dir, project_owner):
+    for item in _list_projects(repo_dir, project_owner, include_closed=True):
         item_title = item.get("title")
         item_number = item.get("number")
         if (
@@ -569,9 +570,10 @@ def _backup_paths(
 ) -> tuple[Path, str]:
     root = Path(backup_dir) if backup_dir else _default_backup_dir(repo_dir)
     backup_root = root if root.is_absolute() else (repo_dir / root)
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
+    suffix = uuid.uuid4().hex[:8]
     backup_root.mkdir(parents=True, exist_ok=True)
-    return backup_root / f"{prefix}-{stamp}.json", stamp
+    return backup_root / f"{prefix}-{stamp}-{suffix}.json", stamp
 
 
 def _write_backup_file(path: Path, payload: dict[str, object]) -> None:

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -1,0 +1,1131 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from .backlog_ops import (
+    _list_projects,
+    _parse_repo_owner,
+    _project_scope_hint,
+    _run_gh,
+    resolve_authenticated_login,
+)
+
+DEFAULT_PROJECT_BACKUP_REL_DIR = "artifacts/project-backups"
+
+
+@dataclass(frozen=True)
+class ProjectInfo:
+    owner: str
+    number: int
+    title: str
+    id: str | None = None
+    closed: bool | None = None
+    visibility: str | None = None
+    description: str | None = None
+    readme: str | None = None
+
+
+@dataclass(frozen=True)
+class ProjectItemInfo:
+    id: str
+    title: str
+    content_type: str
+    content_url: str | None
+    issue_number: int | None
+    repository: str | None
+    body: str | None = None
+
+
+@dataclass(frozen=True)
+class ProjectListSummary:
+    owner: str
+    projects: tuple[ProjectInfo, ...]
+
+
+@dataclass(frozen=True)
+class ProjectItemsSummary:
+    project: ProjectInfo
+    items: tuple[ProjectItemInfo, ...]
+
+
+@dataclass(frozen=True)
+class ProjectMutationSummary:
+    action: str
+    owner: str
+    project_number: int | None
+    project_title: str | None
+    failures: int
+    changed: bool
+    backup_file: Path | None = None
+    undo_command: str | None = None
+    restored_project_number: int | None = None
+    restored_item_id: str | None = None
+
+
+@dataclass(frozen=True)
+class _ProjectBackup:
+    kind: str
+    payload: dict[str, object]
+
+
+def _emit_err_factory(err: Callable[[str], None] | None) -> Callable[[str], None]:
+    return err if err is not None else (lambda line: print(line, file=sys.stderr))
+
+
+def _normalize_visibility(payload: dict[str, object]) -> str | None:
+    visibility = payload.get("visibility")
+    if isinstance(visibility, str) and visibility.strip():
+        return visibility.strip().upper()
+    public = payload.get("public")
+    if isinstance(public, bool):
+        return "PUBLIC" if public else "PRIVATE"
+    return None
+
+
+def _project_from_payload(
+    payload: dict[str, object], *, owner: str, fallback_number: int | None = None
+) -> ProjectInfo:
+    number = payload.get("number")
+    if not isinstance(number, int):
+        if fallback_number is None:
+            raise RuntimeError(
+                "Project payload did not include a numeric project number."
+            )
+        number = fallback_number
+
+    title = payload.get("title")
+    if not isinstance(title, str) or not title.strip():
+        title = f"Project #{number}"
+
+    description_value = payload.get("shortDescription")
+    if not isinstance(description_value, str) or not description_value.strip():
+        description_value = payload.get("description")
+    description = (
+        description_value.strip()
+        if isinstance(description_value, str) and description_value.strip()
+        else None
+    )
+
+    readme_value = payload.get("readme")
+    readme = (
+        readme_value.strip()
+        if isinstance(readme_value, str) and readme_value.strip()
+        else None
+    )
+
+    project_id = payload.get("id")
+    project_id_value = (
+        project_id.strip()
+        if isinstance(project_id, str) and project_id.strip()
+        else None
+    )
+
+    closed_value = payload.get("closed")
+    closed = closed_value if isinstance(closed_value, bool) else None
+
+    return ProjectInfo(
+        owner=owner,
+        number=number,
+        title=title.strip(),
+        id=project_id_value,
+        closed=closed,
+        visibility=_normalize_visibility(payload),
+        description=description,
+        readme=readme,
+    )
+
+
+def _parse_project_item(item: dict[str, object]) -> ProjectItemInfo:
+    item_id = item.get("id")
+    if not isinstance(item_id, str) or not item_id.strip():
+        raise RuntimeError("Project item payload did not include a stable item id.")
+
+    content = item.get("content")
+    content_dict = content if isinstance(content, dict) else {}
+
+    title: str | None = None
+    for candidate in (item.get("title"), content_dict.get("title")):
+        if isinstance(candidate, str) and candidate.strip():
+            title = candidate.strip()
+            break
+    if title is None:
+        title = f"Item {item_id.strip()}"
+
+    body_value = item.get("body")
+    if not isinstance(body_value, str) or not body_value.strip():
+        body_value = content_dict.get("body")
+    body = (
+        body_value.strip()
+        if isinstance(body_value, str) and body_value.strip()
+        else None
+    )
+
+    content_type_value = content_dict.get("type")
+    if not isinstance(content_type_value, str) or not content_type_value.strip():
+        content_type_value = item.get("type")
+    content_type = (
+        content_type_value.strip()
+        if isinstance(content_type_value, str) and content_type_value.strip()
+        else "DraftIssue"
+    )
+
+    content_url_value = content_dict.get("url")
+    if not isinstance(content_url_value, str) or not content_url_value.strip():
+        content_url_value = item.get("url")
+    content_url = (
+        content_url_value.strip()
+        if isinstance(content_url_value, str) and content_url_value.strip()
+        else None
+    )
+
+    issue_number_value = content_dict.get("number")
+    if not isinstance(issue_number_value, int):
+        issue_number_value = item.get("number")
+    issue_number = issue_number_value if isinstance(issue_number_value, int) else None
+
+    repository_value = content_dict.get("repository")
+    repository: str | None = None
+    if isinstance(repository_value, dict):
+        for key in ("nameWithOwner", "full_name"):
+            raw = repository_value.get(key)
+            if isinstance(raw, str) and raw.strip():
+                repository = raw.strip()
+                break
+    elif isinstance(repository_value, str) and repository_value.strip():
+        repository = repository_value.strip()
+
+    return ProjectItemInfo(
+        id=item_id.strip(),
+        title=title,
+        content_type=content_type,
+        content_url=content_url,
+        issue_number=issue_number,
+        repository=repository,
+        body=body,
+    )
+
+
+def _load_project_view(repo_dir: Path, owner: str, number: int) -> dict[str, object]:
+    cp = _run_gh(
+        repo_dir,
+        ["project", "view", str(number), "--owner", owner, "--format", "json"],
+    )
+    if cp.returncode != 0:
+        detail = (
+            cp.stderr.strip()
+            or cp.stdout.strip()
+            or f"Failed viewing project #{number}."
+        )
+        raise RuntimeError(_project_scope_hint(detail))
+    try:
+        payload = json.loads(cp.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Unexpected response from gh project view.") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Unexpected response from gh project view.")
+    return payload
+
+
+def _load_project_items(
+    repo_dir: Path, owner: str, number: int, limit: int
+) -> list[dict[str, object]]:
+    cp = _run_gh(
+        repo_dir,
+        [
+            "project",
+            "item-list",
+            str(number),
+            "--owner",
+            owner,
+            "--limit",
+            str(limit),
+            "--format",
+            "json",
+        ],
+    )
+    if cp.returncode != 0:
+        detail = (
+            cp.stderr.strip()
+            or cp.stdout.strip()
+            or f"Failed listing items for project #{number}."
+        )
+        raise RuntimeError(_project_scope_hint(detail))
+    try:
+        payload = json.loads(cp.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Unexpected response from gh project item-list.") from exc
+
+    items_obj: list[object]
+    if isinstance(payload, list):
+        items_obj = payload
+    elif isinstance(payload, dict):
+        raw_items = payload.get("items")
+        if isinstance(raw_items, list):
+            items_obj = raw_items
+        else:
+            raw_nodes = payload.get("nodes")
+            if not isinstance(raw_nodes, list):
+                raise RuntimeError("Unexpected response from gh project item-list.")
+            items_obj = raw_nodes
+        if not isinstance(items_obj, list):
+            raise RuntimeError("Unexpected response from gh project item-list.")
+    else:
+        raise RuntimeError("Unexpected response from gh project item-list.")
+
+    return [item for item in items_obj if isinstance(item, dict)]
+
+
+def _resolve_project_owner(owner: str | None, *, repo_dir: Path) -> str:
+    if owner and owner.strip():
+        return owner.strip()
+
+    for env_key in ("GH_REPO", "GITHUB_REPOSITORY"):
+        env_value = os.environ.get(env_key)
+        if env_value:
+            resolved = _parse_repo_owner(env_value)
+            if resolved:
+                return resolved
+
+    env_owner = (os.environ.get("GITHUB_ORG") or "").strip()
+    if env_owner:
+        return env_owner
+
+    return resolve_authenticated_login(repo_dir)
+
+
+def list_projects(*, repo_dir: Path, owner: str | None = None) -> ProjectListSummary:
+    project_owner = _resolve_project_owner(owner, repo_dir=repo_dir)
+    projects = tuple(
+        _project_from_payload(item, owner=project_owner)
+        for item in _list_projects(repo_dir, project_owner)
+    )
+    return ProjectListSummary(owner=project_owner, projects=projects)
+
+
+def _find_existing_project(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+) -> ProjectInfo:
+    if project_number is None and not project_title:
+        raise RuntimeError("Specify --project-number or --project-title.")
+    if project_number is not None and project_title:
+        raise RuntimeError("Use only one of --project-number or --project-title.")
+
+    project_owner = _resolve_project_owner(owner, repo_dir=repo_dir)
+
+    if project_number is not None:
+        payload = _load_project_view(repo_dir, project_owner, project_number)
+        return _project_from_payload(
+            payload, owner=project_owner, fallback_number=project_number
+        )
+
+    assert project_title is not None
+    wanted_title = project_title.strip()
+    if not wanted_title:
+        raise RuntimeError("--project-title must not be empty.")
+
+    for item in _list_projects(repo_dir, project_owner):
+        item_title = item.get("title")
+        item_number = item.get("number")
+        if (
+            isinstance(item_title, str)
+            and isinstance(item_number, int)
+            and item_title == wanted_title
+        ):
+            payload = _load_project_view(repo_dir, project_owner, item_number)
+            return _project_from_payload(
+                payload, owner=project_owner, fallback_number=item_number
+            )
+
+    raise RuntimeError(f"Project not found: {project_owner}/{wanted_title}")
+
+
+def view_project(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+) -> ProjectInfo:
+    return _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+
+
+def list_project_items(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+    limit: int,
+) -> ProjectItemsSummary:
+    project = _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+    raw_items = _load_project_items(repo_dir, project.owner, project.number, limit)
+    items = tuple(_parse_project_item(item) for item in raw_items)
+    return ProjectItemsSummary(project=project, items=items)
+
+
+def create_project(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_title: str,
+    description: str | None,
+    readme: str | None,
+    visibility: str | None,
+    dry_run: bool,
+    out: Callable[[str], None] = print,
+) -> ProjectMutationSummary:
+    project_owner = _resolve_project_owner(owner, repo_dir=repo_dir)
+    title = project_title.strip()
+    if not title:
+        raise RuntimeError("--project-title must not be empty.")
+
+    if dry_run:
+        out(f"[dry-run] create project: {title} (owner: {project_owner})")
+        if description:
+            out(f"[dry-run] set project description: {title}")
+        if readme:
+            out(f"[dry-run] set project readme: {title}")
+        if visibility:
+            out(f"[dry-run] set project visibility: {visibility.upper()}")
+        return ProjectMutationSummary(
+            action="create",
+            owner=project_owner,
+            project_number=None,
+            project_title=title,
+            failures=0,
+            changed=True,
+        )
+
+    cp = _run_gh(
+        repo_dir,
+        [
+            "project",
+            "create",
+            "--owner",
+            project_owner,
+            "--title",
+            title,
+            "--format",
+            "json",
+        ],
+    )
+    if cp.returncode != 0:
+        detail = (
+            cp.stderr.strip()
+            or cp.stdout.strip()
+            or f"Failed creating project: {title}"
+        )
+        raise RuntimeError(_project_scope_hint(detail))
+
+    payload = json.loads(cp.stdout or "{}")
+    if not isinstance(payload, dict):
+        raise RuntimeError("Unexpected response from gh project create.")
+
+    number = payload.get("number")
+    if not isinstance(number, int):
+        for item in _list_projects(repo_dir, project_owner):
+            item_title = item.get("title")
+            item_number = item.get("number")
+            if (
+                isinstance(item_title, str)
+                and isinstance(item_number, int)
+                and item_title == title
+            ):
+                number = item_number
+                break
+    if not isinstance(number, int):
+        raise RuntimeError(
+            f"Created project '{title}' but could not resolve its number."
+        )
+
+    out(f"Created project: {project_owner}/#{number} ({title})")
+
+    if description or readme or visibility:
+        edit_project(
+            repo_dir=repo_dir,
+            owner=project_owner,
+            project_number=number,
+            project_title=None,
+            title=None,
+            description=description,
+            readme=readme,
+            visibility=visibility,
+            dry_run=False,
+            out=out,
+        )
+
+    return ProjectMutationSummary(
+        action="create",
+        owner=project_owner,
+        project_number=number,
+        project_title=title,
+        failures=0,
+        changed=True,
+    )
+
+
+def edit_project(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+    title: str | None,
+    description: str | None,
+    readme: str | None,
+    visibility: str | None,
+    dry_run: bool,
+    out: Callable[[str], None] = print,
+) -> ProjectMutationSummary:
+    if not any(value for value in (title, description, readme, visibility)):
+        raise RuntimeError(
+            "Project edit requires at least one of --title, --description, --readme, or --visibility."
+        )
+
+    project = _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+
+    if dry_run:
+        if title:
+            out(f"[dry-run] rename project: {project.title} -> {title.strip()}")
+        if description is not None:
+            out(f"[dry-run] update project description: {project.title}")
+        if readme is not None:
+            out(f"[dry-run] update project readme: {project.title}")
+        if visibility is not None:
+            out(f"[dry-run] update project visibility: {visibility.upper()}")
+        return ProjectMutationSummary(
+            action="edit",
+            owner=project.owner,
+            project_number=project.number,
+            project_title=title.strip() if title else project.title,
+            failures=0,
+            changed=True,
+        )
+
+    args = ["project", "edit", str(project.number), "--owner", project.owner]
+    if title and title.strip():
+        args.extend(["--title", title.strip()])
+    if description is not None:
+        args.extend(["--description", description])
+    if readme is not None:
+        args.extend(["--readme", readme])
+    if visibility is not None:
+        args.extend(["--visibility", visibility.upper()])
+
+    cp = _run_gh(repo_dir, args)
+    if cp.returncode != 0:
+        detail = (
+            cp.stderr.strip()
+            or cp.stdout.strip()
+            or f"Failed editing project #{project.number}."
+        )
+        raise RuntimeError(_project_scope_hint(detail))
+
+    out(
+        f"Updated project: {project.owner}/#{project.number} ({title.strip() if title else project.title})"
+    )
+    return ProjectMutationSummary(
+        action="edit",
+        owner=project.owner,
+        project_number=project.number,
+        project_title=title.strip() if title else project.title,
+        failures=0,
+        changed=True,
+    )
+
+
+def _default_backup_dir(repo_dir: Path) -> Path:
+    return repo_dir / DEFAULT_PROJECT_BACKUP_REL_DIR
+
+
+def _backup_paths(
+    *, repo_dir: Path, backup_dir: str | None, prefix: str
+) -> tuple[Path, str]:
+    root = Path(backup_dir) if backup_dir else _default_backup_dir(repo_dir)
+    backup_root = root if root.is_absolute() else (repo_dir / root)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    backup_root.mkdir(parents=True, exist_ok=True)
+    return backup_root / f"{prefix}-{stamp}.json", stamp
+
+
+def _write_backup_file(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _build_undo_command(repo_dir: Path, backup_file: Path) -> str:
+    quoted_repo = shlex.quote(repo_dir.as_posix())
+    quoted_backup = shlex.quote(backup_file.as_posix())
+    return f"cd {quoted_repo} && poetry run repo-scaffold project undo --backup-file {quoted_backup}"
+
+
+def _project_backup_payload(
+    *,
+    action: str,
+    project: ProjectInfo,
+    project_payload: dict[str, object],
+    item_payloads: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "version": 1,
+        "kind": action,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "project_owner": project.owner,
+        "project_number": project.number,
+        "project_title": project.title,
+        "project": project_payload,
+        "items": item_payloads,
+        "notes": {
+            "restore": "repo-scaffold restores project structure and item membership, but does not recreate custom project fields or field values.",
+        },
+    }
+
+
+def _project_item_backup_payload(
+    *,
+    project: ProjectInfo,
+    project_payload: dict[str, object],
+    item_payload: dict[str, object],
+) -> dict[str, object]:
+    item = _parse_project_item(item_payload)
+    return {
+        "version": 1,
+        "kind": "project_item_delete",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "project_owner": project.owner,
+        "project_number": project.number,
+        "project_title": project.title,
+        "project": project_payload,
+        "item": item_payload,
+        "item_summary": {
+            "id": item.id,
+            "title": item.title,
+            "content_type": item.content_type,
+            "content_url": item.content_url,
+            "issue_number": item.issue_number,
+            "repository": item.repository,
+        },
+    }
+
+
+def _require_danger(action: str, *, danger: bool) -> None:
+    if not danger:
+        raise RuntimeError(f"Refusing dangerous operation '{action}' without --danger.")
+
+
+def _confirm_dangerous_action(
+    *,
+    prompt_message: str,
+    assume_yes: bool,
+    prompt: Callable[[str], str],
+    is_tty: bool,
+    out: Callable[[str], None],
+) -> bool:
+    if assume_yes:
+        return True
+    if not is_tty:
+        out(
+            "Non-interactive shell detected and --yes not set; skipping dangerous operation."
+        )
+        return False
+    reply = prompt(f"{prompt_message} [y/N] ").strip().lower()
+    return reply in {"y", "yes"}
+
+
+def delete_project(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+    danger: bool,
+    assume_yes: bool,
+    dry_run: bool,
+    backup_dir: str | None,
+    prompt: Callable[[str], str],
+    is_tty: bool,
+    out: Callable[[str], None] = print,
+    err: Callable[[str], None] | None = None,
+) -> ProjectMutationSummary:
+    _require_danger("project delete", danger=danger)
+    emit_err = _emit_err_factory(err)
+    project = _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+
+    if dry_run:
+        out(
+            f"[dry-run] backup project before delete: {project.owner}/#{project.number} ({project.title})"
+        )
+        out(
+            f"[dry-run] delete project: {project.owner}/#{project.number} ({project.title})"
+        )
+        return ProjectMutationSummary(
+            action="delete",
+            owner=project.owner,
+            project_number=project.number,
+            project_title=project.title,
+            failures=0,
+            changed=True,
+        )
+
+    if not _confirm_dangerous_action(
+        prompt_message=f"Delete project {project.owner}/#{project.number} ({project.title})?",
+        assume_yes=assume_yes,
+        prompt=prompt,
+        is_tty=is_tty,
+        out=out,
+    ):
+        out("Aborted.")
+        return ProjectMutationSummary(
+            action="delete",
+            owner=project.owner,
+            project_number=project.number,
+            project_title=project.title,
+            failures=0,
+            changed=False,
+        )
+
+    project_payload = _load_project_view(repo_dir, project.owner, project.number)
+    item_payloads = _load_project_items(repo_dir, project.owner, project.number, 500)
+    backup_file, _ = _backup_paths(
+        repo_dir=repo_dir,
+        backup_dir=backup_dir,
+        prefix=f"project-delete-{project.owner}-{project.number}",
+    )
+    _write_backup_file(
+        backup_file,
+        _project_backup_payload(
+            action="project_delete",
+            project=project,
+            project_payload=project_payload,
+            item_payloads=item_payloads,
+        ),
+    )
+    undo_command = _build_undo_command(repo_dir, backup_file)
+
+    cp = _run_gh(
+        repo_dir,
+        ["project", "delete", str(project.number), "--owner", project.owner],
+    )
+    if cp.returncode != 0:
+        detail = (
+            cp.stderr.strip()
+            or cp.stdout.strip()
+            or f"Failed deleting project #{project.number}."
+        )
+        emit_err(_project_scope_hint(detail))
+        return ProjectMutationSummary(
+            action="delete",
+            owner=project.owner,
+            project_number=project.number,
+            project_title=project.title,
+            failures=1,
+            changed=False,
+            backup_file=backup_file,
+            undo_command=undo_command,
+        )
+
+    out(f"Deleted project: {project.owner}/#{project.number} ({project.title})")
+    out(f"Backup written: {backup_file}")
+    out(f"Undo with: {undo_command}")
+    return ProjectMutationSummary(
+        action="delete",
+        owner=project.owner,
+        project_number=project.number,
+        project_title=project.title,
+        failures=0,
+        changed=True,
+        backup_file=backup_file,
+        undo_command=undo_command,
+    )
+
+
+def _find_project_item(
+    *,
+    repo_dir: Path,
+    project: ProjectInfo,
+    item_id: str | None,
+    issue_number: int | None,
+) -> tuple[dict[str, object], ProjectItemInfo]:
+    if not item_id and issue_number is None:
+        raise RuntimeError("Specify --item-id or --issue-number.")
+    if item_id and issue_number is not None:
+        raise RuntimeError("Use only one of --item-id or --issue-number.")
+
+    for raw_item in _load_project_items(repo_dir, project.owner, project.number, 500):
+        item = _parse_project_item(raw_item)
+        if item_id and item.id == item_id.strip():
+            return raw_item, item
+        if issue_number is not None and item.issue_number == issue_number:
+            return raw_item, item
+
+    selector = item_id.strip() if item_id else f"issue #{issue_number}"
+    raise RuntimeError(
+        f"Project item not found in {project.owner}/#{project.number}: {selector}"
+    )
+
+
+def delete_project_item(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+    item_id: str | None,
+    issue_number: int | None,
+    danger: bool,
+    assume_yes: bool,
+    dry_run: bool,
+    backup_dir: str | None,
+    prompt: Callable[[str], str],
+    is_tty: bool,
+    out: Callable[[str], None] = print,
+    err: Callable[[str], None] | None = None,
+) -> ProjectMutationSummary:
+    _require_danger("project item delete", danger=danger)
+    emit_err = _emit_err_factory(err)
+    project = _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+    raw_item, item = _find_project_item(
+        repo_dir=repo_dir,
+        project=project,
+        item_id=item_id,
+        issue_number=issue_number,
+    )
+
+    if dry_run:
+        out(f"[dry-run] backup project item before delete: {item.title} ({item.id})")
+        out(f"[dry-run] delete project item: {item.title} ({item.id})")
+        return ProjectMutationSummary(
+            action="item-delete",
+            owner=project.owner,
+            project_number=project.number,
+            project_title=project.title,
+            failures=0,
+            changed=True,
+        )
+
+    if not _confirm_dangerous_action(
+        prompt_message=(
+            f"Delete project item '{item.title}' ({item.id}) from {project.owner}/#{project.number}?"
+        ),
+        assume_yes=assume_yes,
+        prompt=prompt,
+        is_tty=is_tty,
+        out=out,
+    ):
+        out("Aborted.")
+        return ProjectMutationSummary(
+            action="item-delete",
+            owner=project.owner,
+            project_number=project.number,
+            project_title=project.title,
+            failures=0,
+            changed=False,
+        )
+
+    project_payload = _load_project_view(repo_dir, project.owner, project.number)
+    backup_file, _ = _backup_paths(
+        repo_dir=repo_dir,
+        backup_dir=backup_dir,
+        prefix=f"project-item-delete-{project.owner}-{project.number}",
+    )
+    _write_backup_file(
+        backup_file,
+        _project_item_backup_payload(
+            project=project,
+            project_payload=project_payload,
+            item_payload=raw_item,
+        ),
+    )
+    undo_command = _build_undo_command(repo_dir, backup_file)
+
+    cp = _run_gh(
+        repo_dir,
+        [
+            "project",
+            "item-delete",
+            str(project.number),
+            "--owner",
+            project.owner,
+            "--id",
+            item.id,
+        ],
+    )
+    if cp.returncode != 0:
+        detail = (
+            cp.stderr.strip()
+            or cp.stdout.strip()
+            or f"Failed deleting project item {item.id}."
+        )
+        emit_err(_project_scope_hint(detail))
+        return ProjectMutationSummary(
+            action="item-delete",
+            owner=project.owner,
+            project_number=project.number,
+            project_title=project.title,
+            failures=1,
+            changed=False,
+            backup_file=backup_file,
+            undo_command=undo_command,
+        )
+
+    out(f"Deleted project item: {item.title} ({item.id})")
+    out(f"Backup written: {backup_file}")
+    out(f"Undo with: {undo_command}")
+    return ProjectMutationSummary(
+        action="item-delete",
+        owner=project.owner,
+        project_number=project.number,
+        project_title=project.title,
+        failures=0,
+        changed=True,
+        backup_file=backup_file,
+        undo_command=undo_command,
+    )
+
+
+def _restore_item_to_project(
+    *,
+    repo_dir: Path,
+    project_owner: str,
+    project_number: int,
+    raw_item: dict[str, object],
+    out: Callable[[str], None],
+) -> str | None:
+    item = _parse_project_item(raw_item)
+    if item.content_url:
+        cp = _run_gh(
+            repo_dir,
+            [
+                "project",
+                "item-add",
+                str(project_number),
+                "--owner",
+                project_owner,
+                "--url",
+                item.content_url,
+            ],
+        )
+        if cp.returncode != 0:
+            detail = (
+                cp.stderr.strip()
+                or cp.stdout.strip()
+                or f"Failed restoring item: {item.title}"
+            )
+            raise RuntimeError(_project_scope_hint(detail))
+        out(f"Restored project item: {item.title}")
+        return item.id
+
+    args = [
+        "project",
+        "item-create",
+        str(project_number),
+        "--owner",
+        project_owner,
+        "--title",
+        item.title,
+    ]
+    if item.body:
+        args.extend(["--body", item.body])
+    cp = _run_gh(repo_dir, args)
+    if cp.returncode != 0:
+        detail = (
+            cp.stderr.strip()
+            or cp.stdout.strip()
+            or f"Failed restoring draft item: {item.title}"
+        )
+        raise RuntimeError(_project_scope_hint(detail))
+    out(f"Restored draft project item: {item.title}")
+
+    try:
+        payload = json.loads(cp.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    if isinstance(payload, dict):
+        restored_id = payload.get("id")
+        if isinstance(restored_id, str) and restored_id.strip():
+            return restored_id.strip()
+    return None
+
+
+def _next_restore_title(repo_dir: Path, owner: str, title: str) -> str:
+    existing_titles = {
+        item.title for item in list_projects(repo_dir=repo_dir, owner=owner).projects
+    }
+    if title not in existing_titles:
+        return title
+    restored = f"{title} (Restored)"
+    if restored not in existing_titles:
+        return restored
+    counter = 2
+    while True:
+        candidate = f"{title} (Restored {counter})"
+        if candidate not in existing_titles:
+            return candidate
+        counter += 1
+
+
+def undo_project_backup(
+    *,
+    repo_dir: Path,
+    backup_file: Path,
+    dry_run: bool,
+    out: Callable[[str], None] = print,
+) -> ProjectMutationSummary:
+    try:
+        payload = json.loads(backup_file.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Backup file not found: {backup_file}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Backup file is not valid JSON: {backup_file}") from exc
+
+    if not isinstance(payload, dict):
+        raise RuntimeError("Backup file is not a valid project backup payload.")
+
+    kind = payload.get("kind")
+    if not isinstance(kind, str) or not kind.strip():
+        raise RuntimeError("Backup file is missing backup kind metadata.")
+
+    owner_value = payload.get("project_owner")
+    if not isinstance(owner_value, str) or not owner_value.strip():
+        raise RuntimeError("Backup file is missing project owner metadata.")
+    owner = owner_value.strip()
+
+    if kind == "project_delete":
+        project_payload = payload.get("project")
+        raw_items = payload.get("items")
+        if not isinstance(project_payload, dict) or not isinstance(raw_items, list):
+            raise RuntimeError("Backup file is missing project snapshot data.")
+        title = project_payload.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise RuntimeError("Backup file is missing project title.")
+        restore_title = _next_restore_title(repo_dir, owner, title.strip())
+        description = project_payload.get("shortDescription")
+        if not isinstance(description, str):
+            description = project_payload.get("description")
+        readme = project_payload.get("readme")
+        visibility = _normalize_visibility(project_payload)
+
+        if dry_run:
+            out(
+                f"[dry-run] restore project from backup: {restore_title} (owner: {owner})"
+            )
+            for raw_item in raw_items:
+                if isinstance(raw_item, dict):
+                    item = _parse_project_item(raw_item)
+                    out(f"[dry-run] restore project item: {item.title}")
+            return ProjectMutationSummary(
+                action="undo",
+                owner=owner,
+                project_number=None,
+                project_title=restore_title,
+                failures=0,
+                changed=True,
+            )
+
+        summary = create_project(
+            repo_dir=repo_dir,
+            owner=owner,
+            project_title=restore_title,
+            description=description if isinstance(description, str) else None,
+            readme=readme if isinstance(readme, str) else None,
+            visibility=visibility,
+            dry_run=False,
+            out=out,
+        )
+        if summary.project_number is None:
+            raise RuntimeError(
+                "Restored project creation did not resolve a project number."
+            )
+        restored_number = summary.project_number
+        for raw_item in raw_items:
+            if isinstance(raw_item, dict):
+                _restore_item_to_project(
+                    repo_dir=repo_dir,
+                    project_owner=owner,
+                    project_number=restored_number,
+                    raw_item=raw_item,
+                    out=out,
+                )
+        return ProjectMutationSummary(
+            action="undo",
+            owner=owner,
+            project_number=restored_number,
+            project_title=restore_title,
+            failures=0,
+            changed=True,
+            backup_file=backup_file,
+            restored_project_number=restored_number,
+        )
+
+    if kind == "project_item_delete":
+        project_number_value = payload.get("project_number")
+        raw_item = payload.get("item")
+        if not isinstance(project_number_value, int) or not isinstance(raw_item, dict):
+            raise RuntimeError("Backup file is missing project item snapshot data.")
+        item = _parse_project_item(raw_item)
+        if dry_run:
+            out(
+                f"[dry-run] restore project item: {item.title} -> {owner}/#{project_number_value}"
+            )
+            return ProjectMutationSummary(
+                action="undo",
+                owner=owner,
+                project_number=project_number_value,
+                project_title=None,
+                failures=0,
+                changed=True,
+            )
+        restored_item_id = _restore_item_to_project(
+            repo_dir=repo_dir,
+            project_owner=owner,
+            project_number=project_number_value,
+            raw_item=raw_item,
+            out=out,
+        )
+        return ProjectMutationSummary(
+            action="undo",
+            owner=owner,
+            project_number=project_number_value,
+            project_title=None,
+            failures=0,
+            changed=True,
+            backup_file=backup_file,
+            restored_item_id=restored_item_id,
+        )
+
+    raise RuntimeError(f"Unsupported backup kind: {kind}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,13 @@ from repo_scaffold.backlog_ops import BacklogApplySummary
 from repo_scaffold.create_ops import CreateSummary, SettingsCheckSummary
 from repo_scaffold.cli import main
 from repo_scaffold.delete_ops import DeleteSummary
+from repo_scaffold.project_ops import (
+    ProjectInfo,
+    ProjectItemInfo,
+    ProjectItemsSummary,
+    ProjectListSummary,
+    ProjectMutationSummary,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -46,6 +53,7 @@ def test_root_help_shows_all_modes(capsys: pytest.CaptureFixture[str]) -> None:
     assert "check" in stdout
     assert "delete" in stdout
     assert "import" in stdout
+    assert "project" in stdout
 
 
 def test_init_defaults_name_and_languages(
@@ -1478,3 +1486,125 @@ def test_delete_subcommand_delete_local_only(
     assert called["owner"] is None
     assert called["include_local"] is True
     assert called["delete_local_only"] is True
+
+
+def test_project_list_subcommand_prints_projects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_projects",
+        lambda **_kwargs: ProjectListSummary(
+            owner="acme",
+            projects=(
+                ProjectInfo(owner="acme", number=1, title="Roadmap", closed=False),
+                ProjectInfo(owner="acme", number=2, title="Archive", closed=True),
+            ),
+        ),
+    )
+
+    rc = main(["project", "list", "--path", str(repo_dir), "--project-owner", "acme"])
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "acme/#1 Roadmap" in stdout
+    assert "acme/#2 Archive [closed]" in stdout
+    assert "projects: 2" in stdout
+
+
+def test_project_items_subcommand_prints_project_contents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    def _fake_items(**_kwargs) -> ProjectItemsSummary:
+        return ProjectItemsSummary(
+            project=ProjectInfo(owner="acme", number=4, title="Roadmap"),
+            items=(
+                ProjectItemInfo(
+                    id="PVTI_1",
+                    title="Ticket A",
+                    content_type="Issue",
+                    content_url="https://github.com/acme/repo/issues/11",
+                    issue_number=11,
+                    repository="acme/repo",
+                ),
+            ),
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.list_project_items", _fake_items)
+
+    rc = main(
+        [
+            "project",
+            "items",
+            "--path",
+            str(repo_dir),
+            "--project-owner",
+            "acme",
+            "--project-number",
+            "4",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "Project: acme/#4 (Roadmap)" in stdout
+    assert "[Issue] item=PVTI_1 #11 Ticket A" in stdout
+    assert "repo: acme/repo" in stdout
+    assert "items: 1" in stdout
+
+
+def test_project_delete_subcommand_delegates_to_project_ops(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    called: dict[str, object] = {}
+
+    def _fake_delete_project(**kwargs) -> ProjectMutationSummary:
+        called.update(kwargs)
+        return ProjectMutationSummary(
+            action="delete",
+            owner="acme",
+            project_number=4,
+            project_title="Roadmap",
+            failures=0,
+            changed=True,
+            backup_file=repo_dir / "artifacts" / "project-backups" / "backup.json",
+            undo_command="undo-cmd",
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.delete_project", _fake_delete_project)
+
+    rc = main(
+        [
+            "project",
+            "delete",
+            "--path",
+            str(repo_dir),
+            "--project-owner",
+            "acme",
+            "--project-number",
+            "4",
+            "--danger",
+            "--yes",
+        ]
+    )
+
+    assert rc == 0
+    assert called["danger"] is True
+    assert called["assume_yes"] is True
+    stdout = capsys.readouterr().out
+    assert "backup file:" in stdout
+    assert "undo: undo-cmd" in stdout

--- a/tests/test_project_ops.py
+++ b/tests/test_project_ops.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import repo_scaffold.project_ops as project_ops
+
+
+def _cp_ok(stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=0, stdout=stdout, stderr=""
+    )
+
+
+def test_list_projects_resolves_and_parses_projects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        project_ops,
+        "_list_projects",
+        lambda _repo_dir, _owner: [
+            {"number": 1, "title": "Roadmap", "closed": False, "public": True},
+            {"number": 2, "title": "Archive", "closed": True, "public": False},
+        ],
+    )
+
+    summary = project_ops.list_projects(repo_dir=repo_dir, owner="acme")
+
+    assert summary.owner == "acme"
+    assert [project.title for project in summary.projects] == ["Roadmap", "Archive"]
+    assert summary.projects[0].visibility == "PUBLIC"
+    assert summary.projects[1].closed is True
+
+
+def test_list_project_items_parses_issue_and_draft_items(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        project_ops,
+        "_find_existing_project",
+        lambda **_kwargs: project_ops.ProjectInfo(
+            owner="acme", number=4, title="Roadmap"
+        ),
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "_load_project_items",
+        lambda *_args, **_kwargs: [
+            {
+                "id": "PVTI_issue",
+                "content": {
+                    "type": "Issue",
+                    "title": "Issue Ticket",
+                    "url": "https://github.com/acme/repo/issues/11",
+                    "number": 11,
+                    "repository": {"nameWithOwner": "acme/repo"},
+                },
+            },
+            {
+                "id": "PVTI_draft",
+                "title": "Draft Ticket",
+                "body": "draft body",
+                "type": "DraftIssue",
+            },
+        ],
+    )
+
+    summary = project_ops.list_project_items(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=4,
+        project_title=None,
+        limit=50,
+    )
+
+    assert summary.project.number == 4
+    assert summary.items[0].issue_number == 11
+    assert summary.items[0].repository == "acme/repo"
+    assert summary.items[1].content_type == "DraftIssue"
+    assert summary.items[1].body == "draft body"
+
+
+def test_create_project_delegates_optional_metadata_edit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    calls: list[list[str]] = []
+    edits: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        project_ops,
+        "_run_gh",
+        lambda _repo_dir, args: calls.append(args)
+        or _cp_ok('{"number": 9, "title": "Roadmap"}'),
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "edit_project",
+        lambda **kwargs: edits.append(kwargs)
+        or project_ops.ProjectMutationSummary(
+            action="edit",
+            owner="acme",
+            project_number=9,
+            project_title="Roadmap",
+            failures=0,
+            changed=True,
+        ),
+    )
+
+    summary = project_ops.create_project(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_title="Roadmap",
+        description="desc",
+        readme="body",
+        visibility="private",
+        dry_run=False,
+        out=lambda _line: None,
+    )
+
+    assert calls[0][:4] == ["project", "create", "--owner", "acme"]
+    assert summary.project_number == 9
+    assert edits and edits[0]["project_number"] == 9
+
+
+def test_delete_project_requires_danger(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="without --danger"):
+        project_ops.delete_project(
+            repo_dir=repo_dir,
+            owner="acme",
+            project_number=4,
+            project_title=None,
+            danger=False,
+            assume_yes=True,
+            dry_run=False,
+            backup_dir=None,
+            prompt=lambda _msg: "yes",
+            is_tty=True,
+            out=lambda _line: None,
+        )
+
+
+def test_delete_project_writes_backup_and_undo_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        project_ops,
+        "_find_existing_project",
+        lambda **_kwargs: project_ops.ProjectInfo(
+            owner="acme", number=4, title="Roadmap"
+        ),
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "_load_project_view",
+        lambda *_args, **_kwargs: {"number": 4, "title": "Roadmap", "id": "PVT_1"},
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "_load_project_items",
+        lambda *_args, **_kwargs: [
+            {
+                "id": "PVTI_1",
+                "content": {
+                    "type": "Issue",
+                    "title": "Ticket A",
+                    "url": "https://github.com/acme/repo/issues/11",
+                    "number": 11,
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(project_ops, "_run_gh", lambda *_args, **_kwargs: _cp_ok())
+
+    summary = project_ops.delete_project(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=4,
+        project_title=None,
+        danger=True,
+        assume_yes=True,
+        dry_run=False,
+        backup_dir=None,
+        prompt=lambda _msg: "yes",
+        is_tty=True,
+        out=lambda _line: None,
+    )
+
+    assert summary.failures == 0
+    assert summary.backup_file is not None
+    payload = json.loads(summary.backup_file.read_text(encoding="utf-8"))
+    assert payload["kind"] == "project_delete"
+    assert "project undo --backup-file" in (summary.undo_command or "")
+
+
+def test_delete_project_item_by_issue_number_writes_backup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        project_ops,
+        "_find_existing_project",
+        lambda **_kwargs: project_ops.ProjectInfo(
+            owner="acme", number=4, title="Roadmap"
+        ),
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "_load_project_view",
+        lambda *_args, **_kwargs: {"number": 4, "title": "Roadmap", "id": "PVT_1"},
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "_load_project_items",
+        lambda *_args, **_kwargs: [
+            {
+                "id": "PVTI_1",
+                "content": {
+                    "type": "Issue",
+                    "title": "Ticket A",
+                    "url": "https://github.com/acme/repo/issues/11",
+                    "number": 11,
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(project_ops, "_run_gh", lambda *_args, **_kwargs: _cp_ok())
+
+    summary = project_ops.delete_project_item(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=4,
+        project_title=None,
+        item_id=None,
+        issue_number=11,
+        danger=True,
+        assume_yes=True,
+        dry_run=False,
+        backup_dir=None,
+        prompt=lambda _msg: "yes",
+        is_tty=True,
+        out=lambda _line: None,
+    )
+
+    assert summary.failures == 0
+    assert summary.backup_file is not None
+    payload = json.loads(summary.backup_file.read_text(encoding="utf-8"))
+    assert payload["kind"] == "project_item_delete"
+    assert payload["item_summary"]["issue_number"] == 11
+
+
+def test_undo_project_delete_restores_project_and_items(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+    backup_file = repo_dir / "backup.json"
+    backup_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "kind": "project_delete",
+                "project_owner": "acme",
+                "project_number": 4,
+                "project_title": "Roadmap",
+                "project": {
+                    "number": 4,
+                    "title": "Roadmap",
+                    "shortDescription": "desc",
+                    "readme": "hello",
+                    "public": False,
+                },
+                "items": [
+                    {
+                        "id": "PVTI_issue",
+                        "content": {
+                            "type": "Issue",
+                            "title": "Issue Ticket",
+                            "url": "https://github.com/acme/repo/issues/11",
+                            "number": 11,
+                        },
+                    },
+                    {
+                        "id": "PVTI_draft",
+                        "title": "Draft Ticket",
+                        "body": "draft body",
+                        "type": "DraftIssue",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        project_ops,
+        "list_projects",
+        lambda **_kwargs: project_ops.ProjectListSummary(owner="acme", projects=()),
+    )
+
+    def _fake_run_gh(
+        _repo_dir: Path, args: list[str]
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args[:2] == ["project", "create"]:
+            return _cp_ok('{"number": 7, "title": "Roadmap"}')
+        if args[:2] == ["project", "view"]:
+            return _cp_ok('{"number": 7, "title": "Roadmap"}')
+        if args[:2] == ["project", "edit"]:
+            return _cp_ok()
+        if args[:2] == ["project", "item-add"]:
+            return _cp_ok()
+        if args[:2] == ["project", "item-create"]:
+            return _cp_ok('{"id":"PVTI_new"}')
+        raise AssertionError(f"Unexpected gh invocation: {args}")
+
+    monkeypatch.setattr(project_ops, "_run_gh", _fake_run_gh)
+
+    summary = project_ops.undo_project_backup(
+        repo_dir=repo_dir,
+        backup_file=backup_file,
+        dry_run=False,
+        out=lambda _line: None,
+    )
+
+    assert summary.failures == 0
+    assert summary.restored_project_number == 7
+    assert any(args[:2] == ["project", "item-add"] for args in calls)
+    assert any(args[:2] == ["project", "item-create"] for args in calls)
+
+
+def test_undo_project_item_delete_restores_item(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+    backup_file = repo_dir / "item-backup.json"
+    backup_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "kind": "project_item_delete",
+                "project_owner": "acme",
+                "project_number": 4,
+                "project_title": "Roadmap",
+                "item": {
+                    "id": "PVTI_issue",
+                    "content": {
+                        "type": "Issue",
+                        "title": "Issue Ticket",
+                        "url": "https://github.com/acme/repo/issues/11",
+                        "number": 11,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        project_ops,
+        "_run_gh",
+        lambda _repo_dir, args: calls.append(args) or _cp_ok(),
+    )
+
+    summary = project_ops.undo_project_backup(
+        repo_dir=repo_dir,
+        backup_file=backup_file,
+        dry_run=False,
+        out=lambda _line: None,
+    )
+
+    assert summary.failures == 0
+    assert any(args[:2] == ["project", "item-add"] for args in calls)

--- a/tests/test_project_ops.py
+++ b/tests/test_project_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import json
 import subprocess
 from pathlib import Path
@@ -36,6 +37,88 @@ def test_list_projects_resolves_and_parses_projects(
     assert [project.title for project in summary.projects] == ["Roadmap", "Archive"]
     assert summary.projects[0].visibility == "PUBLIC"
     assert summary.projects[1].closed is True
+
+
+def test_find_existing_project_by_title_includes_closed_projects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        project_ops,
+        "_list_projects",
+        lambda _repo_dir, _owner, *, include_closed=False: (
+            calls.append(include_closed)
+            or [
+                {
+                    "number": 7,
+                    "title": "Archived Roadmap",
+                    "closed": True,
+                    "public": False,
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "_load_project_view",
+        lambda *_args, **_kwargs: {
+            "number": 7,
+            "title": "Archived Roadmap",
+            "closed": True,
+            "public": False,
+        },
+    )
+
+    project = project_ops._find_existing_project(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=None,
+        project_title="Archived Roadmap",
+    )
+
+    assert calls == [True]
+    assert project.number == 7
+    assert project.closed is True
+
+
+def test_backup_paths_are_unique_within_same_second(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    class _FixedDatetime:
+        @staticmethod
+        def now(_tz):
+            return datetime.datetime(2026, 4, 29, 12, 0, 0, 123456)
+
+    class _FakeUuid:
+        def __init__(self, hex_value: str) -> None:
+            self.hex = hex_value
+
+    uuids = iter([_FakeUuid("aaaaaaaa12345678"), _FakeUuid("bbbbbbbb12345678")])
+    monkeypatch.setattr(project_ops, "datetime", _FixedDatetime)
+    monkeypatch.setattr(project_ops.uuid, "uuid4", lambda: next(uuids))
+
+    first, first_stamp = project_ops._backup_paths(
+        repo_dir=repo_dir,
+        backup_dir=None,
+        prefix="project-delete",
+    )
+    second, second_stamp = project_ops._backup_paths(
+        repo_dir=repo_dir,
+        backup_dir=None,
+        prefix="project-delete",
+    )
+
+    assert first != second
+    assert first_stamp == second_stamp
+    assert first.name.endswith("-aaaaaaaa.json")
+    assert second.name.endswith("-bbbbbbbb.json")
+    assert first.parent.is_dir()
 
 
 def test_list_project_items_parses_issue_and_draft_items(


### PR DESCRIPTION
## 🧾 Title
Add guarded GitHub Project management with backup and undo

## 🧠 Description
This PR adds a first-class `project` mode to `repo-scaffold` so GitHub Projects can be managed directly without mixing destructive operations into backlog apply flows.

The new surface supports read/write project operations, but treats destructive actions as explicitly dangerous:
- deleting a project now requires `--danger`
- deleting a project item now requires `--danger`
- dangerous operations prompt for confirmation unless `--yes` is passed
- dangerous operations automatically write a backup snapshot before mutating state
- each destructive operation prints an exact `project undo --backup-file ...` command for recovery

## 🧩 Changes Included
- [x] Added/updated documentation
- [x] Implemented new feature or enhancement
- [x] Improved error handling or logging
- [x] Added destructive-op guardrails
- [x] Added backup / undo flow
- [x] Added test coverage

## 🎯 Purpose
Give `repo-scaffold` a safe project-management surface with explicit risk acknowledgment.

This branch adds:
- project listing and inspection
- project creation and metadata edits
- guarded project deletion
- guarded project-item deletion
- automatic backup snapshots for dangerous operations
- a best-effort undo path for restoring deleted projects/items

## 🔗 Related Issues / Epics
- **Epic:** N/A
- **Issue:** N/A
- **Closes:** N/A

## 🧪 Testing
1. `poetry run pytest -q tests/test_project_ops.py tests/test_cli.py tests/test_backlog_ops.py`
2. `poetry run tox -e type`
3. `poetry run pre-commit run --all-files`
4. Manual dry-run checks:
   - `poetry run repo-scaffold project list --project-owner blairg23`
   - `poetry run repo-scaffold project items --project-owner blairg23 --project-title "mobile-backup Roadmap"`
   - `poetry run repo-scaffold project delete --project-owner blairg23 --project-title "mobile-backup Roadmap" --danger --dry-run`
   - `poetry run repo-scaffold project item-delete --project-owner blairg23 --project-title "mobile-backup Roadmap" --issue-number 42 --danger --dry-run`

## 🧰 Developer Notes
New CLI surface:
- `repo-scaffold project list`
- `repo-scaffold project view`
- `repo-scaffold project items`
- `repo-scaffold project create`
- `repo-scaffold project edit`
- `repo-scaffold project delete`
- `repo-scaffold project item-delete`
- `repo-scaffold project undo`

Safety model:
- destructive project operations require `--danger`
- destructive project operations prompt `y/N` unless `--yes` is passed
- backup snapshots default to `<repo-path>/artifacts/project-backups`
- summary output includes the generated undo command after a destructive write

Current undo scope:
- restores deleted projects by recreating the project and re-adding stored items
- restores deleted project items by re-adding the stored issue/draft item
- does not recreate custom project fields or field values
