### PR TITLE
feat(agent): add issue view command for agent-readable issue details (#84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# repo-scaffold
+
+## Golden rule: use repo-scaffold for everything GitHub
+
+**Never use PowerShell + `gh.exe` directly.** Always use `poetry run repo-scaffold` commands (via Bash/WSL). The CLI wraps `gh` internally with proper auth from `.env`.
+
+## Available commands
+
+```bash
+# Issues
+poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N
+poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N --json
+
+# Projects
+poetry run repo-scaffold project items --project-title "TITLE" --limit 40
+poetry run repo-scaffold project list --project-owner OWNER
+poetry run repo-scaffold project view --project-title "TITLE"
+
+# Backlog
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
+poetry run repo-scaffold import backlog --repo OWNER/REPO
+
+# Scaffold generation
+poetry run repo-scaffold init --name NAME --languages go,gin,python,react --owner OWNER --out /path --yes
+poetry run repo-scaffold apply ci --path . --languages go,gin,python,react
+poetry run repo-scaffold apply templates --path . --name NAME --owner OWNER
+
+# Repo management
+poetry run repo-scaffold create --repo OWNER/REPO
+poetry run repo-scaffold check rules --repo OWNER/REPO
+```
+
+## Supported languages for init/apply ci
+`go`, `gin`, `python`, `react`
+
+- `gin` = Go web server with Gin framework (router, health handler, CI, CodeQL)
+- `gin` and `go` are mutually exclusive (both use go.mod)
+
+## GitHub auth
+Token lives in `.env` as `GH_TOKEN`. Commands pick it up automatically via `_seed_env_from_dotenv`.
+
+## Still missing (potential future tickets)
+- `repo-scaffold pr list`
+- `repo-scaffold pr create`
+- `repo-scaffold pr comment --reply-to <id>`
+- `repo-scaffold pr resolve-thread`
+
+## Running tests
+```bash
+poetry run pytest                          # all tests
+poetry run pytest tests/test_cli.py -q    # CLI only
+poetry run tox -e precommit               # full gate (format + lint + type + coverage)
+```
+
+## Pre-commit
+Runs `tox -e precommit` on every commit. Must pass before commit lands.
+Format with `poetry run black src tests` if it fails on formatting.

--- a/src/repo_scaffold/backlog_ops.py
+++ b/src/repo_scaffold/backlog_ops.py
@@ -1014,6 +1014,8 @@ def fetch_issue(repo_dir: Path, repo: str, issue_number: int) -> IssueDetail:
         raise RuntimeError(
             f"Unexpected response when fetching issue #{issue_number}."
         ) from exc
+    if "pull_request" in data:
+        raise RuntimeError(f"#{issue_number} is a pull request, not an issue.")
     return IssueDetail(
         number=int(data.get("number", issue_number)),
         title=str(data.get("title", "")),

--- a/src/repo_scaffold/backlog_ops.py
+++ b/src/repo_scaffold/backlog_ops.py
@@ -7,12 +7,22 @@ import shutil
 import subprocess
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
 
 from .auth_tokens import is_placeholder_token, resolve_gh_token
 from .project_metadata import write_project_metadata
+
+
+@dataclass(frozen=True)
+class IssueDetail:
+    number: int
+    title: str
+    body: str
+    state: str
+    labels: list[str] = field(default_factory=list)
+    assignees: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -985,4 +995,38 @@ def apply_backlog(
         project_created=project_created,
         project_items_added=project_items_added,
         project_items_skipped=project_items_skipped,
+    )
+
+
+def fetch_issue(repo_dir: Path, repo: str, issue_number: int) -> IssueDetail:
+    _ensure_gh_auth(repo_dir)
+    cp = _run_gh(repo_dir, ["api", f"/repos/{repo}/issues/{issue_number}"])
+    if cp.returncode != 0:
+        stderr = cp.stderr.strip()
+        if "404" in stderr or "Not Found" in (cp.stdout or ""):
+            raise RuntimeError(f"Issue #{issue_number} not found in {repo}.")
+        raise RuntimeError(
+            stderr or f"Failed to fetch issue #{issue_number} from {repo}."
+        )
+    try:
+        data = json.loads(cp.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Unexpected response when fetching issue #{issue_number}."
+        ) from exc
+    return IssueDetail(
+        number=int(data.get("number", issue_number)),
+        title=str(data.get("title", "")),
+        body=str(data.get("body", "") or ""),
+        state=str(data.get("state", "")),
+        labels=[
+            lbl["name"]
+            for lbl in data.get("labels", [])
+            if isinstance(lbl, dict) and "name" in lbl
+        ],
+        assignees=[
+            a["login"]
+            for a in data.get("assignees", [])
+            if isinstance(a, dict) and "login" in a
+        ],
     )

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -10,7 +10,9 @@ from pathlib import Path
 from .auth_tokens import is_placeholder_token, resolve_gh_token
 from .backlog_ops import (
     BacklogApplySummary,
+    IssueDetail,
     apply_backlog,
+    fetch_issue,
     resolve_authenticated_login,
     resolve_project_target_for_auth_check,
 )
@@ -740,6 +742,29 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    issue_cmd = subparsers.add_parser("issue", help="Query GitHub issues")
+    issue_sub = issue_cmd.add_subparsers(dest="issue_command", required=True)
+    issue_view_cmd = issue_sub.add_parser(
+        "view", help="View details for a single issue"
+    )
+    issue_view_cmd.add_argument(
+        "--repo",
+        required=True,
+        help="Target GitHub repo (owner/repo)",
+    )
+    issue_view_cmd.add_argument(
+        "--issue-number",
+        type=int,
+        required=True,
+        help="Issue number to fetch",
+    )
+    issue_view_cmd.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output structured JSON instead of human-readable text",
+    )
+
     return parser
 
 
@@ -755,6 +780,7 @@ def _normalize_argv(argv: list[str] | None) -> list[str]:
         "delete",
         "import",
         "project",
+        "issue",
     }:
         return raw
     # Backward-compatible behavior: previous root command maps to init.
@@ -1494,6 +1520,51 @@ def main(argv: list[str] | None = None) -> int:
                 f"{'Dry-run complete for' if ns.dry_run else 'Imported backlog to'}: {output_file}"
             )
         return 1 if apply_summary.failures > 0 else 0
+
+    if ns.mode == "issue" and ns.issue_command == "view":
+        target_repo, repo_error = _resolve_repo_from_args_or_env(
+            repo=ns.repo, fallback_name=None
+        )
+        if repo_error:
+            print(repo_error, file=sys.stderr)
+            return 2
+        assert target_repo is not None
+        try:
+            issue: IssueDetail = fetch_issue(
+                repo_dir=Path.cwd(),
+                repo=target_repo,
+                issue_number=ns.issue_number,
+            )
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        if ns.json_output:
+            import json as _json
+
+            print(
+                _json.dumps(
+                    {
+                        "number": issue.number,
+                        "title": issue.title,
+                        "body": issue.body,
+                        "labels": issue.labels,
+                        "assignees": issue.assignees,
+                        "state": issue.state,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Issue #{issue.number}: {issue.title}")
+            print(f"State: {issue.state}")
+            if issue.labels:
+                print(f"Labels: {', '.join(issue.labels)}")
+            if issue.assignees:
+                print(f"Assignees: {', '.join(issue.assignees)}")
+            if issue.body:
+                print("")
+                print(issue.body)
+        return 0
 
     parser.error("Unsupported command.")
     return 2

--- a/tests/test_backlog_ops.py
+++ b/tests/test_backlog_ops.py
@@ -798,3 +798,30 @@ def test_fetch_issue_auth_error_raises(
 
     with pytest.raises(RuntimeError, match="requires authentication"):
         backlog_ops.fetch_issue(repo_dir, "acme/repo", 1)
+
+
+def test_fetch_issue_rejects_pull_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    monkeypatch.setattr(backlog_ops, "_ensure_gh_auth", lambda repo_dir: None)
+    payload = json.dumps(
+        {
+            "number": 10,
+            "title": "Some PR",
+            "body": "PR body",
+            "state": "open",
+            "labels": [],
+            "assignees": [],
+            "pull_request": {"url": "https://api.github.com/repos/acme/repo/pulls/10"},
+        }
+    )
+    monkeypatch.setattr(
+        backlog_ops,
+        "_run_gh",
+        lambda repo_dir, args: _cp_ok(payload),
+    )
+
+    with pytest.raises(RuntimeError, match="pull request"):
+        backlog_ops.fetch_issue(repo_dir, "acme/repo", 10)

--- a/tests/test_backlog_ops.py
+++ b/tests/test_backlog_ops.py
@@ -723,3 +723,78 @@ def test_apply_backlog_requires_epic_body_and_key(
     assert summary.failures == 1
     assert errors
     assert "epic.key, epic.title, epic.body are required" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# fetch_issue tests
+# ---------------------------------------------------------------------------
+
+
+def _cp_err(stderr: str, stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=1, stdout=stdout, stderr=stderr
+    )
+
+
+def test_fetch_issue_returns_detail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    monkeypatch.setattr(backlog_ops, "_ensure_gh_auth", lambda repo_dir: None)
+    payload = json.dumps(
+        {
+            "number": 42,
+            "title": "Fix the bug",
+            "body": "Some body text.",
+            "state": "open",
+            "labels": [{"name": "bug"}, {"name": "high-priority"}],
+            "assignees": [{"login": "alice"}],
+        }
+    )
+    monkeypatch.setattr(
+        backlog_ops,
+        "_run_gh",
+        lambda repo_dir, args: _cp_ok(payload),
+    )
+
+    issue = backlog_ops.fetch_issue(repo_dir, "acme/repo", 42)
+
+    assert issue.number == 42
+    assert issue.title == "Fix the bug"
+    assert issue.body == "Some body text."
+    assert issue.state == "open"
+    assert issue.labels == ["bug", "high-priority"]
+    assert issue.assignees == ["alice"]
+
+
+def test_fetch_issue_not_found_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    monkeypatch.setattr(backlog_ops, "_ensure_gh_auth", lambda repo_dir: None)
+    monkeypatch.setattr(
+        backlog_ops,
+        "_run_gh",
+        lambda repo_dir, args: _cp_err("404 Not Found"),
+    )
+
+    with pytest.raises(RuntimeError, match="not found"):
+        backlog_ops.fetch_issue(repo_dir, "acme/repo", 999)
+
+
+def test_fetch_issue_auth_error_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    monkeypatch.setattr(backlog_ops, "_ensure_gh_auth", lambda repo_dir: None)
+    monkeypatch.setattr(
+        backlog_ops,
+        "_run_gh",
+        lambda repo_dir, args: _cp_err("requires authentication"),
+    )
+
+    with pytest.raises(RuntimeError, match="requires authentication"):
+        backlog_ops.fetch_issue(repo_dir, "acme/repo", 1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 import repo_scaffold.cli as cli_module
 
-from repo_scaffold.backlog_ops import BacklogApplySummary
+from repo_scaffold.backlog_ops import BacklogApplySummary, IssueDetail
 from repo_scaffold.create_ops import CreateSummary, SettingsCheckSummary
 from repo_scaffold.cli import main
 from repo_scaffold.delete_ops import DeleteSummary
@@ -55,6 +55,7 @@ def test_root_help_shows_all_modes(capsys: pytest.CaptureFixture[str]) -> None:
     assert "delete" in stdout
     assert "import" in stdout
     assert "project" in stdout
+    assert "issue" in stdout
 
 
 def test_seed_env_from_dotenv_promotes_project_token_when_gh_token_is_placeholder(
@@ -1655,3 +1656,98 @@ def test_project_delete_subcommand_delegates_to_project_ops(
     stdout = capsys.readouterr().out
     assert "backup file:" in stdout
     assert "undo: undo-cmd" in stdout
+
+
+# ---------------------------------------------------------------------------
+# issue view tests
+# ---------------------------------------------------------------------------
+
+
+def test_issue_view_human_readable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    fake_issue = IssueDetail(
+        number=42,
+        title="Fix the bug",
+        body="This is the body.",
+        state="open",
+        labels=["bug", "high-priority"],
+        assignees=["alice"],
+    )
+    monkeypatch.setattr(
+        "repo_scaffold.cli.fetch_issue",
+        lambda repo_dir, repo, issue_number: fake_issue,
+    )
+
+    rc = main(["issue", "view", "--repo", "acme/repo", "--issue-number", "42"])
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "Issue #42: Fix the bug" in stdout
+    assert "State: open" in stdout
+    assert "bug" in stdout
+    assert "high-priority" in stdout
+    assert "alice" in stdout
+    assert "This is the body." in stdout
+
+
+def test_issue_view_json_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+
+    monkeypatch.chdir(tmp_path)
+    fake_issue = IssueDetail(
+        number=7,
+        title="JSON issue",
+        body="Body text.",
+        state="closed",
+        labels=["wontfix"],
+        assignees=[],
+    )
+    monkeypatch.setattr(
+        "repo_scaffold.cli.fetch_issue",
+        lambda repo_dir, repo, issue_number: fake_issue,
+    )
+
+    rc = main(["issue", "view", "--repo", "acme/repo", "--issue-number", "7", "--json"])
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    data = json.loads(stdout)
+    assert data["number"] == 7
+    assert data["title"] == "JSON issue"
+    assert data["state"] == "closed"
+    assert data["labels"] == ["wontfix"]
+    assert data["assignees"] == []
+    assert data["body"] == "Body text."
+
+
+def test_issue_view_not_found_returns_1(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.fetch_issue",
+        lambda repo_dir, repo, issue_number: (_ for _ in ()).throw(
+            RuntimeError("Issue #999 not found in acme/repo.")
+        ),
+    )
+
+    rc = main(["issue", "view", "--repo", "acme/repo", "--issue-number", "999"])
+    assert rc == 1
+
+
+def test_issue_view_bad_repo_format_returns_2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = main(["issue", "view", "--repo", "not-valid", "--issue-number", "1"])
+    assert rc == 2


### PR DESCRIPTION
## 🧾 Title
feat(agent): Add issue detail query command

## 🧠 Description
Adds `repo-scaffold issue view --repo OWNER/REPO --issue-number N [--json]` so agents can read full issue details (title, body, labels, assignees, state) without requiring external `gh` invocations.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [x] Added/updated documentation

## 🎯 Purpose
Enables agents to read acceptance criteria and implementation notes directly from repo-scaffold.

## 🔗 Related Issues / Epics
- **Epic:** #48
- **Issue:** #84
- **Closes:** Fixes #84

## 🧪 Testing
1. `repo-scaffold issue view --repo blairg23/repo-scaffold --issue-number 84` — human-readable
2. Add `--json` flag — structured JSON output
3. Pass missing issue number — clean error message
4. `pytest tests/test_cli.py tests/test_backlog_ops.py` — all 65 pass

## 🧰 Developer Notes
- `IssueDetail` dataclass and `fetch_issue` added to backlog_ops.py using existing `_run_gh` pattern
- JSON output: `{number, title, body, labels, assignees, state}`