### PR TITLE
Document cross-repo markdown backlog auto-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Subcommands:
 - `templates`: apply `.github` PR/issue templates, issue config, and `CODEOWNERS`
 - `ci --languages <list>`: apply `.github/workflows/ci.yml`
 - `dependabot [--low-noise]`: apply `.github/dependabot.yml`
-- `backlog --repo owner/repo [--file PATH] [--dry-run] [--auth-check] [--with-project] [--project-number N | --project-title T] [--project-owner O]`: bulk-create milestones/issues using `gh`
+- `backlog --repo owner/repo [--file PATH] [--dry-run] [--auth-check] [--with-project] [--project-number N | --project-title T] [--project-owner O]`: bulk-create milestones/issues using `gh`; when `--file` is omitted, markdown tickets are auto-imported first if a ticket source directory exists
 - `rules [--repo owner/repo] [--apply]`: preview or apply merge settings, the managed default-branch ruleset, and security defaults
 
 ### `import`
@@ -316,6 +316,21 @@ If `--file` is omitted and markdown source exists under `<repo-path>/artifacts/t
 ```bash
 poetry run repo-scaffold apply backlog --repo OWNER/REPO --with-project --dry-run
 poetry run repo-scaffold apply backlog --repo OWNER/REPO --with-project
+```
+
+When the markdown tickets live in this repo but the target backlog belongs to another checkout, pass the target repo path and point `GITHUB_TICKETS_DIR` at this repo's ticket directory. Use an absolute path because relative `GITHUB_TICKETS_DIR` values resolve from `--path`.
+
+```bash
+GITHUB_TICKETS_DIR="$PWD/artifacts/tickets" \
+  poetry run repo-scaffold apply backlog \
+  --path /path/to/gallery-dl-wrapper \
+  --repo OWNER/gallery-dl-wrapper \
+  --dry-run
+
+GITHUB_TICKETS_DIR="$PWD/artifacts/tickets" \
+  poetry run repo-scaffold apply backlog \
+  --path /path/to/gallery-dl-wrapper \
+  --repo OWNER/gallery-dl-wrapper
 ```
 
 When `--with-project` resolves or creates a GitHub Project, repo-scaffold also writes `<repo-path>/.repo-scaffold/project.json`. That gives the target repo a stable local pointer to its roadmap project for repo-local agents and scripts without depending on disposable `artifacts/`.


### PR DESCRIPTION
## 🧾 Title
Document cross-repo markdown backlog auto-import

## 🧠 Description
This PR clarifies that `repo-scaffold apply backlog` can auto-import markdown tickets into the JSON backlog input form when `--file` is omitted.

It also documents the cross-repo workflow where markdown tickets live in this `repo-scaffold` workspace but the generated backlog and GitHub issues target another repository checkout.

## 🧩 Changes Included
- [x] Added/updated documentation
- [ ] Implemented new feature or enhancement
- [ ] Refactored existing code
- [ ] Improved error handling or logging
- [ ] Updated environment configuration
- [ ] Other (specify)

## 🎯 Purpose
Make the command clear for using `repo-scaffold` as the source-of-truth ticket workspace while applying backlog tickets to another repository.

## 🔗 Related Issues / Epics
- **Epic:** N/A
- **Issue:** N/A
- **Closes:** N/A

## 🧪 Testing
1. `GITHUB_TICKETS_DIR="$PWD/artifacts/tickets" poetry run repo-scaffold apply backlog --path /mnt/d/Dropbox/Projects/sandboxes/python/gallery-dl-wrapper --repo blairg23/gallery-dl-wrapper --dry-run`
2. Confirmed `apply backlog` auto-imported from `artifacts/tickets`.
3. Confirmed local markdown import scanned 3 files and imported 3 tickets.
4. `git diff --check README.md`

## 🧰 Developer Notes
- Use an absolute `GITHUB_TICKETS_DIR` for cross-repo applies because relative values resolve from `--path`.
