### PR TITLE
feat(core): replace gh CLI shell-outs with direct GitHub API via urllib (#91)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Golden rule: use repo-scaffold for everything GitHub
 
-**Never use PowerShell + `gh.exe` directly.** Always use `poetry run repo-scaffold` commands (via Bash/WSL). The CLI wraps `gh` internally with proper auth from `.env`.
+**Never use PowerShell + `gh.exe` directly.** Always use `poetry run repo-scaffold` commands (via Bash/WSL). The CLI should NEVER require `gh` on the PATH — it must use GH_TOKEN/GitHub API directly for all operations.
 
 ## Available commands
 
@@ -26,7 +26,10 @@ poetry run repo-scaffold apply ci --path . --languages go,gin,python,react
 poetry run repo-scaffold apply templates --path . --name NAME --owner OWNER
 
 # Repo management
-poetry run repo-scaffold create --repo OWNER/REPO
+# Both flows use the same command — create handles git init + initial commit internally:
+# New project OR existing local code with no .git:
+poetry run repo-scaffold create --repo OWNER/REPO --visibility public --path /path/to/code
+
 poetry run repo-scaffold check rules --repo OWNER/REPO
 ```
 
@@ -39,7 +42,7 @@ poetry run repo-scaffold check rules --repo OWNER/REPO
 ## GitHub auth
 Token lives in `.env` as `GH_TOKEN`. Commands pick it up automatically via `_seed_env_from_dotenv`.
 
-## Still missing (potential future tickets)
+## Still missing (file tickets, do NOT work around with gh/PS)
 - `repo-scaffold pr list`
 - `repo-scaffold pr create`
 - `repo-scaffold pr comment --reply-to <id>`

--- a/src/repo_scaffold/backlog_ops.py
+++ b/src/repo_scaffold/backlog_ops.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import shutil
 import subprocess
 import tempfile
 import time
@@ -12,6 +11,20 @@ from pathlib import Path
 from typing import Callable
 
 from .auth_tokens import is_placeholder_token, resolve_gh_token
+from .github_api import (
+    issue_node_id,
+    project_create,
+    project_delete,
+    project_edit,
+    project_item_add,
+    project_item_delete,
+    project_item_list,
+    project_list,
+    project_view,
+    rest,
+    rest_paginated,
+    token_from_repo,
+)
 from .project_metadata import write_project_metadata
 
 
@@ -395,9 +408,6 @@ def _load_token_from_env_file(env_file: Path) -> None:
 
 
 def _ensure_gh_auth(repo_dir: Path) -> None:
-    if shutil.which("gh") is None:
-        raise RuntimeError("GitHub CLI (gh) is required.")
-
     for env_file in (Path.cwd() / ".env", repo_dir / ".env"):
         _load_token_from_env_file(env_file)
     resolved_token = resolve_gh_token(os.environ)
@@ -407,31 +417,336 @@ def _ensure_gh_auth(repo_dir: Path) -> None:
     ):
         os.environ["GH_TOKEN"] = resolved_token
 
-    if os.environ.get("GH_TOKEN") and not is_placeholder_token(os.environ["GH_TOKEN"]):
+    token = os.environ.get("GH_TOKEN")
+    if token and not is_placeholder_token(token):
         return
 
-    status = subprocess.run(
-        ["gh", "auth", "status"],
-        cwd=repo_dir,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-        text=True,
+    raise RuntimeError(
+        "Authenticate first: set GH_TOKEN/GITHUB_TOKEN or github_token in .env."
     )
-    if status.returncode != 0:
+
+
+def _get_token(repo_dir: Path) -> str:
+    token = token_from_repo(repo_dir)
+    if not token or is_placeholder_token(token):
         raise RuntimeError(
-            "Authenticate first: gh auth login (or set GH_TOKEN/GITHUB_TOKEN or github_token in .env)."
+            "Authenticate first: set GH_TOKEN/GITHUB_TOKEN or github_token in .env."
         )
+    return token
 
 
 def _run_gh(repo_dir: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["gh", *args],
-        cwd=repo_dir,
-        text=True,
-        capture_output=True,
-        check=False,
+    """Route gh CLI args to direct GitHub API calls — no gh binary required."""
+    token = token_from_repo(repo_dir) or ""
+
+    if not args:
+        return subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="Empty gh args."
+        )
+
+    subcmd = args[0]
+
+    # ---- REST API calls: gh api [--paginate] [--method M] endpoint [-f k=v ...] ----
+    if subcmd == "api":
+        rest_args = args[1:]
+        paginate = "--paginate" in rest_args
+        if paginate:
+            rest_args = [a for a in rest_args if a != "--paginate"]
+
+        method = "GET"
+        endpoint = ""
+        fields: dict[str, str] = {}
+        skip_next = False
+        positional: list[str] = []
+
+        i = 0
+        while i < len(rest_args):
+            a = rest_args[i]
+            if skip_next:
+                skip_next = False
+                i += 1
+                continue
+            if a in ("--method", "-X") and i + 1 < len(rest_args):
+                method = rest_args[i + 1]
+                i += 2
+                continue
+            if a in ("-f", "--field") and i + 1 < len(rest_args):
+                kv = rest_args[i + 1]
+                if "=" in kv:
+                    k, v = kv.split("=", 1)
+                    fields[k] = v
+                i += 2
+                continue
+            if a in ("--input", "-") and i + 1 < len(rest_args):
+                # skip --input - (we don't support stdin piping here)
+                i += 2
+                continue
+            if not a.startswith("-"):
+                positional.append(a)
+            i += 1
+
+        endpoint = positional[0] if positional else ""
+
+        if paginate:
+            return rest_paginated(endpoint, token)
+        if fields:
+            return rest(method, endpoint, token, fields)
+        return rest(method, endpoint, token)
+
+    # ---- gh issue create ----
+    if subcmd == "issue" and len(args) > 1 and args[1] == "create":
+        return _gh_issue_create(args[2:], token)
+
+    # ---- gh project subcommands ----
+    if subcmd == "project":
+        return _gh_project(args[1:], repo_dir, token)
+
+    return subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr=f"Unsupported gh subcommand: {subcmd}"
     )
+
+
+def _gh_issue_create(args: list[str], token: str) -> subprocess.CompletedProcess[str]:
+    repo = title = body_file = milestone = labels = assignees = None
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--repo" and i + 1 < len(args):
+            repo = args[i + 1]
+            i += 2
+            continue
+        if a == "--title" and i + 1 < len(args):
+            title = args[i + 1]
+            i += 2
+            continue
+        if a == "--body-file" and i + 1 < len(args):
+            body_file = args[i + 1]
+            i += 2
+            continue
+        if a == "--milestone" and i + 1 < len(args):
+            milestone = args[i + 1]
+            i += 2
+            continue
+        if a == "--label" and i + 1 < len(args):
+            labels = args[i + 1]
+            i += 2
+            continue
+        if a == "--assignee" and i + 1 < len(args):
+            assignees = args[i + 1]
+            i += 2
+            continue
+        i += 1
+
+    if not repo or not title:
+        return subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="--repo and --title are required."
+        )
+
+    body = ""
+    if body_file:
+        try:
+            body = Path(body_file).read_text(encoding="utf-8")
+        except OSError:
+            pass
+
+    payload: dict[str, object] = {"title": title, "body": body}
+    if labels:
+        label_list = [lb.strip() for lb in labels.split(",") if lb.strip()]
+        if label_list:
+            payload["labels"] = label_list
+    if assignees:
+        assignee_list = [a.strip() for a in assignees.split(",") if a.strip()]
+        if assignee_list:
+            payload["assignees"] = assignee_list
+    if milestone:
+        # resolve milestone number
+        owner_repo = repo
+        ms_cp = rest_paginated(
+            f"/repos/{owner_repo}/milestones?state=all&per_page=100", token
+        )
+        if ms_cp.returncode == 0:
+            try:
+                for ms in json.loads(ms_cp.stdout):
+                    if isinstance(ms, dict) and ms.get("title") == milestone:
+                        payload["milestone"] = ms["number"]
+                        break
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+    cp = rest("POST", f"/repos/{repo}/issues", token, payload)
+    if cp.returncode not in (200, 201):
+        return cp
+    try:
+        url = json.loads(cp.stdout).get("html_url", "")
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=url + "\n", stderr=""
+        )
+    except (json.JSONDecodeError, AttributeError):
+        return cp
+
+
+def _gh_project(
+    args: list[str], repo_dir: Path, token: str
+) -> subprocess.CompletedProcess[str]:
+    if not args:
+        return subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="Missing project subcommand."
+        )
+
+    sub = args[0]
+    rest_args = args[1:]
+
+    def _get(flag: str) -> str | None:
+        try:
+            idx = rest_args.index(flag)
+            return rest_args[idx + 1] if idx + 1 < len(rest_args) else None
+        except ValueError:
+            return None
+
+    owner = _get("--owner") or ""
+    number_str = (
+        rest_args[0] if rest_args and not rest_args[0].startswith("-") else None
+    )
+    number = int(number_str) if number_str and number_str.isdigit() else None
+
+    if sub == "list":
+        include_closed = "--closed" in rest_args
+        return project_list(owner, token, include_closed=include_closed)
+
+    if sub == "view":
+        if number is None:
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Project number required."
+            )
+        return project_view(owner, number, token)
+
+    if sub == "create":
+        title = _get("--title") or ""
+        return project_create(owner, title, token)
+
+    if sub == "edit":
+        if number is None:
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Project number required."
+            )
+        # Get project ID first
+        pv = project_view(owner, number, token)
+        if pv.returncode != 0:
+            return pv
+        try:
+            project_id = json.loads(pv.stdout).get("id", "")
+        except (json.JSONDecodeError, AttributeError):
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Could not resolve project ID."
+            )
+        visibility = _get("--visibility")
+        return project_edit(
+            project_id,
+            token,
+            title=_get("--title"),
+            description=_get("--description"),
+            readme=_get("--readme"),
+            visibility=visibility,
+        )
+
+    if sub == "delete":
+        if number is None:
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Project number required."
+            )
+        pv = project_view(owner, number, token)
+        if pv.returncode != 0:
+            return pv
+        try:
+            project_id = json.loads(pv.stdout).get("id", "")
+        except (json.JSONDecodeError, AttributeError):
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Could not resolve project ID."
+            )
+        return project_delete(project_id, token)
+
+    if sub == "item-list":
+        if number is None:
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Project number required."
+            )
+        limit_str = _get("--limit")
+        limit = int(limit_str) if limit_str and limit_str.isdigit() else 100
+        pv = project_view(owner, number, token)
+        if pv.returncode != 0:
+            return pv
+        try:
+            project_id = json.loads(pv.stdout).get("id", "")
+        except (json.JSONDecodeError, AttributeError):
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Could not resolve project ID."
+            )
+        return project_item_list(project_id, token, limit=limit)
+
+    if sub == "item-add":
+        if number is None:
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Project number required."
+            )
+        url = _get("--url") or ""
+        # Extract issue number and repo from URL
+        # e.g. https://github.com/owner/repo/issues/42
+        content_id = _resolve_content_node_id(url, token)
+        if not content_id:
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr=f"Could not resolve content ID for: {url}",
+            )
+        pv = project_view(owner, number, token)
+        if pv.returncode != 0:
+            return pv
+        try:
+            project_id = json.loads(pv.stdout).get("id", "")
+        except (json.JSONDecodeError, AttributeError):
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Could not resolve project ID."
+            )
+        return project_item_add(project_id, content_id, token)
+
+    if sub == "item-delete":
+        if number is None:
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Project number required."
+            )
+        item_id = _get("--id") or ""
+        pv = project_view(owner, number, token)
+        if pv.returncode != 0:
+            return pv
+        try:
+            project_id = json.loads(pv.stdout).get("id", "")
+        except (json.JSONDecodeError, AttributeError):
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Could not resolve project ID."
+            )
+        return project_item_delete(project_id, item_id, token)
+
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=1,
+        stdout="",
+        stderr=f"Unsupported project subcommand: {sub}",
+    )
+
+
+def _resolve_content_node_id(url: str, token: str) -> str | None:
+    """Extract issue/PR node ID from a GitHub URL."""
+    # https://github.com/owner/repo/issues/42
+    parts = url.rstrip("/").split("/")
+    try:
+        idx = parts.index("issues") if "issues" in parts else parts.index("pull")
+        number = int(parts[idx + 1])
+        repo_owner = parts[idx - 2]
+        repo_name = parts[idx - 1]
+    except (ValueError, IndexError):
+        return None
+    return issue_node_id(repo_owner, repo_name, number, token)
 
 
 def _parse_concatenated_json_arrays(raw: str) -> list[dict[str, object]]:

--- a/src/repo_scaffold/backlog_ops.py
+++ b/src/repo_scaffold/backlog_ops.py
@@ -13,6 +13,7 @@ from typing import Callable
 from .auth_tokens import is_placeholder_token, resolve_gh_token
 from .github_api import (
     issue_node_id,
+    link_project_to_repository,
     project_create,
     project_delete,
     project_edit,
@@ -726,6 +727,31 @@ def _gh_project(
                 args=[], returncode=1, stdout="", stderr="Could not resolve project ID."
             )
         return project_item_delete(project_id, item_id, token)
+
+    if sub == "link":
+        if number is None:
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Project number required."
+            )
+        repo = _get("--repo") or ""
+        pv = project_view(owner, number, token)
+        if pv.returncode != 0:
+            return pv
+        try:
+            project_id = json.loads(pv.stdout).get("id", "")
+        except (json.JSONDecodeError, AttributeError):
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Could not resolve project ID."
+            )
+        repo_owner, _, repo_name = repo.partition("/")
+        cp = link_project_to_repository(project_id, repo_owner, repo_name, token)
+        if cp.returncode != 0:
+            stderr = (cp.stderr or "").lower()
+            if "already" in stderr and "link" in stderr:
+                return subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout="already linked", stderr=""
+                )
+        return cp
 
     return subprocess.CompletedProcess(
         args=[],

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -934,6 +934,9 @@ def _create_or_push_repo(
                 cp.stderr.strip() or f"Failed creating repository: {repo}",
             )
 
+        _ensure_origin_remote(
+            repo_dir=repo_dir, env=env, repo=repo, dry_run=False, out=out
+        )
         out("push main to origin")
         pushed, push_error = _push_main(repo_dir=repo_dir, env=env)
         if not pushed:

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -11,6 +11,11 @@ from typing import Callable
 from urllib.parse import quote
 
 from .auth_tokens import is_placeholder_token, resolve_gh_token
+from .github_api import (
+    repo_create as _github_repo_create,
+    rest as _github_rest,
+    token_from_repo as _token_from_repo,
+)
 
 
 @dataclass(frozen=True)
@@ -49,12 +54,7 @@ def _is_managed_ruleset_name(name: object) -> bool:
 
 
 def _api_headers() -> list[str]:
-    return [
-        "-H",
-        "Accept: application/vnd.github+json",
-        "-H",
-        f"X-GitHub-Api-Version: {_API_VERSION}",
-    ]
+    return []  # kept for any residual callers; not used by _api anymore
 
 
 def _repo_patch_payload() -> str:
@@ -207,10 +207,14 @@ def _api(
     endpoint: str,
     stdin_text: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    args = ["gh", "api", "--method", method, *_api_headers(), endpoint]
-    if stdin_text is not None:
-        args.extend(["--input", "-"])
-    return _run(args, cwd=repo_dir, env=env, stdin_text=stdin_text)
+    token = (
+        _token_from_repo(repo_dir)
+        or env.get("GH_TOKEN")
+        or env.get("GITHUB_TOKEN")
+        or ""
+    )
+    data = json.loads(stdin_text) if stdin_text else None
+    return _github_rest(method, endpoint, token, data)
 
 
 def _load_json(text: str, *, error_message: str) -> object:
@@ -596,21 +600,17 @@ def _compare_ruleset_against_baseline(
 
 
 def _ensure_tools() -> None:
-    if shutil.which("gh") is None:
-        raise RuntimeError("GitHub CLI (gh) is required.")
     if shutil.which("git") is None:
         raise RuntimeError("git is required.")
 
 
 def _ensure_gh_auth(repo_dir: Path, env: dict[str, str]) -> None:
-    if env.get("GH_TOKEN"):
+    token = _token_from_repo(repo_dir) or env.get("GH_TOKEN") or env.get("GITHUB_TOKEN")
+    if token and not is_placeholder_token(token):
         return
-
-    cp = _run(["gh", "auth", "status"], cwd=repo_dir, env=env)
-    if cp.returncode != 0:
-        raise RuntimeError(
-            "Authenticate first: gh auth login (or set GH_TOKEN/GITHUB_TOKEN; legacy alias github_token is supported)."
-        )
+    raise RuntimeError(
+        "Authenticate first: set GH_TOKEN/GITHUB_TOKEN or github_token in .env."
+    )
 
 
 def _resolve_repo(
@@ -734,14 +734,19 @@ def _ensure_git_repo(
 
 
 def _repo_exists(*, repo_dir: Path, env: dict[str, str], repo: str) -> bool:
-    cp = _run(
-        ["gh", "repo", "view", repo, "--json", "nameWithOwner"], cwd=repo_dir, env=env
+    token = (
+        _token_from_repo(repo_dir)
+        or env.get("GH_TOKEN")
+        or env.get("GITHUB_TOKEN")
+        or ""
     )
-    if cp.returncode == 0:
+    cp = _github_rest("GET", f"/repos/{repo}", token)
+    if cp.returncode == 200 or cp.returncode == 0:
         return True
-
+    if cp.returncode == 404:
+        return False
     stderr = (cp.stderr or "").lower()
-    not_found_markers = ("not found", "http 404", "could not resolve to a repository")
+    not_found_markers = ("not found", "404")
     if any(marker in stderr for marker in not_found_markers):
         return False
     raise RuntimeError(cp.stderr.strip() or f"Failed checking repository: {repo}")
@@ -787,15 +792,8 @@ def _ensure_origin_remote(
 
 
 def _resolve_push_token(*, repo_dir: Path, env: dict[str, str]) -> str | None:
-    token = env.get("GH_TOKEN")
-    if token:
-        return token
-
-    cp = _run(["gh", "auth", "token"], cwd=repo_dir, env=env)
-    if cp.returncode != 0:
-        return None
-    resolved = cp.stdout.strip()
-    return resolved or None
+    token = _token_from_repo(repo_dir) or env.get("GH_TOKEN") or env.get("GITHUB_TOKEN")
+    return token or None
 
 
 def _push_main(*, repo_dir: Path, env: dict[str, str]) -> tuple[bool, str | None]:
@@ -921,22 +919,15 @@ def _create_or_push_repo(
 
     out(f"{'[dry-run] ' if dry_run else ''}create repository: {repo} ({visibility})")
     if not dry_run:
-        cp = _run(
-            [
-                "gh",
-                "repo",
-                "create",
-                repo,
-                f"--{visibility}",
-                "--source",
-                str(repo_dir),
-                "--remote",
-                "origin",
-            ],
-            cwd=repo_dir,
-            env=env,
+        token = (
+            _token_from_repo(repo_dir)
+            or env.get("GH_TOKEN")
+            or env.get("GITHUB_TOKEN")
+            or ""
         )
-        if cp.returncode != 0:
+        owner, name = repo.split("/", 1)
+        cp = _github_repo_create(owner, name, token, visibility=visibility)
+        if cp.returncode not in (0, 201):
             return (
                 False,
                 False,

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -188,7 +188,7 @@ def resolve_owner_node_id(owner: str, token: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 _GQL_LIST_PROJECTS = """
-query($login: String!, $first: Int!, $after: String, $includeClosed: Boolean!) {
+query($login: String!, $first: Int!, $after: String) {
   user(login: $login) {
     projectsV2(
       first: $first
@@ -206,7 +206,7 @@ query($login: String!, $first: Int!, $after: String, $includeClosed: Boolean!) {
 """
 
 _GQL_LIST_PROJECTS_ORG = """
-query($login: String!, $first: Int!, $after: String, $includeClosed: Boolean!) {
+query($login: String!, $first: Int!, $after: String) {
   organization(login: $login) {
     projectsV2(
       first: $first
@@ -366,12 +366,7 @@ def project_list(
         while True:
             cp = graphql(
                 query,
-                {
-                    "login": owner,
-                    "first": 100,
-                    "after": after,
-                    "includeClosed": include_closed,
-                },
+                {"login": owner, "first": 100, "after": after},
                 token,
             )
             if cp.returncode != 0:
@@ -551,6 +546,51 @@ def project_item_delete(
 ) -> subprocess.CompletedProcess[str]:
     return graphql(
         _GQL_DELETE_ITEM, {"projectId": project_id, "itemId": item_id}, token
+    )
+
+
+# ---------------------------------------------------------------------------
+# Link project to repository
+# ---------------------------------------------------------------------------
+
+_GQL_LINK_PROJECT = """
+mutation($projectId: ID!, $repositoryId: ID!) {
+  linkProjectV2ToRepository(input: {projectId: $projectId, repositoryId: $repositoryId}) {
+    repository { id }
+  }
+}
+"""
+
+_GQL_REPO_NODE_ID = """
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) { id }
+}
+"""
+
+
+def repo_node_id(owner: str, repo: str, token: str) -> str | None:
+    cp = graphql(_GQL_REPO_NODE_ID, {"owner": owner, "repo": repo}, token)
+    if cp.returncode != 0:
+        return None
+    try:
+        return json.loads(cp.stdout).get("repository", {}).get("id")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
+def link_project_to_repository(
+    project_id: str,
+    owner: str,
+    repo: str,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    repository_id = repo_node_id(owner, repo, token)
+    if not repository_id:
+        return _err(f"Could not resolve node ID for repository {owner}/{repo}.")
+    return graphql(
+        _GQL_LINK_PROJECT,
+        {"projectId": project_id, "repositoryId": repository_id},
+        token,
     )
 
 

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1,0 +1,672 @@
+"""OS-agnostic GitHub API client — no gh CLI required.
+
+All operations use urllib (stdlib) + GH_TOKEN. Works on Windows, macOS, and
+Linux without the gh binary installed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+_GITHUB_API = "https://api.github.com"
+_GITHUB_GRAPHQL = "https://api.github.com/graphql"
+_API_VERSION = "2022-11-28"
+
+
+# ---------------------------------------------------------------------------
+# Compatibility shim — callers expect subprocess.CompletedProcess[str]
+# ---------------------------------------------------------------------------
+
+
+def _ok(stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _err(stderr: str, returncode: int = 1) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout="", stderr=stderr
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_token(env: dict[str, str] | None = None) -> str | None:
+    src = env if env is not None else dict(os.environ)
+    return src.get("GH_TOKEN") or src.get("GITHUB_TOKEN") or src.get("github_token")
+
+
+# ---------------------------------------------------------------------------
+# Low-level HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": _API_VERSION,
+        "Content-Type": "application/json",
+    }
+
+
+def _http(
+    method: str,
+    url: str,
+    token: str,
+    data: object = None,
+) -> subprocess.CompletedProcess[str]:
+    body = json.dumps(data).encode() if data is not None else None
+    req = urllib.request.Request(url, data=body, headers=_headers(token), method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return _ok(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8") if exc.fp else ""
+        return _err(raw or str(exc), returncode=exc.code)
+    except urllib.error.URLError as exc:
+        return _err(str(exc))
+
+
+def _parse_next_link(link_header: str) -> str | None:
+    for part in link_header.split(","):
+        segments = part.strip().split(";")
+        if len(segments) < 2:
+            continue
+        url_part = segments[0].strip().strip("<>")
+        if any('rel="next"' in seg for seg in segments[1:]):
+            return url_part
+    return None
+
+
+# ---------------------------------------------------------------------------
+# REST API
+# ---------------------------------------------------------------------------
+
+
+def rest(
+    method: str,
+    endpoint: str,
+    token: str,
+    data: object = None,
+) -> subprocess.CompletedProcess[str]:
+    url = f"{_GITHUB_API}{endpoint}"
+    return _http(method, url, token, data)
+
+
+def rest_paginated(endpoint: str, token: str) -> subprocess.CompletedProcess[str]:
+    """Fetch all pages and return concatenated JSON arrays."""
+    all_items: list[object] = []
+    url: str | None = f"{_GITHUB_API}{endpoint}"
+    while url:
+        req = urllib.request.Request(url, headers=_headers(token), method="GET")
+        try:
+            with urllib.request.urlopen(req) as resp:
+                page = json.loads(resp.read().decode("utf-8"))
+                if isinstance(page, list):
+                    all_items.extend(page)
+                link = resp.headers.get("Link", "")
+                url = _parse_next_link(link)
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode("utf-8") if exc.fp else ""
+            return _err(raw or str(exc), returncode=exc.code)
+        except urllib.error.URLError as exc:
+            return _err(str(exc))
+    return _ok(json.dumps(all_items))
+
+
+# ---------------------------------------------------------------------------
+# GraphQL API
+# ---------------------------------------------------------------------------
+
+
+def graphql(
+    query: str,
+    variables: dict[str, object],
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    cp = _http("POST", _GITHUB_GRAPHQL, token, {"query": query, "variables": variables})
+    if cp.returncode != 0:
+        return cp
+    try:
+        payload = json.loads(cp.stdout)
+    except json.JSONDecodeError:
+        return _err("GraphQL response was not valid JSON.")
+    if "errors" in payload:
+        msgs = "; ".join(e.get("message", "") for e in payload["errors"])
+        return _err(msgs)
+    return _ok(json.dumps(payload.get("data", {})))
+
+
+# ---------------------------------------------------------------------------
+# Owner ID (needed for project creation)
+# ---------------------------------------------------------------------------
+
+_GQL_OWNER_ID = """
+query($login: String!) {
+  user(login: $login) { id }
+}
+"""
+
+_GQL_ORG_ID = """
+query($login: String!) {
+  organization(login: $login) { id }
+}
+"""
+
+
+def resolve_owner_node_id(owner: str, token: str) -> str | None:
+    cp = graphql(_GQL_OWNER_ID, {"login": owner}, token)
+    if cp.returncode == 0:
+        try:
+            node_id = json.loads(cp.stdout).get("user", {}).get("id")
+            if node_id:
+                return node_id
+        except (json.JSONDecodeError, AttributeError):
+            pass
+    cp = graphql(_GQL_ORG_ID, {"login": owner}, token)
+    if cp.returncode == 0:
+        try:
+            node_id = json.loads(cp.stdout).get("organization", {}).get("id")
+            if node_id:
+                return node_id
+        except (json.JSONDecodeError, AttributeError):
+            pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# GitHub Projects v2 — GraphQL queries / mutations
+# ---------------------------------------------------------------------------
+
+_GQL_LIST_PROJECTS = """
+query($login: String!, $first: Int!, $after: String, $includeClosed: Boolean!) {
+  user(login: $login) {
+    projectsV2(
+      first: $first
+      after: $after
+      orderBy: {field: UPDATED_AT, direction: DESC}
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id number title closed url
+        visibility shortDescription readme
+      }
+    }
+  }
+}
+"""
+
+_GQL_LIST_PROJECTS_ORG = """
+query($login: String!, $first: Int!, $after: String, $includeClosed: Boolean!) {
+  organization(login: $login) {
+    projectsV2(
+      first: $first
+      after: $after
+      orderBy: {field: UPDATED_AT, direction: DESC}
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id number title closed url
+        visibility shortDescription readme
+      }
+    }
+  }
+}
+"""
+
+_GQL_VIEW_PROJECT = """
+query($login: String!, $number: Int!) {
+  user(login: $login) {
+    projectV2(number: $number) {
+      id number title closed url
+      visibility shortDescription readme
+    }
+  }
+}
+"""
+
+_GQL_VIEW_PROJECT_ORG = """
+query($login: String!, $number: Int!) {
+  organization(login: $login) {
+    projectV2(number: $number) {
+      id number title closed url
+      visibility shortDescription readme
+    }
+  }
+}
+"""
+
+_GQL_CREATE_PROJECT = """
+mutation($ownerId: ID!, $title: String!) {
+  createProjectV2(input: {ownerId: $ownerId, title: $title}) {
+    projectV2 {
+      id number title closed url visibility shortDescription readme
+    }
+  }
+}
+"""
+
+_GQL_UPDATE_PROJECT = """
+mutation(
+  $projectId: ID!
+  $title: String
+  $description: String
+  $readme: String
+  $public: Boolean
+) {
+  updateProjectV2(input: {
+    projectId: $projectId
+    title: $title
+    shortDescription: $description
+    readme: $readme
+    public: $public
+  }) {
+    projectV2 {
+      id number title closed url visibility shortDescription readme
+    }
+  }
+}
+"""
+
+_GQL_DELETE_PROJECT = """
+mutation($projectId: ID!) {
+  deleteProjectV2(input: {projectId: $projectId}) {
+    projectV2 { id }
+  }
+}
+"""
+
+_GQL_LIST_ITEMS = """
+query($projectId: ID!, $first: Int!, $after: String) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: $first, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          content {
+            ... on Issue {
+              number title state url
+              labels(first: 10) { nodes { name } }
+              assignees(first: 5) { nodes { login } }
+            }
+            ... on PullRequest { number title state url }
+            ... on DraftIssue { title body }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_GQL_ADD_ITEM = """
+mutation($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+    item { id }
+  }
+}
+"""
+
+_GQL_DELETE_ITEM = """
+mutation($projectId: ID!, $itemId: ID!) {
+  deleteProjectV2Item(input: {projectId: $projectId, itemId: $itemId}) {
+    deletedItemId
+  }
+}
+"""
+
+
+def _project_nodes_from_data(data: dict[str, object]) -> list[dict[str, object]]:
+    for key in ("user", "organization"):
+        owner_obj = data.get(key)
+        if not isinstance(owner_obj, dict):
+            continue
+        projects = owner_obj.get("projectsV2")
+        if not isinstance(projects, dict):
+            continue
+        nodes = projects.get("nodes")
+        if isinstance(nodes, list):
+            return [n for n in nodes if isinstance(n, dict)]
+    return []
+
+
+def _project_page_info(data: dict[str, object]) -> dict[str, object]:
+    for key in ("user", "organization"):
+        owner_obj = data.get(key)
+        if not isinstance(owner_obj, dict):
+            continue
+        projects = owner_obj.get("projectsV2")
+        if isinstance(projects, dict):
+            pi = projects.get("pageInfo")
+            if isinstance(pi, dict):
+                return pi
+    return {}
+
+
+def project_list(
+    owner: str,
+    token: str,
+    include_closed: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    all_nodes: list[dict[str, object]] = []
+    after: str | None = None
+
+    for query in (_GQL_LIST_PROJECTS, _GQL_LIST_PROJECTS_ORG):
+        after = None
+        while True:
+            cp = graphql(
+                query,
+                {
+                    "login": owner,
+                    "first": 100,
+                    "after": after,
+                    "includeClosed": include_closed,
+                },
+                token,
+            )
+            if cp.returncode != 0:
+                break
+            try:
+                data = json.loads(cp.stdout)
+            except json.JSONDecodeError:
+                break
+            nodes = _project_nodes_from_data(data)
+            all_nodes.extend(nodes)
+            pi = _project_page_info(data)
+            if pi.get("hasNextPage"):
+                after = str(pi.get("endCursor", ""))
+            else:
+                break
+        if all_nodes:
+            break
+
+    if not include_closed:
+        all_nodes = [n for n in all_nodes if not n.get("closed", False)]
+
+    payload = {"projects": all_nodes, "totalCount": len(all_nodes)}
+    return _ok(json.dumps(payload))
+
+
+def _project_from_graphql(data: dict[str, object]) -> dict[str, object] | None:
+    for key in ("user", "organization"):
+        owner_obj = data.get(key)
+        if not isinstance(owner_obj, dict):
+            continue
+        proj = owner_obj.get("projectV2")
+        if isinstance(proj, dict):
+            return proj
+    return None
+
+
+def project_view(
+    owner: str,
+    number: int,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    for query in (_GQL_VIEW_PROJECT, _GQL_VIEW_PROJECT_ORG):
+        cp = graphql(query, {"login": owner, "number": number}, token)
+        if cp.returncode != 0:
+            continue
+        try:
+            data = json.loads(cp.stdout)
+        except json.JSONDecodeError:
+            continue
+        proj = _project_from_graphql(data)
+        if proj:
+            return _ok(json.dumps(proj))
+    return _err(f"Project #{number} not found for owner {owner!r}.")
+
+
+def project_create(
+    owner: str,
+    title: str,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    owner_id = resolve_owner_node_id(owner, token)
+    if not owner_id:
+        return _err(f"Could not resolve node ID for owner {owner!r}.")
+    cp = graphql(_GQL_CREATE_PROJECT, {"ownerId": owner_id, "title": title}, token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        data = json.loads(cp.stdout)
+        proj = data.get("createProjectV2", {}).get("projectV2")
+        if isinstance(proj, dict):
+            return _ok(json.dumps(proj))
+    except (json.JSONDecodeError, AttributeError):
+        pass
+    return _err("Unexpected response creating project.")
+
+
+def project_edit(
+    project_id: str,
+    token: str,
+    title: str | None = None,
+    description: str | None = None,
+    readme: str | None = None,
+    visibility: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    public: bool | None = None
+    if visibility is not None:
+        public = visibility.upper() == "PUBLIC"
+    cp = graphql(
+        _GQL_UPDATE_PROJECT,
+        {
+            "projectId": project_id,
+            "title": title,
+            "description": description,
+            "readme": readme,
+            "public": public,
+        },
+        token,
+    )
+    if cp.returncode != 0:
+        return cp
+    try:
+        data = json.loads(cp.stdout)
+        proj = data.get("updateProjectV2", {}).get("projectV2")
+        if isinstance(proj, dict):
+            return _ok(json.dumps(proj))
+    except (json.JSONDecodeError, AttributeError):
+        pass
+    return _err("Unexpected response updating project.")
+
+
+def project_delete(project_id: str, token: str) -> subprocess.CompletedProcess[str]:
+    return graphql(_GQL_DELETE_PROJECT, {"projectId": project_id}, token)
+
+
+def project_item_list(
+    project_id: str,
+    token: str,
+    limit: int = 100,
+) -> subprocess.CompletedProcess[str]:
+    all_items: list[dict[str, object]] = []
+    after: str | None = None
+    while len(all_items) < limit:
+        fetch = min(100, limit - len(all_items))
+        cp = graphql(
+            _GQL_LIST_ITEMS,
+            {"projectId": project_id, "first": fetch, "after": after},
+            token,
+        )
+        if cp.returncode != 0:
+            return cp
+        try:
+            data = json.loads(cp.stdout)
+            node = data.get("node", {})
+            if not isinstance(node, dict):
+                break
+            items_obj = node.get("items", {})
+            nodes = items_obj.get("nodes", [])
+            if isinstance(nodes, list):
+                all_items.extend(n for n in nodes if isinstance(n, dict))
+            pi = items_obj.get("pageInfo", {})
+            if pi.get("hasNextPage"):
+                after = str(pi.get("endCursor", ""))
+            else:
+                break
+        except (json.JSONDecodeError, AttributeError):
+            break
+    payload = {"items": all_items, "totalCount": len(all_items)}
+    return _ok(json.dumps(payload))
+
+
+def project_item_add(
+    project_id: str,
+    content_node_id: str,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    cp = graphql(
+        _GQL_ADD_ITEM,
+        {"projectId": project_id, "contentId": content_node_id},
+        token,
+    )
+    if cp.returncode != 0:
+        return cp
+    try:
+        data = json.loads(cp.stdout)
+        item = data.get("addProjectV2ItemById", {}).get("item")
+        if isinstance(item, dict):
+            return _ok(json.dumps(item))
+    except (json.JSONDecodeError, AttributeError):
+        pass
+    return _err("Unexpected response adding project item.")
+
+
+def project_item_delete(
+    project_id: str,
+    item_id: str,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    return graphql(
+        _GQL_DELETE_ITEM, {"projectId": project_id, "itemId": item_id}, token
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue node ID (needed for adding issues to projects)
+# ---------------------------------------------------------------------------
+
+_GQL_ISSUE_NODE_ID = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) { id }
+  }
+}
+"""
+
+
+def issue_node_id(owner: str, repo: str, number: int, token: str) -> str | None:
+    cp = graphql(
+        _GQL_ISSUE_NODE_ID, {"owner": owner, "repo": repo, "number": number}, token
+    )
+    if cp.returncode != 0:
+        return None
+    try:
+        return json.loads(cp.stdout).get("repository", {}).get("issue", {}).get("id")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Repo creation
+# ---------------------------------------------------------------------------
+
+
+def repo_create(
+    owner: str,
+    name: str,
+    token: str,
+    visibility: str = "private",
+) -> subprocess.CompletedProcess[str]:
+    """Create a GitHub repo via REST API. Returns the created repo JSON."""
+    is_org = _is_org(owner, token)
+    if is_org:
+        endpoint = f"/orgs/{owner}/repos"
+    else:
+        endpoint = "/user/repos"
+
+    payload = {
+        "name": name,
+        "private": visibility.lower() != "public",
+        "auto_init": False,
+    }
+    return rest("POST", endpoint, token, payload)
+
+
+def _is_org(owner: str, token: str) -> bool:
+    cp = rest("GET", f"/users/{owner}", token)
+    if cp.returncode != 0:
+        return False
+    try:
+        data = json.loads(cp.stdout)
+        return data.get("type", "").lower() == "organization"
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Auth validation (replaces gh auth status)
+# ---------------------------------------------------------------------------
+
+
+def validate_token(token: str) -> bool:
+    """Return True if the token can reach the GitHub API."""
+    cp = rest("GET", "/user", token)
+    return cp.returncode == 0
+
+
+def get_authenticated_login(token: str) -> str | None:
+    cp = rest("GET", "/user", token)
+    if cp.returncode != 0:
+        return None
+    try:
+        return json.loads(cp.stdout).get("login")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Token resolution from repo .env files
+# ---------------------------------------------------------------------------
+
+
+def _load_env_file(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().rstrip("\r")
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        result[key] = value
+    return result
+
+
+def token_from_repo(repo_dir: Path) -> str | None:
+    """Try to resolve a GH token from the repo .env and environment."""
+    env = dict(os.environ)
+    for env_file in (repo_dir / ".env", Path.cwd() / ".env"):
+        for k, v in _load_env_file(env_file).items():
+            env.setdefault(k, v)
+    return resolve_token(env)

--- a/tests/test_backlog_ops.py
+++ b/tests/test_backlog_ops.py
@@ -215,12 +215,7 @@ def test_load_token_from_env_file_and_ensure_gh_auth(
     backlog_ops._load_token_from_env_file(env_file)
     assert os.environ["GH_TOKEN"] == "token-from-env"
 
-    monkeypatch.setattr(
-        backlog_ops.shutil,
-        "which",
-        lambda tool: "/usr/bin/gh" if tool == "gh" else None,
-    )
-    monkeypatch.setattr(backlog_ops.subprocess, "run", lambda *args, **kwargs: _cp_ok())
+    # GH_TOKEN is now set from env file — _ensure_gh_auth should pass
     backlog_ops._ensure_gh_auth(repo_dir)
 
     monkeypatch.delenv("GH_TOKEN", raising=False)
@@ -229,13 +224,6 @@ def test_load_token_from_env_file_and_ensure_gh_auth(
     clean_repo_dir = tmp_path / "clean-repo"
     clean_repo_dir.mkdir()
     monkeypatch.chdir(clean_repo_dir)
-    monkeypatch.setattr(
-        backlog_ops.subprocess,
-        "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(
-            args=["gh", "auth", "status"], returncode=1, stdout="", stderr=""
-        ),
-    )
     with pytest.raises(RuntimeError, match="Authenticate first"):
         backlog_ops._ensure_gh_auth(clean_repo_dir)
 

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -505,51 +505,43 @@ def test_tool_auth_remote_and_push_helpers_cover_common_error_paths(
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir()
 
-    monkeypatch.setattr(
-        create_ops.shutil,
-        "which",
-        lambda tool: None if tool == "gh" else "/usr/bin/git",
-    )
-    with pytest.raises(RuntimeError, match="GitHub CLI"):
-        create_ops._ensure_tools()
-
-    monkeypatch.setattr(
-        create_ops.shutil, "which", lambda tool: "/usr/bin/gh" if tool == "gh" else None
-    )
+    monkeypatch.setattr(create_ops.shutil, "which", lambda tool: None)
     with pytest.raises(RuntimeError, match="git is required"):
         create_ops._ensure_tools()
 
-    monkeypatch.setattr(create_ops.shutil, "which", lambda _tool: "/usr/bin/tool")
+    monkeypatch.setattr(create_ops.shutil, "which", lambda _tool: "/usr/bin/git")
     create_ops._ensure_tools()
 
-    monkeypatch.setattr(
-        create_ops,
-        "_run",
-        lambda args, **kwargs: (
-            subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
-            if args[:3] == ["gh", "auth", "status"]
-            else subprocess.CompletedProcess(
-                args=args, returncode=0, stdout="", stderr=""
-            )
-        ),
-    )
+    import repo_scaffold.github_api as github_api_module
+
+    monkeypatch.setattr(github_api_module, "token_from_repo", lambda _repo_dir: None)
+    monkeypatch.setattr(create_ops, "_token_from_repo", lambda _repo_dir: None)
     with pytest.raises(RuntimeError, match="Authenticate first"):
         create_ops._ensure_gh_auth(repo_dir, {})
 
-    assert create_ops._repo_exists(repo_dir=repo_dir, env={}, repo="acme/repo") is True
     monkeypatch.setattr(
-        create_ops,
-        "_run",
-        lambda args, **kwargs: subprocess.CompletedProcess(
-            args=args, returncode=1, stdout="", stderr="not found"
+        github_api_module,
+        "_http",
+        lambda method, url, token, data=None: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='{"nameWithOwner":"acme/repo"}', stderr=""
+        ),
+    )
+    assert create_ops._repo_exists(repo_dir=repo_dir, env={}, repo="acme/repo") is True
+
+    monkeypatch.setattr(
+        github_api_module,
+        "_http",
+        lambda method, url, token, data=None: subprocess.CompletedProcess(
+            args=[], returncode=404, stdout="", stderr="not found"
         ),
     )
     assert create_ops._repo_exists(repo_dir=repo_dir, env={}, repo="acme/repo") is False
+
     monkeypatch.setattr(
-        create_ops,
-        "_run",
-        lambda args, **kwargs: subprocess.CompletedProcess(
-            args=args, returncode=1, stdout="", stderr="boom"
+        github_api_module,
+        "_http",
+        lambda method, url, token, data=None: subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="boom"
         ),
     )
     with pytest.raises(RuntimeError, match="boom"):
@@ -608,17 +600,12 @@ def test_tool_auth_remote_and_push_helpers_cover_common_error_paths(
         out=lambda _line: None,
     )
 
-    monkeypatch.setattr(
-        create_ops,
-        "_run",
-        lambda args, **kwargs: subprocess.CompletedProcess(
-            args=args,
-            returncode=0 if args[:3] == ["gh", "auth", "token"] else 1,
-            stdout="gh-token\n" if args[:3] == ["gh", "auth", "token"] else "",
-            stderr="",
-        ),
+    assert (
+        create_ops._resolve_push_token(repo_dir=repo_dir, env={"GH_TOKEN": "gh-token"})
+        == "gh-token"
     )
-    assert create_ops._resolve_push_token(repo_dir=repo_dir, env={}) == "gh-token"
+    monkeypatch.setattr(create_ops, "_token_from_repo", lambda _: None)
+    assert create_ops._resolve_push_token(repo_dir=repo_dir, env={}) is None
     assert "workflow write permission" in create_ops._format_push_failure(
         "workflow missing scope"
     )
@@ -649,9 +636,9 @@ def test_create_or_push_repo_covers_existing_and_create_failures(
     monkeypatch.setattr(create_ops, "_repo_exists", lambda **_: False)
     monkeypatch.setattr(
         create_ops,
-        "_run",
-        lambda args, **kwargs: subprocess.CompletedProcess(
-            args=args, returncode=1, stdout="", stderr="create failed"
+        "_github_repo_create",
+        lambda owner, name, token, visibility="private": subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="create failed"
         ),
     )
     created, pushed, error = create_ops._create_or_push_repo(
@@ -928,22 +915,18 @@ def test_create_or_push_repo_uses_absolute_source_path(
     repo_dir = Path("rel-repo")
     repo_dir.mkdir(parents=True)
 
-    run_calls: list[tuple[list[str], Path]] = []
+    create_calls: list[tuple[str, str, str, str]] = []
 
     def _fake_repo_exists(*, repo_dir: Path, env: dict[str, str], repo: str) -> bool:
         assert repo_dir == repo_dir.resolve()
         return False
 
-    def _fake_run(
-        args: list[str],
-        *,
-        cwd: Path,
-        env: dict[str, str],
-        stdin_text: str | None = None,
+    def _fake_repo_create(
+        owner: str, name: str, token: str, visibility: str = "private"
     ) -> subprocess.CompletedProcess[str]:
-        run_calls.append((args, cwd))
+        create_calls.append((owner, name, token, visibility))
         return subprocess.CompletedProcess(
-            args=args, returncode=0, stdout="", stderr=""
+            args=[], returncode=201, stdout="{}", stderr=""
         )
 
     def _fake_push_main(
@@ -952,7 +935,7 @@ def test_create_or_push_repo_uses_absolute_source_path(
         return True, None
 
     monkeypatch.setattr(create_ops, "_repo_exists", _fake_repo_exists)
-    monkeypatch.setattr(create_ops, "_run", _fake_run)
+    monkeypatch.setattr(create_ops, "_github_repo_create", _fake_repo_create)
     monkeypatch.setattr(create_ops, "_push_main", _fake_push_main)
 
     created, pushed, error = create_ops._create_or_push_repo(
@@ -967,13 +950,11 @@ def test_create_or_push_repo_uses_absolute_source_path(
     assert created is True
     assert pushed is True
     assert error is None
-    assert run_calls, "Expected gh repo create call"
-    gh_call_args, gh_call_cwd = run_calls[0]
-    assert gh_call_args[:4] == ["gh", "repo", "create", "acme/example"]
-    assert "--source" in gh_call_args
-    source_idx = gh_call_args.index("--source") + 1
-    assert Path(gh_call_args[source_idx]).is_absolute()
-    assert gh_call_cwd.is_absolute()
+    assert create_calls, "Expected repo create call"
+    owner, name, _, visibility = create_calls[0]
+    assert owner == "acme"
+    assert name == "example"
+    assert visibility == "public"
 
 
 def test_ensure_git_repo_initializes_when_inside_parent_repo(

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -936,6 +936,7 @@ def test_create_or_push_repo_uses_absolute_source_path(
 
     monkeypatch.setattr(create_ops, "_repo_exists", _fake_repo_exists)
     monkeypatch.setattr(create_ops, "_github_repo_create", _fake_repo_create)
+    monkeypatch.setattr(create_ops, "_ensure_origin_remote", lambda **_: None)
     monkeypatch.setattr(create_ops, "_push_main", _fake_push_main)
 
     created, pushed, error = create_ops._create_or_push_repo(

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import repo_scaffold.github_api as github_api
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_resp(status: int, body: str | bytes) -> MagicMock:
+    raw = body.encode() if isinstance(body, str) else body
+    resp = MagicMock()
+    resp.read.return_value = raw
+    resp.headers = {"Link": ""}
+    resp.status = status
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _http_error(code: int, body: str = "") -> urllib.error.HTTPError:
+    fp = BytesIO(body.encode())
+    return urllib.error.HTTPError(url="", code=code, msg="", hdrs=MagicMock(), fp=fp)
+
+
+# ---------------------------------------------------------------------------
+# resolve_token
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_token_reads_gh_token() -> None:
+    assert github_api.resolve_token({"GH_TOKEN": "tok"}) == "tok"
+
+
+def test_resolve_token_fallback_order() -> None:
+    assert github_api.resolve_token({"GITHUB_TOKEN": "tok2"}) == "tok2"
+    assert github_api.resolve_token({"github_token": "tok3"}) == "tok3"
+    assert github_api.resolve_token({}) is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_next_link
+# ---------------------------------------------------------------------------
+
+
+def test_parse_next_link_returns_url() -> None:
+    link = '<https://api.github.com/repos/X/issues?page=2>; rel="next", <https://api.github.com/repos/X/issues?page=5>; rel="last"'
+    assert (
+        github_api._parse_next_link(link)
+        == "https://api.github.com/repos/X/issues?page=2"
+    )
+
+
+def test_parse_next_link_no_next_returns_none() -> None:
+    link = '<https://api.github.com/repos/X/issues?page=5>; rel="last"'
+    assert github_api._parse_next_link(link) is None
+
+
+def test_parse_next_link_empty_returns_none() -> None:
+    assert github_api._parse_next_link("") is None
+
+
+# ---------------------------------------------------------------------------
+# rest
+# ---------------------------------------------------------------------------
+
+
+def test_rest_get_success() -> None:
+    payload = json.dumps({"login": "octocat"})
+    with patch("urllib.request.urlopen", return_value=_mock_resp(200, payload)):
+        cp = github_api.rest("GET", "/user", "token")
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout)["login"] == "octocat"
+
+
+def test_rest_returns_err_on_http_error() -> None:
+    with patch("urllib.request.urlopen", side_effect=_http_error(404, "not found")):
+        cp = github_api.rest("GET", "/repos/x/y", "token")
+    assert cp.returncode == 404
+    assert "not found" in cp.stderr
+
+
+def test_rest_returns_err_on_url_error() -> None:
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        cp = github_api.rest("GET", "/user", "token")
+    assert cp.returncode != 0
+    assert "connection refused" in cp.stderr
+
+
+# ---------------------------------------------------------------------------
+# rest_paginated
+# ---------------------------------------------------------------------------
+
+
+def test_rest_paginated_collects_all_pages() -> None:
+    page1 = json.dumps([{"number": 1}])
+    page2 = json.dumps([{"number": 2}])
+
+    resp1 = _mock_resp(200, page1)
+    resp1.headers = {"Link": '<https://api.github.com/issues?page=2>; rel="next"'}
+
+    resp2 = _mock_resp(200, page2)
+    resp2.headers = {"Link": ""}
+
+    call_count = 0
+
+    class _CM:
+        def __init__(self, resp: MagicMock) -> None:
+            self._resp = resp
+
+        def __enter__(self) -> MagicMock:
+            return self._resp
+
+        def __exit__(self, *_: object) -> bool:
+            return False
+
+    responses = [_CM(resp1), _CM(resp2)]
+
+    def _fake_urlopen(req: object) -> object:
+        nonlocal call_count
+        r = responses[call_count]
+        call_count += 1
+        return r
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        cp = github_api.rest_paginated("/issues", "token")
+
+    assert cp.returncode == 0
+    items = json.loads(cp.stdout)
+    assert len(items) == 2
+    assert items[0]["number"] == 1
+    assert items[1]["number"] == 2
+
+
+# ---------------------------------------------------------------------------
+# graphql
+# ---------------------------------------------------------------------------
+
+
+def test_graphql_success() -> None:
+    payload = json.dumps({"data": {"user": {"id": "U_123"}}})
+    with patch("urllib.request.urlopen", return_value=_mock_resp(200, payload)):
+        cp = github_api.graphql("query { user { id } }", {}, "token")
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout)["user"]["id"] == "U_123"
+
+
+def test_graphql_surfaces_errors() -> None:
+    payload = json.dumps({"errors": [{"message": "Field 'x' doesn't exist"}]})
+    with patch("urllib.request.urlopen", return_value=_mock_resp(200, payload)):
+        cp = github_api.graphql("query { x }", {}, "token")
+    assert cp.returncode != 0
+    assert "doesn't exist" in cp.stderr
+
+
+def test_graphql_http_error() -> None:
+    with patch("urllib.request.urlopen", side_effect=_http_error(401, "Unauthorized")):
+        cp = github_api.graphql("query { user { id } }", {}, "bad-token")
+    assert cp.returncode == 401
+
+
+# ---------------------------------------------------------------------------
+# project_list / project_view / project_create (smoke tests with mocks)
+# ---------------------------------------------------------------------------
+
+
+def _graphql_ok(data: dict) -> MagicMock:  # type: ignore[type-arg]
+    return _mock_resp(200, json.dumps({"data": data}))
+
+
+def test_project_list_user() -> None:
+    data = {
+        "user": {
+            "projectsV2": {
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                "nodes": [
+                    {"id": "PV2_1", "number": 1, "title": "My Project", "closed": False}
+                ],
+            }
+        }
+    }
+    with patch("urllib.request.urlopen", return_value=_graphql_ok(data)):
+        cp = github_api.project_list("alice", "token")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert result["totalCount"] == 1
+    assert result["projects"][0]["title"] == "My Project"
+
+
+def test_project_view_user() -> None:
+    data = {
+        "user": {
+            "projectV2": {
+                "id": "PV2_1",
+                "number": 1,
+                "title": "My Project",
+                "closed": False,
+            }
+        }
+    }
+    with patch("urllib.request.urlopen", return_value=_graphql_ok(data)):
+        cp = github_api.project_view("alice", 1, "token")
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout)["title"] == "My Project"
+
+
+def test_project_view_not_found() -> None:
+    data: dict = {"user": {"projectV2": None}, "organization": {"projectV2": None}}
+    with patch("urllib.request.urlopen", return_value=_graphql_ok(data)):
+        cp = github_api.project_view("alice", 999, "token")
+    assert cp.returncode != 0
+
+
+def test_project_create() -> None:
+    owner_data = {"user": {"id": "U_abc"}}
+    create_data = {
+        "createProjectV2": {
+            "projectV2": {"id": "PV2_2", "number": 2, "title": "New Project"}
+        }
+    }
+
+    responses = [_graphql_ok(owner_data), _graphql_ok(create_data)]
+    call_count = 0
+
+    class _CM:
+        def __init__(self, resp: MagicMock) -> None:
+            self._resp = resp
+
+        def __enter__(self) -> MagicMock:
+            return self._resp
+
+        def __exit__(self, *_: object) -> bool:
+            return False
+
+    def _fake_urlopen(req: object) -> object:
+        nonlocal call_count
+        r = _CM(responses[call_count])
+        call_count += 1
+        return r
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        cp = github_api.project_create("alice", "New Project", "token")
+
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout)["title"] == "New Project"
+
+
+# ---------------------------------------------------------------------------
+# repo_create
+# ---------------------------------------------------------------------------
+
+
+def test_repo_create_user() -> None:
+    user_data = json.dumps({"type": "User", "login": "alice"})
+    repo_data = json.dumps(
+        {"full_name": "alice/myrepo", "html_url": "https://github.com/alice/myrepo"}
+    )
+
+    responses = [_mock_resp(200, user_data), _mock_resp(201, repo_data)]
+    call_count = 0
+
+    class _CM:
+        def __init__(self, resp: MagicMock) -> None:
+            self._resp = resp
+
+        def __enter__(self) -> MagicMock:
+            return self._resp
+
+        def __exit__(self, *_: object) -> bool:
+            return False
+
+    def _fake_urlopen(req: object) -> object:
+        nonlocal call_count
+        r = _CM(responses[call_count])
+        call_count += 1
+        return r
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        cp = github_api.repo_create("alice", "myrepo", "token", visibility="public")
+
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout)["full_name"] == "alice/myrepo"
+
+
+# ---------------------------------------------------------------------------
+# validate_token / get_authenticated_login
+# ---------------------------------------------------------------------------
+
+
+def test_validate_token_true_on_200() -> None:
+    with patch(
+        "urllib.request.urlopen", return_value=_mock_resp(200, '{"login":"alice"}')
+    ):
+        assert github_api.validate_token("good-token") is True
+
+
+def test_validate_token_false_on_401() -> None:
+    with patch("urllib.request.urlopen", side_effect=_http_error(401)):
+        assert github_api.validate_token("bad-token") is False
+
+
+def test_get_authenticated_login() -> None:
+    with patch(
+        "urllib.request.urlopen", return_value=_mock_resp(200, '{"login":"alice"}')
+    ):
+        assert github_api.get_authenticated_login("token") == "alice"
+
+
+# ---------------------------------------------------------------------------
+# token_from_repo
+# ---------------------------------------------------------------------------
+
+
+def test_token_from_repo_reads_env_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("github_token", raising=False)
+    monkeypatch.chdir(tmp_path)
+    env_file = tmp_path / ".env"
+    env_file.write_text("GH_TOKEN=mytoken\n", encoding="utf-8")
+    token = github_api.token_from_repo(tmp_path)
+    assert token == "mytoken"
+
+
+def test_token_from_repo_returns_none_without_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("github_token", raising=False)
+    monkeypatch.chdir(tmp_path)  # avoid picking up project-root .env
+    token = github_api.token_from_repo(tmp_path)
+    assert token is None


### PR DESCRIPTION
## 🧾 Title
Replace gh CLI shell-outs with direct GitHub API calls (urllib) — OS-agnostic

## 🧠 Description
Every internal GitHub operation was shelling out to the `gh` CLI binary. This broke on Windows without WSL, CI environments, and any machine where `gh` wasn't on PATH — even though the tool already had `GH_TOKEN`. Now all GitHub calls go directly through `urllib` + `GH_TOKEN`. The `gh` binary is never required.

## 🧩 Changes Included
- [x] New `github_api.py`: REST + GraphQL client using urllib + GH_TOKEN
- [x] Removed all `shutil.which("gh")` checks
- [x] Replaced `_run_gh()` in `backlog_ops.py` with urllib dispatcher (REST + GraphQL)
- [x] Replaced `_api()` in `create_ops.py` with urllib
- [x] Replaced `gh repo create`, `gh auth status`, `gh auth token` calls
- [x] 22 unit tests for `github_api.py`

## 🎯 Purpose
Works on Windows, macOS, Ubuntu — no `gh` binary required. Just `GH_TOKEN`.

## 🔗 Related Issues / Epics
- **Issue:** #91
- **Closes:** Fixes #91

## 🧪 Testing
1. `poetry run pytest` — 150 passed
2. `poetry run tox -e precommit` — all gates pass, 71.67% coverage
3. Verified `repo-scaffold create` no longer errors with gh-not-found

## 🧰 Developer Notes
- `github_api.py` uses only stdlib (`urllib`, `json`, `os`) — zero new dependencies
- `_run_gh()` retained as a compatibility shim that routes to urllib internally
- GraphQL used for GitHub Projects v2 API (project list/view/create/edit/delete/items)