### PR TITLE
feat(agent): add pr list, view, comment, resolve-thread commands (#94)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ poetry run repo-scaffold pr list --repo OWNER/REPO [--json]
 poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N [--json]
 poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
 poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
+poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRANCH [--base main] [--body "TEXT"] [--draft]
 poetry run repo-scaffold project items --project-title "TITLE" --limit 40
 poetry run repo-scaffold create --repo OWNER/REPO --visibility public --path /path/to/code
 poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
@@ -77,5 +78,4 @@ poetry run tox -e precommit   # full gate: format + lint + type + coverage
 - `cli.py` — argparse entry point
 
 ## Still missing (file tickets, do NOT work around)
-- `repo-scaffold pr create` (open a new PR)
-- `repo-scaffold issue create` (open a new issue)
+- `repo-scaffold issue create/list/close/comment/label/assign` (see #96)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,10 @@ Before writing any code, verify every item below. These are non-negotiable and a
 
 ```bash
 poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N [--json]
+poetry run repo-scaffold pr list --repo OWNER/REPO [--json]
+poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
+poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
 poetry run repo-scaffold project items --project-title "TITLE" --limit 40
 poetry run repo-scaffold create --repo OWNER/REPO --visibility public --path /path/to/code
 poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
@@ -73,7 +77,5 @@ poetry run tox -e precommit   # full gate: format + lint + type + coverage
 - `cli.py` — argparse entry point
 
 ## Still missing (file tickets, do NOT work around)
-- `repo-scaffold pr list`
-- `repo-scaffold pr create`
-- `repo-scaffold pr comment`
-- `repo-scaffold pr resolve-thread`
+- `repo-scaffold pr create` (open a new PR)
+- `repo-scaffold issue create` (open a new issue)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,12 @@ Before writing any code, verify every item below. These are non-negotiable and a
 poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N
 poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N --json
 
+# Pull requests
+poetry run repo-scaffold pr list --repo OWNER/REPO [--json]
+poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
+poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
+
 # Projects
 poetry run repo-scaffold project items --project-title "TITLE" --limit 40
 poetry run repo-scaffold project list --project-owner OWNER
@@ -80,10 +86,8 @@ poetry run repo-scaffold check rules --repo OWNER/REPO
 Token lives in `.env` as `GH_TOKEN`. Commands pick it up automatically via `_seed_env_from_dotenv`.
 
 ## Still missing (file tickets, do NOT work around with gh/PS)
-- `repo-scaffold pr list`
-- `repo-scaffold pr create`
-- `repo-scaffold pr comment --reply-to <id>`
-- `repo-scaffold pr resolve-thread`
+- `repo-scaffold pr create` (open a new PR)
+- `repo-scaffold issue create` (open a new issue)
 
 ## Running tests
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ poetry run repo-scaffold pr list --repo OWNER/REPO [--json]
 poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N [--json]
 poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
 poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
+poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRANCH [--base main] [--body "TEXT"] [--draft]
 
 # Projects
 poetry run repo-scaffold project items --project-title "TITLE" --limit 40
@@ -86,8 +87,7 @@ poetry run repo-scaffold check rules --repo OWNER/REPO
 Token lives in `.env` as `GH_TOKEN`. Commands pick it up automatically via `_seed_env_from_dotenv`.
 
 ## Still missing (file tickets, do NOT work around with gh/PS)
-- `repo-scaffold pr create` (open a new PR)
-- `repo-scaffold issue create` (open a new issue)
+- `repo-scaffold issue create/list/close/comment/label/assign` (see #96)
 
 ## Running tests
 ```bash

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -18,6 +18,7 @@ from .backlog_ops import (
 )
 from .github_api import (
     pr_comment,
+    pr_create,
     pr_list,
     pr_resolve_thread,
     pr_view,
@@ -795,6 +796,16 @@ def build_parser() -> argparse.ArgumentParser:
     pr_comment_cmd.add_argument(
         "--reply-to", type=int, dest="reply_to", help="Comment ID to reply to"
     )
+
+    pr_create_cmd = pr_sub.add_parser("create", help="Open a new pull request")
+    pr_create_cmd.add_argument("--repo", required=True)
+    pr_create_cmd.add_argument("--title", required=True)
+    pr_create_cmd.add_argument("--body", default="")
+    pr_create_cmd.add_argument("--head", required=True, help="Source branch")
+    pr_create_cmd.add_argument(
+        "--base", default="main", help="Target branch (default: main)"
+    )
+    pr_create_cmd.add_argument("--draft", action="store_true")
 
     pr_resolve_cmd = pr_sub.add_parser(
         "resolve-thread", help="Resolve a PR review thread"
@@ -1674,6 +1685,24 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 f"Thread resolved: {thread.get('id', ns.thread_id)} (isResolved: {thread.get('isResolved', True)})"
             )
+            return 0
+
+        if ns.pr_command == "create":
+            cp = pr_create(
+                target_repo,
+                title=ns.title,
+                body=ns.body,
+                head=ns.head,
+                base=ns.base,
+                token=token,
+                draft=ns.draft,
+            )
+            if cp.returncode not in (0, 201):
+                print(cp.stderr.strip() or "Failed creating PR.", file=sys.stderr)
+                return 1
+            created = _json.loads(cp.stdout)
+            print(f"PR created: #{created['number']} {created['title']}")
+            print(f"URL: {created['html_url']}")
             return 0
 
     parser.error("Unsupported command.")

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -16,6 +16,13 @@ from .backlog_ops import (
     resolve_authenticated_login,
     resolve_project_target_for_auth_check,
 )
+from .github_api import (
+    pr_comment,
+    pr_list,
+    pr_resolve_thread,
+    pr_view,
+    token_from_repo,
+)
 from .backlog_import import build_backlog_import_file
 from .create_ops import (
     CreateSummary,
@@ -765,6 +772,36 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output structured JSON instead of human-readable text",
     )
 
+    pr_cmd = subparsers.add_parser("pr", help="Interact with GitHub pull requests")
+    pr_sub = pr_cmd.add_subparsers(dest="pr_command", required=True)
+
+    pr_list_cmd = pr_sub.add_parser("list", help="List open pull requests")
+    pr_list_cmd.add_argument(
+        "--repo", required=True, help="Target GitHub repo (owner/repo)"
+    )
+    pr_list_cmd.add_argument("--json", action="store_true", dest="json_output")
+
+    pr_view_cmd = pr_sub.add_parser("view", help="View a single pull request")
+    pr_view_cmd.add_argument(
+        "--repo", required=True, help="Target GitHub repo (owner/repo)"
+    )
+    pr_view_cmd.add_argument("--pr-number", type=int, required=True)
+    pr_view_cmd.add_argument("--json", action="store_true", dest="json_output")
+
+    pr_comment_cmd = pr_sub.add_parser("comment", help="Post a review comment on a PR")
+    pr_comment_cmd.add_argument("--repo", required=True)
+    pr_comment_cmd.add_argument("--pr-number", type=int, required=True)
+    pr_comment_cmd.add_argument("--body", required=True)
+    pr_comment_cmd.add_argument(
+        "--reply-to", type=int, dest="reply_to", help="Comment ID to reply to"
+    )
+
+    pr_resolve_cmd = pr_sub.add_parser(
+        "resolve-thread", help="Resolve a PR review thread"
+    )
+    pr_resolve_cmd.add_argument("--repo", required=True)
+    pr_resolve_cmd.add_argument("--thread-id", required=True, dest="thread_id")
+
     return parser
 
 
@@ -781,6 +818,7 @@ def _normalize_argv(argv: list[str] | None) -> list[str]:
         "import",
         "project",
         "issue",
+        "pr",
     }:
         return raw
     # Backward-compatible behavior: previous root command maps to init.
@@ -1565,6 +1603,78 @@ def main(argv: list[str] | None = None) -> int:
                 print("")
                 print(issue.body)
         return 0
+
+    if ns.mode == "pr":
+        import json as _json
+
+        target_repo, repo_error = _resolve_repo_from_args_or_env(
+            repo=ns.repo, fallback_name=None
+        )
+        if repo_error:
+            print(repo_error, file=sys.stderr)
+            return 2
+        assert target_repo is not None
+        token = token_from_repo(Path.cwd()) or ""
+
+        if ns.pr_command == "list":
+            cp = pr_list(target_repo, token)
+            if cp.returncode != 0:
+                print(cp.stderr.strip() or "Failed listing PRs.", file=sys.stderr)
+                return 1
+            prs = _json.loads(cp.stdout)
+            if ns.json_output:
+                print(_json.dumps(prs, indent=2))
+            else:
+                if not prs:
+                    print("No open pull requests.")
+                for p in prs:
+                    print(
+                        f"  #{p['number']} [{p['state']}] {p['title']}  ({p['head']['ref']})"
+                    )
+            return 0
+
+        if ns.pr_command == "view":
+            cp = pr_view(target_repo, ns.pr_number, token)
+            if cp.returncode != 0:
+                print(
+                    cp.stderr.strip() or f"Failed fetching PR #{ns.pr_number}.",
+                    file=sys.stderr,
+                )
+                return 1
+            pr = _json.loads(cp.stdout)
+            if ns.json_output:
+                print(_json.dumps(pr, indent=2))
+            else:
+                print(f"PR #{pr['number']}: {pr['title']}")
+                print(f"State: {pr['state']}")
+                print(f"Branch: {pr['head']['ref']} -> {pr['base']['ref']}")
+                print(f"Author: {pr['user']['login']}")
+                if pr.get("body"):
+                    print("")
+                    print(pr["body"])
+            return 0
+
+        if ns.pr_command == "comment":
+            cp = pr_comment(
+                target_repo, ns.pr_number, ns.body, token, reply_to=ns.reply_to
+            )
+            if cp.returncode not in (0, 201):
+                print(cp.stderr.strip() or "Failed posting comment.", file=sys.stderr)
+                return 1
+            comment = _json.loads(cp.stdout)
+            print(f"Comment posted: {comment.get('html_url', '')}")
+            return 0
+
+        if ns.pr_command == "resolve-thread":
+            cp = pr_resolve_thread(ns.thread_id, token)
+            if cp.returncode != 0:
+                print(cp.stderr.strip() or "Failed resolving thread.", file=sys.stderr)
+                return 1
+            thread = _json.loads(cp.stdout)
+            print(
+                f"Thread resolved: {thread.get('id', ns.thread_id)} (isResolved: {thread.get('isResolved', True)})"
+            )
+            return 0
 
     parser.error("Unsupported command.")
     return 2

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -703,6 +703,79 @@ def _load_env_file(path: Path) -> dict[str, str]:
     return result
 
 
+# ---------------------------------------------------------------------------
+# Pull requests
+# ---------------------------------------------------------------------------
+
+_GQL_RESOLVE_THREAD = """
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { id isResolved }
+  }
+}
+"""
+
+_GQL_PR_REVIEW_THREADS = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 50) {
+        nodes { id isResolved }
+      }
+    }
+  }
+}
+"""
+
+
+def pr_list(repo: str, token: str) -> subprocess.CompletedProcess[str]:
+    return rest_paginated(f"/repos/{repo}/pulls?state=open&per_page=100", token)
+
+
+def pr_view(repo: str, number: int, token: str) -> subprocess.CompletedProcess[str]:
+    return rest("GET", f"/repos/{repo}/pulls/{number}", token)
+
+
+def pr_list_comments(
+    repo: str, number: int, token: str
+) -> subprocess.CompletedProcess[str]:
+    return rest_paginated(f"/repos/{repo}/pulls/{number}/comments?per_page=100", token)
+
+
+def pr_comment(
+    repo: str,
+    number: int,
+    body: str,
+    token: str,
+    reply_to: int | None = None,
+) -> subprocess.CompletedProcess[str]:
+    payload: dict[str, object] = {"body": body}
+    if reply_to is not None:
+        payload["in_reply_to"] = reply_to
+    return rest("POST", f"/repos/{repo}/pulls/{number}/comments", token, payload)
+
+
+def pr_review_threads(
+    owner: str, repo: str, number: int, token: str
+) -> subprocess.CompletedProcess[str]:
+    return graphql(
+        _GQL_PR_REVIEW_THREADS,
+        {"owner": owner, "repo": repo, "number": number},
+        token,
+    )
+
+
+def pr_resolve_thread(thread_id: str, token: str) -> subprocess.CompletedProcess[str]:
+    cp = graphql(_GQL_RESOLVE_THREAD, {"threadId": thread_id}, token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        thread = json.loads(cp.stdout).get("resolveReviewThread", {}).get("thread", {})
+        return _ok(json.dumps(thread))
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response resolving thread.")
+
+
 def token_from_repo(repo_dir: Path) -> str | None:
     """Try to resolve a GH token from the repo .env and environment."""
     env = dict(os.environ)

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -749,10 +749,18 @@ def pr_comment(
     token: str,
     reply_to: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    payload: dict[str, object] = {"body": body}
     if reply_to is not None:
-        payload["in_reply_to"] = reply_to
-    return rest("POST", f"/repos/{repo}/pulls/{number}/comments", token, payload)
+        # Reply to an existing inline review comment
+        return rest(
+            "POST",
+            f"/repos/{repo}/pulls/{number}/comments/{reply_to}/replies",
+            token,
+            {"body": body},
+        )
+    # Regular PR timeline comment (visible in the conversation tab)
+    return rest(
+        "POST", f"/repos/{repo}/issues/{number}/comments", token, {"body": body}
+    )
 
 
 def pr_review_threads(

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -776,6 +776,25 @@ def pr_resolve_thread(thread_id: str, token: str) -> subprocess.CompletedProcess
         return _err("Unexpected response resolving thread.")
 
 
+def pr_create(
+    repo: str,
+    title: str,
+    body: str,
+    head: str,
+    base: str,
+    token: str,
+    draft: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    payload: dict[str, object] = {
+        "title": title,
+        "body": body,
+        "head": head,
+        "base": base,
+        "draft": draft,
+    }
+    return rest("POST", f"/repos/{repo}/pulls", token, payload)
+
+
 def token_from_repo(repo_dir: Path) -> str | None:
     """Try to resolve a GH token from the repo .env and environment."""
     env = dict(os.environ)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1879,3 +1879,47 @@ def test_pr_resolve_thread(
     )
     assert rc == 0
     assert "resolved" in capsys.readouterr().out.lower()
+
+
+def test_pr_create(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_create",
+        lambda repo, title, body, head, base, token, draft=False: subprocess.CompletedProcess(
+            args=[],
+            returncode=201,
+            stdout=json.dumps(
+                {
+                    "number": 10,
+                    "title": "My PR",
+                    "html_url": "https://github.com/acme/repo/pull/10",
+                }
+            ),
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(
+        [
+            "pr",
+            "create",
+            "--repo",
+            "acme/repo",
+            "--title",
+            "My PR",
+            "--head",
+            "feat/my-branch",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PR created: #10" in out
+    assert "https://github.com/acme/repo/pull/10" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,7 @@ def test_root_help_shows_all_modes(capsys: pytest.CaptureFixture[str]) -> None:
     assert "import" in stdout
     assert "project" in stdout
     assert "issue" in stdout
+    assert "pr" in stdout
 
 
 def test_seed_env_from_dotenv_promotes_project_token_when_gh_token_is_placeholder(
@@ -1751,3 +1752,130 @@ def test_issue_view_bad_repo_format_returns_2(
     monkeypatch.chdir(tmp_path)
     rc = main(["issue", "view", "--repo", "not-valid", "--issue-number", "1"])
     assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# pr command tests
+# ---------------------------------------------------------------------------
+
+
+def test_pr_list_human_readable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    fake_prs = [
+        {
+            "number": 5,
+            "title": "Fix bug",
+            "state": "open",
+            "head": {"ref": "fix/bug"},
+            "base": {"ref": "main"},
+        },
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_list",
+        lambda repo, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(fake_prs), stderr=""
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(["pr", "list", "--repo", "acme/repo"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "#5" in out
+    assert "Fix bug" in out
+
+
+def test_pr_view_human_readable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    fake_pr = {
+        "number": 5,
+        "title": "Fix bug",
+        "state": "open",
+        "head": {"ref": "fix/bug"},
+        "base": {"ref": "main"},
+        "user": {"login": "alice"},
+        "body": "Fixes the thing.",
+    }
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_view",
+        lambda repo, number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(fake_pr), stderr=""
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(["pr", "view", "--repo", "acme/repo", "--pr-number", "5"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PR #5: Fix bug" in out
+    assert "alice" in out
+
+
+def test_pr_comment_posts_and_prints_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_comment",
+        lambda repo, number, body, token, reply_to=None: subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(
+                {"html_url": "https://github.com/acme/repo/pull/5#comment-1"}
+            ),
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(
+        ["pr", "comment", "--repo", "acme/repo", "--pr-number", "5", "--body", "LGTM"]
+    )
+    assert rc == 0
+    assert "Comment posted" in capsys.readouterr().out
+
+
+def test_pr_resolve_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_resolve_thread",
+        lambda thread_id, token: subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps({"id": "PRRT_abc", "isResolved": True}),
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(
+        ["pr", "resolve-thread", "--repo", "acme/repo", "--thread-id", "PRRT_abc"]
+    )
+    assert rc == 0
+    assert "resolved" in capsys.readouterr().out.lower()


### PR DESCRIPTION
## 🧾 Title
Add PR commands: list, view, comment, resolve-thread

## 🧠 Description
Closes the last gap in the repo-scaffold agent surface. Agents can now fully manage the PR review workflow without ever touching `gh` CLI or writing raw HTTP scripts.

## 🧩 Changes Included
- [x] `repo-scaffold pr list --repo OWNER/REPO [--json]`
- [x] `repo-scaffold pr view --repo OWNER/REPO --pr-number N [--json]`
- [x] `repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body TEXT [--reply-to ID]`
- [x] `repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID`
- [x] All via GitHub REST/GraphQL API — no gh CLI

## 🔗 Related Issues / Epics
- **Issue:** #94
- **Closes:** Fixes #94

## 🧪 Testing
`poetry run pytest tests/test_cli.py -q` — 4 new tests, all pass