### PR TITLE
Persist repo-local project context and scaffold local GitHub Projects auth setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ GITHUB_REPO=YOUR_REPO
 # Optional markdown backlog source override for import/apply backlog:
 # GITHUB_TICKETS_DIR=artifacts/tickets
 
+# Classic PAT for GitHub Projects v2 commands run from WSL / Claude Code.
+# Keep the export prefix so child processes inherit it.
+export GH_PROJECT_TOKEN=<classic-PAT>
+
 # Optional local Codecov upload token (read automatically by `tox -e codecov-upload`):
 # CODECOV_TOKEN=your_codecov_token
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,12 +20,16 @@ htmlcov/
 .env
 .env.*
 !.env.example
+.claude/settings.local.json
 
 # Local-only backlog data (do not commit)
 local/backlog/issues.json
 
 # Local generated artifacts (do not commit)
 artifacts/
+
+# Repo-scaffold local metadata (do not commit)
+.repo-scaffold/
 
 # Editor / OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Workflow model:
 - run `project ...` from this toolkit repo when you need to inspect or manage GitHub Projects directly
 - run `delete` from this toolkit repo to clean up test repositories
 
+Repo-local GitHub convention:
+
+- each repo's canonical roadmap/project metadata lives in `.repo-scaffold/project.json`
+- `apply backlog --with-project` writes or refreshes that file automatically
+- older repos can create or refresh it with `project sync-metadata`
+- generated repos include `AGENTS.md` so local agents know to use `GH_REPO` and `.repo-scaffold/project.json` as their GitHub context
+- generated repos include `.claude/settings.local.json` and `scripts/first_time_setup.sh` for the local GitHub Projects v2 token workflow
+
 ## Install
 
 ```bash
@@ -47,6 +55,7 @@ Defaults:
 - output defaults to `./out/<name>`
 - scaffolds include `.pre-commit-config.yaml`
 - Python scaffolds include `tox.ini`; generated CI runs `tox` (`lint`, `type`, `coverage`)
+- scaffolds include `.env.example`, `.claude/settings.local.json`, and `scripts/first_time_setup.sh` for local GitHub Projects v2 setup
 
 Fast path (no required flags):
 
@@ -161,6 +170,7 @@ Subcommands:
 - `list [--project-owner OWNER]`: list projects for an owner
 - `view (--project-number N | --project-title T) [--project-owner OWNER]`: show project metadata
 - `items (--project-number N | --project-title T) [--project-owner OWNER] [--limit N]`: list the contents of a project
+- `sync-metadata (--project-number N | --project-title T) [--project-owner OWNER]`: write `.repo-scaffold/project.json` for the resolved project
 - `create --project-title T [--project-owner OWNER] [--description TEXT] [--readme MD] [--visibility PUBLIC|PRIVATE] [--dry-run]`: create a project
 - `edit (--project-number N | --project-title T) [--project-owner OWNER] [--title T] [--description TEXT] [--readme MD] [--visibility PUBLIC|PRIVATE] [--dry-run]`: update project metadata
 - `delete (--project-number N | --project-title T) [--project-owner OWNER] --danger [--yes] [--dry-run] [--backup-dir PATH]`: delete a project with automatic backup + undo snapshot
@@ -176,15 +186,22 @@ Behavior:
 - destructive commands (`delete`, `item-delete`) require `--danger`
 - destructive commands still prompt `y/N` unless `--yes` is passed
 - destructive commands write a backup snapshot to `<path>/artifacts/project-backups` by default
+- `sync-metadata`, `create`, `edit`, and project restores keep `<path>/.repo-scaffold/project.json` aligned with the resolved project
 - the summary prints an exact `project undo --backup-file ...` command after a destructive write
 - undo restores project membership and draft items, but does not recreate custom project fields or field values
+
+Repo-local agent workflow:
+
+- repo-local agents should treat `GH_REPO` (or `GITHUB_ORG` + `GITHUB_REPO`) as the canonical repo identity
+- repo-local agents should read `.repo-scaffold/project.json` before doing project/ticket work
+- repo-local agents should not mutate other repositories unless the user explicitly asks
 
 Typical destructive flow:
 
 ```bash
 poetry run repo-scaffold project items --project-owner acme --project-title "Roadmap"
 poetry run repo-scaffold project item-delete --project-owner acme --project-title "Roadmap" --issue-number 42 --danger --yes
-poetry run repo-scaffold project undo --backup-file /path/to/artifacts/project-backups/project-item-delete-acme-4-YYYYMMDDHHMMSS.json
+poetry run repo-scaffold project undo --backup-file /path/to/artifacts/project-backups/project-item-delete-<timestamp>-<suffix>.json
 ```
 
 ### `delete`
@@ -299,6 +316,17 @@ If `--file` is omitted and markdown source exists under `<repo-path>/artifacts/t
 ```bash
 poetry run repo-scaffold apply backlog --repo OWNER/REPO --with-project --dry-run
 poetry run repo-scaffold apply backlog --repo OWNER/REPO --with-project
+```
+
+When `--with-project` resolves or creates a GitHub Project, repo-scaffold also writes `<repo-path>/.repo-scaffold/project.json`. That gives the target repo a stable local pointer to its roadmap project for repo-local agents and scripts without depending on disposable `artifacts/`.
+
+SOP for an older repo that already has a GitHub Project:
+
+```bash
+poetry run repo-scaffold project sync-metadata \
+  --path /path/to/repo \
+  --project-owner OWNER \
+  --project-title "REPO_NAME Roadmap"
 ```
 
 ## Backlog import + JSON format

--- a/src/repo_scaffold/auth_tokens.py
+++ b/src/repo_scaffold/auth_tokens.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+_TOKEN_PLACEHOLDERS = {
+    "ghp_replace_with_real_token",
+    "<classic-PAT>",
+    "<classic-PAT-placeholder>",
+}
+
+_TOKEN_KEYS = (
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "github_token",
+    "GH_PROJECT_TOKEN",
+    "GITHUB_PROJECT_TOKEN",
+    "github_project_token",
+)
+
+
+def is_placeholder_token(value: str | None) -> bool:
+    if value is None:
+        return False
+    normalized = value.strip()
+    return normalized in _TOKEN_PLACEHOLDERS
+
+
+def resolve_gh_token(values: Mapping[str, str]) -> str | None:
+    for key in _TOKEN_KEYS:
+        value = values.get(key)
+        if value is None:
+            continue
+        normalized = value.strip()
+        if normalized and normalized not in _TOKEN_PLACEHOLDERS:
+            return normalized
+    return None

--- a/src/repo_scaffold/backlog_ops.py
+++ b/src/repo_scaffold/backlog_ops.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from .auth_tokens import is_placeholder_token, resolve_gh_token
 from .project_metadata import write_project_metadata
 
 
@@ -361,7 +362,7 @@ def _add_issue_to_project(
 def _load_token_from_env_file(env_file: Path) -> None:
     if not env_file.exists():
         return
-
+    loaded: dict[str, str] = {}
     for raw_line in env_file.read_text(encoding="utf-8").splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#"):
@@ -376,10 +377,11 @@ def _load_token_from_env_file(env_file: Path) -> None:
         value = value.strip().rstrip("\r")
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
             value = value[1:-1]
+        loaded[key] = value
 
-        if key in {"github_token", "GH_TOKEN", "GITHUB_TOKEN"}:
-            os.environ["GH_TOKEN"] = value
-            break
+    resolved_token = resolve_gh_token(loaded)
+    if resolved_token:
+        os.environ["GH_TOKEN"] = resolved_token
 
 
 def _ensure_gh_auth(repo_dir: Path) -> None:
@@ -388,10 +390,14 @@ def _ensure_gh_auth(repo_dir: Path) -> None:
 
     for env_file in (Path.cwd() / ".env", repo_dir / ".env"):
         _load_token_from_env_file(env_file)
-    if not os.environ.get("GH_TOKEN") and os.environ.get("GITHUB_TOKEN"):
-        os.environ["GH_TOKEN"] = os.environ["GITHUB_TOKEN"]
+    resolved_token = resolve_gh_token(os.environ)
+    current_gh_token = os.environ.get("GH_TOKEN")
+    if resolved_token and (
+        not current_gh_token or is_placeholder_token(current_gh_token)
+    ):
+        os.environ["GH_TOKEN"] = resolved_token
 
-    if os.environ.get("GH_TOKEN"):
+    if os.environ.get("GH_TOKEN") and not is_placeholder_token(os.environ["GH_TOKEN"]):
         return
 
     status = subprocess.run(

--- a/src/repo_scaffold/backlog_ops.py
+++ b/src/repo_scaffold/backlog_ops.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from .project_metadata import write_project_metadata
+
 
 @dataclass(frozen=True)
 class BacklogApplySummary:
@@ -676,6 +678,16 @@ def apply_backlog(
             out=out,
             emit_err=emit_err,
         )
+        if not dry_run and project.number is not None:
+            metadata_file = write_project_metadata(
+                repo_dir,
+                owner=project.owner,
+                number=project.number,
+                title=project.title,
+                repo=repo,
+                source="apply_backlog",
+            )
+            out(f"Synced project metadata: {metadata_file}")
 
     existing_milestones: set[str] = set()
     cp = _run_gh(

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -7,6 +7,7 @@ import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .auth_tokens import is_placeholder_token, resolve_gh_token
 from .backlog_ops import (
     BacklogApplySummary,
     apply_backlog,
@@ -109,11 +110,12 @@ def _seed_env_from_dotenv(path: Path) -> None:
     for key, value in _load_env_file(path).items():
         os.environ.setdefault(key, value)
 
-    if not os.environ.get("GH_TOKEN"):
-        if os.environ.get("GITHUB_TOKEN"):
-            os.environ["GH_TOKEN"] = os.environ["GITHUB_TOKEN"]
-        elif os.environ.get("github_token"):
-            os.environ["GH_TOKEN"] = os.environ["github_token"]
+    resolved_token = resolve_gh_token(os.environ)
+    current_gh_token = os.environ.get("GH_TOKEN")
+    if resolved_token and (
+        not current_gh_token or is_placeholder_token(current_gh_token)
+    ):
+        os.environ["GH_TOKEN"] = resolved_token
 
     if not os.environ.get("GITHUB_ORG") and os.environ.get("github_org"):
         os.environ["GITHUB_ORG"] = os.environ["github_org"]

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -45,6 +45,7 @@ from .project_ops import (
     edit_project,
     list_project_items,
     list_projects,
+    sync_project_metadata,
     undo_project_backup,
     view_project,
 )
@@ -587,6 +588,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=100,
         help="Maximum number of project items to fetch (default: 100)",
     )
+
+    project_sync_cmd = project_sub.add_parser(
+        "sync-metadata",
+        help="Write .repo-scaffold/project.json for a resolved project",
+    )
+    project_sync_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution and metadata output (default: .)",
+    )
+    _add_project_target_args(project_sync_cmd)
 
     project_create_cmd = project_sub.add_parser("create", help="Create a new project")
     project_create_cmd.add_argument(
@@ -1314,7 +1326,15 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  items: {len(items_summary.items)}")
                 return 0
 
-            if ns.project_command == "create":
+            if ns.project_command == "sync-metadata":
+                mutation_summary = sync_project_metadata(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
+                    out=print,
+                )
+            elif ns.project_command == "create":
                 mutation_summary = create_project(
                     repo_dir=repo_dir,
                     owner=ns.project_owner,
@@ -1400,6 +1420,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  changed: {mutation_summary.changed}")
         if mutation_summary.backup_file is not None:
             print(f"  backup file: {mutation_summary.backup_file}")
+        if mutation_summary.metadata_file is not None:
+            print(f"  metadata file: {mutation_summary.metadata_file}")
         if mutation_summary.undo_command is not None:
             print(f"  undo: {mutation_summary.undo_command}")
         if mutation_summary.restored_project_number is not None:

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Callable
 from urllib.parse import quote
 
+from .auth_tokens import is_placeholder_token, resolve_gh_token
+
 
 @dataclass(frozen=True)
 class CreateSummary:
@@ -159,11 +161,12 @@ def _build_env(repo_dir: Path) -> dict[str, str]:
         for key, value in _load_env_file(env_file).items():
             env.setdefault(key, value)
 
-    if not env.get("GH_TOKEN"):
-        if env.get("GITHUB_TOKEN"):
-            env["GH_TOKEN"] = env["GITHUB_TOKEN"]
-        elif env.get("github_token"):
-            env["GH_TOKEN"] = env["github_token"]
+    resolved_token = resolve_gh_token(env)
+    current_gh_token = env.get("GH_TOKEN")
+    if resolved_token and (
+        not current_gh_token or is_placeholder_token(current_gh_token)
+    ):
+        env["GH_TOKEN"] = resolved_token
 
     if not env.get("GITHUB_ORG") and env.get("github_org"):
         env["GITHUB_ORG"] = env["github_org"]

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -397,6 +397,13 @@ def _render_gitignore(languages: Iterable[str]) -> str:
         ".env",
         ".env.*",
         "!.env.example",
+        ".claude/settings.local.json",
+        "",
+        "# Repo-scaffold local metadata",
+        ".repo-scaffold/",
+        "",
+        "# Local generated artifacts",
+        "artifacts/",
         "",
         "# Logs",
         "*.log",
@@ -667,6 +674,28 @@ def _render_repo_readme(config: ScaffoldConfig) -> str:
             "",
             "Optional wrappers are provided in `Makefile`: `make format`, `make lint`, `make typecheck`, `make test`, `make build`.",
             "",
+            "## Repo-scaffold GitHub workflow",
+            "",
+            "- Keep repo planning markdown in `artifacts/tickets/`.",
+            "- The canonical repo project metadata file is `.repo-scaffold/project.json` once a project has been created or synced.",
+            "- `AGENTS.md` tells local agents to treat `GH_REPO` and `.repo-scaffold/project.json` as the repo-local GitHub context.",
+            "- Prefer `gh auth login` or an OS-backed credential manager for local GitHub auth; use `.env` only when you intentionally want token-based local scripting.",
+            "- Run `./scripts/first_time_setup.sh` once to wire the local GitHub Projects v2 token, Claude Code settings, and the `ghp` shell alias for WSL workflows.",
+            "",
+            "### GitHub Projects v2 auth for WSL / Claude Code",
+            "",
+            "```bash",
+            "./scripts/first_time_setup.sh",
+            "source ~/.bashrc  # or ~/.zshrc",
+            "ghp project list --owner YOUR_OWNER",
+            "GH_TOKEN=<classic-PAT> gh project item-list <PROJECT_NUMBER> --owner YOUR_OWNER",
+            "```",
+            "",
+            "- `.env.example` includes `export GH_PROJECT_TOKEN=<classic-PAT>` because child processes need the export prefix.",
+            "- `.claude/settings.local.json` is local-only and gives Claude Code the same project token context.",
+            "- For direct `gh project ...` calls in WSL/Claude, prefer `ghp ...` or `GH_TOKEN=<classic-PAT> gh ...`.",
+            "- Do not rely on `GH_TOKEN=$GH_PROJECT_TOKEN gh ...` for project board commands in this environment.",
+            "",
             "## GitHub templates included",
             "",
             "- `.github/ISSUE_TEMPLATE/epic.md`",
@@ -692,9 +721,19 @@ GITHUB_REPO={name}
 # Alternative single value instead of GITHUB_ORG + GITHUB_REPO:
 # GH_REPO=YOUR_ORG/{name}
 
+# Optional canonical project title for this repo's roadmap:
+# GITHUB_PROJECT_TITLE={name} Roadmap
+
 # Optional backlog project naming defaults (used with --with-project):
 # GITHUB_PROJECT_TITLE=YOUR_FIXED_PROJECT_TITLE
 # GITHUB_PROJECT_TITLE_TEMPLATE={{repo}} Roadmap
+
+# Optional markdown backlog source override:
+# GITHUB_TICKETS_DIR=artifacts/tickets
+
+# Classic PAT for GitHub Projects v2 commands run from WSL / Claude Code.
+# Keep the export prefix so child processes inherit it.
+export GH_PROJECT_TOKEN=<classic-PAT>
 
 # Optional local Codecov upload token (read automatically by `tox -e codecov-upload`):
 # CODECOV_TOKEN=your_codecov_token
@@ -706,6 +745,139 @@ GITHUB_REPO={name}
 # github_full_repo=...
 # github_project_title=...
 # github_project_title_template=...
+# github_tickets_dir=...
+"""
+
+
+def _render_claude_settings_local() -> str:
+    return """{
+  "env": {
+    "GH_PROJECT_TOKEN": "<classic-PAT>"
+  }
+}
+"""
+
+
+def _render_agents_md(config: ScaffoldConfig) -> str:
+    return f"""# AGENTS
+
+Repo-scaffold conventions for local agents:
+
+- Treat `GH_REPO` (or `GITHUB_ORG` + `GITHUB_REPO`) as the canonical GitHub repo identity for this workspace.
+- Do not mutate other repositories unless the user explicitly asks.
+- If `.repo-scaffold/project.json` exists, it is the canonical GitHub Project metadata for this repo. Read it before doing project or ticket work.
+- Prefer repo issues and the repo-linked roadmap project for planning context.
+- Planning markdown lives in `artifacts/tickets/`.
+- Imported backlog JSON lives in `artifacts/backlog/issues.json`.
+- For local GitHub auth, prefer `gh auth login` or an OS credential manager. Use `.env` tokens only when the user intentionally wants repo-local token-based scripting.
+- For GitHub Projects v2 commands in WSL / Claude Code, prefer the `ghp` shell alias or `GH_TOKEN=<classic-PAT> gh ...`.
+- Do not rely on `GH_TOKEN=$GH_PROJECT_TOKEN gh ...` for project board commands in this environment.
+- `.claude/settings.local.json` is local-only and should carry `GH_PROJECT_TOKEN` for Claude Code sessions.
+
+Expected default project title:
+
+- `{config.name} Roadmap`
+"""
+
+
+def _render_first_time_setup_script() -> str:
+    return """#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_EXAMPLE="$REPO_ROOT/.env.example"
+ENV_FILE="$REPO_ROOT/.env"
+CLAUDE_DIR="$REPO_ROOT/.claude"
+CLAUDE_SETTINGS_FILE="$CLAUDE_DIR/settings.local.json"
+PAT_PLACEHOLDER="<classic-PAT>"
+
+pick_shell_rc() {
+  local shell_name
+  shell_name="$(basename "${SHELL:-bash}")"
+  case "$shell_name" in
+    zsh) printf '%s\n' "$HOME/.zshrc" ;;
+    *) printf '%s\n' "$HOME/.bashrc" ;;
+  esac
+}
+
+upsert_env_line() {
+  local file="$1"
+  local pattern="$2"
+  local replacement="$3"
+  local tmp
+
+  tmp="$(mktemp)"
+  if [ -f "$file" ]; then
+    grep -v -E "$pattern" "$file" > "$tmp" || true
+  fi
+  printf '%s\n' "$replacement" >> "$tmp"
+  mv "$tmp" "$file"
+}
+
+echo "Repo-scaffold first-time GitHub Projects setup"
+echo
+echo "This script will:"
+echo "  1) ensure .env exists"
+echo "  2) set export GH_PROJECT_TOKEN=..."
+echo "  3) write .claude/settings.local.json"
+echo "  4) optionally append a ghp alias to your shell rc"
+echo
+
+if [ ! -f "$ENV_FILE" ]; then
+  if [ -f "$ENV_EXAMPLE" ]; then
+    cp "$ENV_EXAMPLE" "$ENV_FILE"
+    echo "Created $ENV_FILE from .env.example"
+  else
+    : > "$ENV_FILE"
+    echo "Created empty $ENV_FILE"
+  fi
+fi
+
+read -r -p "Classic PAT for GitHub Projects v2 (leave blank to keep placeholder): " PROJECT_TOKEN
+if [ -z "$PROJECT_TOKEN" ]; then
+  PROJECT_TOKEN="$PAT_PLACEHOLDER"
+fi
+
+upsert_env_line "$ENV_FILE" '^(export[[:space:]]+)?GH_PROJECT_TOKEN=' "export GH_PROJECT_TOKEN=$PROJECT_TOKEN"
+echo "Updated $ENV_FILE"
+
+mkdir -p "$CLAUDE_DIR"
+cat > "$CLAUDE_SETTINGS_FILE" <<EOF
+{
+  "env": {
+    "GH_PROJECT_TOKEN": "$PROJECT_TOKEN"
+  }
+}
+EOF
+echo "Wrote $CLAUDE_SETTINGS_FILE"
+
+RC_FILE="$(pick_shell_rc)"
+ALIAS_LINE="alias ghp='GH_TOKEN=$PROJECT_TOKEN gh'"
+read -r -p "Append ghp alias to $RC_FILE? [y/N] " APPEND_ALIAS
+case "$APPEND_ALIAS" in
+  [yY]|[yY][eE][sS])
+    touch "$RC_FILE"
+    if ! grep -Fqx "$ALIAS_LINE" "$RC_FILE"; then
+      printf '\n%s\n' "$ALIAS_LINE" >> "$RC_FILE"
+      echo "Appended ghp alias to $RC_FILE"
+    else
+      echo "ghp alias already present in $RC_FILE"
+    fi
+    ;;
+  *)
+    echo "Skipped shell alias update."
+    ;;
+esac
+
+echo
+echo "Next steps:"
+echo "  source $RC_FILE"
+echo "  ghp project list --owner YOUR_OWNER"
+echo "  GH_TOKEN=$PROJECT_TOKEN gh project item-list <PROJECT_NUMBER> --owner YOUR_OWNER"
+echo
+echo "For project board commands in WSL / Claude Code, use ghp or direct GH_TOKEN=... gh ... commands."
+echo "Do not rely on GH_TOKEN=\\$GH_PROJECT_TOKEN gh ... in this environment."
 """
 
 
@@ -2618,6 +2790,11 @@ def build_scaffold_files(config: ScaffoldConfig) -> list[ScaffoldFile]:
         ),
         ScaffoldFile(config.out_dir / "docs" / "api-v1.md", "# API v1\n\nTBD\n"),
         ScaffoldFile(config.out_dir / ".env.example", _render_env_example(config.name)),
+        ScaffoldFile(
+            config.out_dir / ".claude" / "settings.local.json",
+            _render_claude_settings_local(),
+        ),
+        ScaffoldFile(config.out_dir / "AGENTS.md", _render_agents_md(config)),
         ScaffoldFile(config.out_dir / "README.md", _render_repo_readme(config)),
         ScaffoldFile(config.out_dir / "LICENSE", _apache_2_license()),
         ScaffoldFile(
@@ -2625,6 +2802,11 @@ def build_scaffold_files(config: ScaffoldConfig) -> list[ScaffoldFile]:
         ),
         ScaffoldFile(config.out_dir / ".editorconfig", _render_editorconfig()),
         ScaffoldFile(config.out_dir / "Makefile", _render_makefile()),
+        ScaffoldFile(
+            config.out_dir / "scripts" / "first_time_setup.sh",
+            _render_first_time_setup_script(),
+            executable=True,
+        ),
     ]
 
     selected = set(config.languages)

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -820,8 +820,9 @@ echo
 echo "This script will:"
 echo "  1) ensure .env exists"
 echo "  2) set export GH_PROJECT_TOKEN=..."
-echo "  3) write .claude/settings.local.json"
-echo "  4) optionally append a ghp alias to your shell rc"
+echo "  3) set GH_TOKEN=... for repo-scaffold compatibility"
+echo "  4) write .claude/settings.local.json"
+echo "  5) optionally append a ghp alias to your shell rc"
 echo
 
 if [ ! -f "$ENV_FILE" ]; then
@@ -839,7 +840,13 @@ if [ -z "$PROJECT_TOKEN" ]; then
   PROJECT_TOKEN="$PAT_PLACEHOLDER"
 fi
 
+read -r -p "Repo-scaffold GH_TOKEN (leave blank to reuse the project token): " REPO_TOKEN
+if [ -z "$REPO_TOKEN" ]; then
+  REPO_TOKEN="$PROJECT_TOKEN"
+fi
+
 upsert_env_line "$ENV_FILE" '^(export[[:space:]]+)?GH_PROJECT_TOKEN=' "export GH_PROJECT_TOKEN=$PROJECT_TOKEN"
+upsert_env_line "$ENV_FILE" '^GH_TOKEN=' "GH_TOKEN=$REPO_TOKEN"
 echo "Updated $ENV_FILE"
 
 mkdir -p "$CLAUDE_DIR"

--- a/src/repo_scaffold/project_metadata.py
+++ b/src/repo_scaffold/project_metadata.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_PROJECT_METADATA_REL_PATH = ".repo-scaffold/project.json"
+
+
+def project_metadata_path(
+    repo_dir: Path, rel_path: str = DEFAULT_PROJECT_METADATA_REL_PATH
+) -> Path:
+    metadata_path = Path(rel_path)
+    return metadata_path if metadata_path.is_absolute() else (repo_dir / metadata_path)
+
+
+def write_project_metadata(
+    repo_dir: Path,
+    *,
+    owner: str,
+    number: int,
+    title: str,
+    source: str,
+    repo: str | None = None,
+    closed: bool | None = None,
+    visibility: str | None = None,
+    description: str | None = None,
+    readme: str | None = None,
+    url: str | None = None,
+) -> Path:
+    metadata_file = project_metadata_path(repo_dir)
+    metadata_file.parent.mkdir(parents=True, exist_ok=True)
+
+    payload: dict[str, object] = {
+        "version": 1,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "source": source,
+        "owner": owner,
+        "number": number,
+        "title": title,
+    }
+    if repo:
+        payload["repo"] = repo
+    if closed is not None:
+        payload["closed"] = closed
+    if visibility:
+        payload["visibility"] = visibility
+    if description:
+        payload["description"] = description
+    if readme:
+        payload["readme"] = readme
+    if url:
+        payload["url"] = url
+
+    metadata_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return metadata_file

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -17,6 +17,7 @@ from .backlog_ops import (
     _run_gh,
     resolve_authenticated_login,
 )
+from .project_metadata import write_project_metadata
 
 DEFAULT_PROJECT_BACKUP_REL_DIR = "artifacts/project-backups"
 
@@ -68,6 +69,7 @@ class ProjectMutationSummary:
     undo_command: str | None = None
     restored_project_number: int | None = None
     restored_item_id: str | None = None
+    metadata_file: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -78,6 +80,34 @@ class _ProjectBackup:
 
 def _emit_err_factory(err: Callable[[str], None] | None) -> Callable[[str], None]:
     return err if err is not None else (lambda line: print(line, file=sys.stderr))
+
+
+def _resolve_repo_ref_from_env() -> str | None:
+    full_repo = os.environ.get("GH_REPO") or os.environ.get("GITHUB_REPOSITORY")
+    if full_repo and "/" in full_repo:
+        return full_repo.strip()
+    owner = (os.environ.get("GITHUB_ORG") or "").strip()
+    name = (os.environ.get("GITHUB_REPO") or "").strip()
+    if owner and name:
+        return f"{owner}/{name}"
+    return None
+
+
+def _sync_project_metadata_file(
+    *, repo_dir: Path, project: ProjectInfo, source: str
+) -> Path:
+    return write_project_metadata(
+        repo_dir,
+        owner=project.owner,
+        number=project.number,
+        title=project.title,
+        repo=_resolve_repo_ref_from_env(),
+        source=source,
+        closed=project.closed,
+        visibility=project.visibility,
+        description=project.description,
+        readme=project.readme,
+    )
 
 
 def _normalize_visibility(payload: dict[str, object]) -> str | None:
@@ -385,6 +415,37 @@ def list_project_items(
     return ProjectItemsSummary(project=project, items=items)
 
 
+def sync_project_metadata(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+    out: Callable[[str], None] = print,
+) -> ProjectMutationSummary:
+    project = _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+    metadata_file = _sync_project_metadata_file(
+        repo_dir=repo_dir,
+        project=project,
+        source="project_sync_metadata",
+    )
+    out(f"Synced project metadata: {metadata_file}")
+    return ProjectMutationSummary(
+        action="sync-metadata",
+        owner=project.owner,
+        project_number=project.number,
+        project_title=project.title,
+        failures=0,
+        changed=True,
+        metadata_file=metadata_file,
+    )
+
+
 def create_project(
     *,
     repo_dir: Path,
@@ -463,7 +524,7 @@ def create_project(
     out(f"Created project: {project_owner}/#{number} ({title})")
 
     if description or readme or visibility:
-        edit_project(
+        edit_summary = edit_project(
             repo_dir=repo_dir,
             owner=project_owner,
             project_number=number,
@@ -475,6 +536,19 @@ def create_project(
             dry_run=False,
             out=out,
         )
+        metadata_file = edit_summary.metadata_file
+    else:
+        project = _project_from_payload(
+            _load_project_view(repo_dir, project_owner, number),
+            owner=project_owner,
+            fallback_number=number,
+        )
+        metadata_file = _sync_project_metadata_file(
+            repo_dir=repo_dir,
+            project=project,
+            source="project_create",
+        )
+        out(f"Synced project metadata: {metadata_file}")
 
     return ProjectMutationSummary(
         action="create",
@@ -483,6 +557,7 @@ def create_project(
         project_title=title,
         failures=0,
         changed=True,
+        metadata_file=metadata_file,
     )
 
 
@@ -548,16 +623,28 @@ def edit_project(
         )
         raise RuntimeError(_project_scope_hint(detail))
 
+    updated_project = _project_from_payload(
+        _load_project_view(repo_dir, project.owner, project.number),
+        owner=project.owner,
+        fallback_number=project.number,
+    )
+    metadata_file = _sync_project_metadata_file(
+        repo_dir=repo_dir,
+        project=updated_project,
+        source="project_edit",
+    )
     out(
         f"Updated project: {project.owner}/#{project.number} ({title.strip() if title else project.title})"
     )
+    out(f"Synced project metadata: {metadata_file}")
     return ProjectMutationSummary(
         action="edit",
         owner=project.owner,
         project_number=project.number,
-        project_title=title.strip() if title else project.title,
+        project_title=updated_project.title,
         failures=0,
         changed=True,
+        metadata_file=metadata_file,
     )
 
 
@@ -1091,6 +1178,7 @@ def undo_project_backup(
             failures=0,
             changed=True,
             backup_file=backup_file,
+            metadata_file=summary.metadata_file,
             restored_project_number=restored_number,
         )
 
@@ -1119,6 +1207,17 @@ def undo_project_backup(
             raw_item=raw_item,
             out=out,
         )
+        project = _project_from_payload(
+            _load_project_view(repo_dir, owner, project_number_value),
+            owner=owner,
+            fallback_number=project_number_value,
+        )
+        metadata_file = _sync_project_metadata_file(
+            repo_dir=repo_dir,
+            project=project,
+            source="project_undo",
+        )
+        out(f"Synced project metadata: {metadata_file}")
         return ProjectMutationSummary(
             action="undo",
             owner=owner,
@@ -1127,6 +1226,7 @@ def undo_project_backup(
             failures=0,
             changed=True,
             backup_file=backup_file,
+            metadata_file=metadata_file,
             restored_item_id=restored_item_id,
         )
 

--- a/tests/test_backlog_ops.py
+++ b/tests/test_backlog_ops.py
@@ -224,6 +224,8 @@ def test_load_token_from_env_file_and_ensure_gh_auth(
     backlog_ops._ensure_gh_auth(repo_dir)
 
     monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GH_PROJECT_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_PROJECT_TOKEN", raising=False)
     clean_repo_dir = tmp_path / "clean-repo"
     clean_repo_dir.mkdir()
     monkeypatch.chdir(clean_repo_dir)
@@ -236,6 +238,30 @@ def test_load_token_from_env_file_and_ensure_gh_auth(
     )
     with pytest.raises(RuntimeError, match="Authenticate first"):
         backlog_ops._ensure_gh_auth(clean_repo_dir)
+
+
+def test_load_token_from_env_file_uses_project_token_when_gh_token_is_placeholder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "GH_TOKEN=ghp_replace_with_real_token",
+                "export GH_PROJECT_TOKEN=ghp_project_real_token",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GH_PROJECT_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_PROJECT_TOKEN", raising=False)
+
+    backlog_ops._load_token_from_env_file(env_file)
+
+    assert os.environ["GH_TOKEN"] == "ghp_project_real_token"
 
 
 def test_find_issue_number_uses_repo_issues_api_exact_match(

--- a/tests/test_backlog_ops.py
+++ b/tests/test_backlog_ops.py
@@ -562,6 +562,13 @@ def test_apply_backlog_project_title_creates_and_adds_items(
     assert summary.issues_skipped == 2
     assert summary.epic_issues_skipped == 1
     assert summary.ticket_issues_skipped == 1
+    project_metadata = repo_dir / ".repo-scaffold" / "project.json"
+    assert project_metadata.exists()
+    payload = json.loads(project_metadata.read_text(encoding="utf-8"))
+    assert payload["source"] == "apply_backlog"
+    assert payload["repo"] == "acme/repo"
+    assert payload["number"] == 42
+    assert payload["title"] == "Roadmap"
 
 
 def test_list_projects_supports_wrapped_json_response(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -918,6 +918,60 @@ def test_apply_backlog_project_title_delegates_to_backlog_ops(
     assert called["project_owner"] == "acme"
 
 
+def test_project_sync_metadata_delegates_to_project_ops(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+
+    called: dict[str, object] = {}
+
+    def _fake_sync_project_metadata(
+        *,
+        repo_dir: Path,
+        owner: str | None,
+        project_number: int | None,
+        project_title: str | None,
+        out,
+    ) -> ProjectMutationSummary:
+        called["repo_dir"] = repo_dir
+        called["owner"] = owner
+        called["project_number"] = project_number
+        called["project_title"] = project_title
+        return ProjectMutationSummary(
+            action="sync-metadata",
+            owner="acme",
+            project_number=4,
+            project_title="Roadmap",
+            failures=0,
+            changed=True,
+            metadata_file=repo_dir / ".repo-scaffold" / "project.json",
+        )
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.sync_project_metadata", _fake_sync_project_metadata
+    )
+
+    rc = main(
+        [
+            "project",
+            "sync-metadata",
+            "--path",
+            str(repo_dir),
+            "--project-owner",
+            "acme",
+            "--project-title",
+            "Roadmap",
+        ]
+    )
+
+    assert rc == 0
+    assert called["repo_dir"] == repo_dir
+    assert called["owner"] == "acme"
+    assert called["project_number"] is None
+    assert called["project_title"] == "Roadmap"
+
+
 def test_apply_backlog_with_project_defaults_title_from_repo_name(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
+import repo_scaffold.cli as cli_module
 
 from repo_scaffold.backlog_ops import BacklogApplySummary
 from repo_scaffold.create_ops import CreateSummary, SettingsCheckSummary
@@ -54,6 +55,29 @@ def test_root_help_shows_all_modes(capsys: pytest.CaptureFixture[str]) -> None:
     assert "delete" in stdout
     assert "import" in stdout
     assert "project" in stdout
+
+
+def test_seed_env_from_dotenv_promotes_project_token_when_gh_token_is_placeholder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "GH_TOKEN=ghp_replace_with_real_token",
+                "export GH_PROJECT_TOKEN=ghp_project_real_token",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GH_PROJECT_TOKEN", raising=False)
+
+    cli_module._seed_env_from_dotenv(env_file)
+
+    assert cli_module.os.environ["GH_TOKEN"] == "ghp_project_real_token"
 
 
 def test_init_defaults_name_and_languages(

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -88,6 +88,35 @@ def test_load_env_file_and_build_env_support_aliases(
     assert env["GH_REPO"] == "from/cwd"
 
 
+def test_build_env_promotes_project_token_when_gh_token_is_placeholder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cwd = tmp_path / "cwd"
+    repo_dir = tmp_path / "repo"
+    cwd.mkdir()
+    repo_dir.mkdir()
+    (repo_dir / ".env").write_text(
+        "\n".join(
+            [
+                "GH_TOKEN=ghp_replace_with_real_token",
+                "export GH_PROJECT_TOKEN=ghp_project_real_token",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(cwd)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_PROJECT_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_PROJECT_TOKEN", raising=False)
+
+    env = create_ops._build_env(repo_dir)
+
+    assert env["GH_TOKEN"] == "ghp_project_real_token"
+
+
 def test_load_json_invalid_raises_runtime_error() -> None:
     with pytest.raises(RuntimeError, match="bad json"):
         create_ops._load_json("not-json", error_message="bad json")

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -216,6 +216,14 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     script_text = first_time_setup.read_text(encoding="utf-8")
     assert "alias ghp='GH_TOKEN=$PROJECT_TOKEN gh'" in script_text
     assert "GH_TOKEN=$PROJECT_TOKEN gh project item-list" in script_text
+    assert (
+        "Repo-scaffold GH_TOKEN (leave blank to reuse the project token): "
+        in script_text
+    )
+    assert (
+        'upsert_env_line "$ENV_FILE" \'^GH_TOKEN=\' "GH_TOKEN=$REPO_TOKEN"'
+        in script_text
+    )
 
 
 def test_generation_is_deterministic(tmp_path: Path) -> None:

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -47,11 +47,14 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
         "docs/requirements.md",
         "docs/api-v1.md",
         "README.md",
+        "AGENTS.md",
         ".env.example",
+        ".claude/settings.local.json",
         "LICENSE",
         ".gitignore",
         ".editorconfig",
         "Makefile",
+        "scripts/first_time_setup.sh",
         "go.mod",
         "cmd/demo/main.go",
         "internal/.gitkeep",
@@ -118,6 +121,12 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "already present in `.env`" in generated_readme
     assert "minimum coverage gate is 70%" in generated_readme
     assert "make typecheck" in generated_readme
+    assert "## Repo-scaffold GitHub workflow" in generated_readme
+    assert ".repo-scaffold/project.json" in generated_readme
+    assert "AGENTS.md" in generated_readme
+    assert "./scripts/first_time_setup.sh" in generated_readme
+    assert "GH_TOKEN=<classic-PAT> gh project item-list" in generated_readme
+    assert ".claude/settings.local.json" in generated_readme
     assert "## Backlog bootstrap" not in generated_readme
     assert "## GitHub token permissions" not in generated_readme
     assert "./scripts/create-issues.sh" not in generated_readme
@@ -125,10 +134,23 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "GH_TOKEN=" in env_example
     assert "GITHUB_ORG=" in env_example
     assert "GH_REPO=" in env_example
+    assert f"GITHUB_PROJECT_TITLE={cfg.name} Roadmap" in env_example
     assert "GITHUB_PROJECT_TITLE=" in env_example
     assert "GITHUB_PROJECT_TITLE_TEMPLATE=" in env_example
+    assert "GITHUB_TICKETS_DIR=" in env_example
+    assert "export GH_PROJECT_TOKEN=<classic-PAT>" in env_example
     assert "CODECOV_TOKEN=" in env_example
     assert "read automatically by `tox -e codecov-upload`" in env_example
+    claude_settings = (out_dir / ".claude" / "settings.local.json").read_text(
+        encoding="utf-8"
+    )
+    assert '"GH_PROJECT_TOKEN": "<classic-PAT>"' in claude_settings
+    agents_md = (out_dir / "AGENTS.md").read_text(encoding="utf-8")
+    assert ".repo-scaffold/project.json" in agents_md
+    assert "GH_REPO" in agents_md
+    assert f"{cfg.name} Roadmap" in agents_md
+    assert "ghp" in agents_md
+    assert "GH_TOKEN=$GH_PROJECT_TOKEN gh ..." in agents_md
     pyproject = (out_dir / "pyproject.toml").read_text(encoding="utf-8")
     assert "black>=" in pyproject
     assert "mypy>=" in pyproject
@@ -180,12 +202,20 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert '"eslint": "^9.21.0"' in web_package
     gitignore = (out_dir / ".gitignore").read_text(encoding="utf-8")
     assert "!.env.example" in gitignore
+    assert ".claude/settings.local.json" in gitignore
+    assert ".repo-scaffold/" in gitignore
+    assert "artifacts/" in gitignore
     assert ".coverage" in gitignore
     assert "coverage.xml" in gitignore
     assert "htmlcov/" in gitignore
     assert ".pre-commit-cache/" in gitignore
     assert not (out_dir / "backlog").exists()
-    assert not (out_dir / "scripts").exists()
+    first_time_setup = out_dir / "scripts" / "first_time_setup.sh"
+    assert first_time_setup.exists()
+    assert first_time_setup.stat().st_mode & 0o111
+    script_text = first_time_setup.read_text(encoding="utf-8")
+    assert "alias ghp='GH_TOKEN=$PROJECT_TOKEN gh'" in script_text
+    assert "GH_TOKEN=$PROJECT_TOKEN gh project item-list" in script_text
 
 
 def test_generation_is_deterministic(tmp_path: Path) -> None:

--- a/tests/test_project_ops.py
+++ b/tests/test_project_ops.py
@@ -172,6 +172,42 @@ def test_list_project_items_parses_issue_and_draft_items(
     assert summary.items[1].body == "draft body"
 
 
+def test_sync_project_metadata_writes_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+    monkeypatch.setenv("GH_REPO", "acme/repo")
+    monkeypatch.setattr(
+        project_ops,
+        "_find_existing_project",
+        lambda **_kwargs: project_ops.ProjectInfo(
+            owner="acme",
+            number=4,
+            title="Roadmap",
+            closed=False,
+            visibility="PRIVATE",
+            description="desc",
+        ),
+    )
+
+    summary = project_ops.sync_project_metadata(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=4,
+        project_title=None,
+        out=lambda _line: None,
+    )
+
+    assert summary.metadata_file is not None
+    payload = json.loads(summary.metadata_file.read_text(encoding="utf-8"))
+    assert payload["repo"] == "acme/repo"
+    assert payload["owner"] == "acme"
+    assert payload["number"] == 4
+    assert payload["title"] == "Roadmap"
+    assert payload["source"] == "project_sync_metadata"
+
+
 def test_create_project_delegates_optional_metadata_edit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## 🧾 Title
Persist repo-local project context and scaffold local GitHub Projects auth setup

## 🧠 Description
This pull request persists canonical GitHub Project metadata inside each managed repo and adds a repeatable first-time setup workflow for local GitHub Projects v2 access in WSL / Claude Code environments.

It separates disposable planning artifacts from agent-critical repo context by writing project metadata to `.repo-scaffold/project.json`, and it standardizes the local token/bootstrap flow for new repos with generated setup files and a guided shell script.

## 🧩 Changes Included
- [x] Added/updated documentation
- [x] Implemented new feature or enhancement
- [x] Improved error handling or logging
- [x] Updated environment configuration
- [x] Other (generated repo-local agent/setup files)

## 🎯 Purpose
This PR aims to make each managed repo self-describing for local agents and safer to operate independently of this toolkit repo.

It adds:
- canonical repo-local GitHub Project metadata in `.repo-scaffold/project.json`
- `project sync-metadata` for older repos that already have a roadmap project
- generated `AGENTS.md` guidance for repo-local agents
- generated `.claude/settings.local.json` and `.env.example` guidance for local Projects v2 token setup
- generated `scripts/first_time_setup.sh` to bootstrap the local WSL-safe auth flow

## 🔗 Related Issues / Epics
- **Epic:** N/A
- **Issue:** N/A
- **Closes:** N/A

## 🧪 Testing
1. `poetry run pytest -q tests/test_backlog_ops.py tests/test_project_ops.py tests/test_cli.py tests/test_generation.py`
2. `.tox/type/bin/mypy src`
3. `poetry run pytest -q tests/test_generation.py`
4. `git diff --check`

## 🧰 Developer Notes
- `apply backlog --with-project` now writes or refreshes `.repo-scaffold/project.json`.
- `repo-scaffold project sync-metadata` is the SOP for older repos that already have a project.
- Generated repos now include `scripts/first_time_setup.sh` for the local GitHub Projects v2 setup flow.
- Generated `.env.example` includes `export GH_PROJECT_TOKEN=<classic-PAT>` because child processes need the export prefix.
- Generated `.claude/settings.local.json` is local-only and is ignored by git.
- Generated guidance standardizes the WSL-safe `ghp` alias and direct `GH_TOKEN=<classic-PAT> gh project ...` pattern instead of relying on `GH_TOKEN=$GH_PROJECT_TOKEN gh ...`.
- `artifacts/` remains disposable; agent-critical project metadata now lives in `.repo-scaffold/`.