### PR TITLE
fix(ci): add react/javascript-typescript to CodeQL and include codeql.yml in apply ci

### DIFF
--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -325,9 +325,13 @@ jobs:
 
 def _render_codeql_yaml(languages: Iterable[str]) -> str:
     codeql_langs = [
-        "go" if lang == "gin" else lang
+        (
+            "go"
+            if lang == "gin"
+            else ("javascript-typescript" if lang == "react" else lang)
+        )
         for lang in languages
-        if lang in {"go", "gin", "python"}
+        if lang in {"go", "gin", "python", "react"}
     ]
     codeql_langs = list(dict.fromkeys(codeql_langs))
 
@@ -344,7 +348,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Skip
-        run: echo "No Go/Python selected; CodeQL scan is skipped."
+        run: echo "No supported CodeQL languages selected; scan is skipped."
 """
 
     matrix_lines = "\n".join(f"          - {lang}" for lang in codeql_langs)
@@ -3138,7 +3142,9 @@ def build_ci_files(
         out_dir=target_dir,
     )
     return _filter_files_for_paths(
-        build_scaffold_files(cfg), target_dir, [".github/workflows/ci.yml"]
+        build_scaffold_files(cfg),
+        target_dir,
+        [".github/workflows/ci.yml", ".github/workflows/codeql.yml"],
     )
 
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -253,7 +253,7 @@ def test_generation_is_deterministic(tmp_path: Path) -> None:
     assert _tree_hash(cfg_a.out_dir) == _tree_hash(cfg_b.out_dir)
 
 
-def test_react_only_codeql_is_noop(tmp_path: Path) -> None:
+def test_react_only_codeql_scans_javascript(tmp_path: Path) -> None:
     cfg = ScaffoldConfig(
         name="frontend",
         languages=("react",),
@@ -265,8 +265,8 @@ def test_react_only_codeql_is_noop(tmp_path: Path) -> None:
     generate_scaffold(cfg)
 
     codeql = (cfg.out_dir / ".github/workflows/codeql.yml").read_text(encoding="utf-8")
-    assert "noop:" in codeql
-    assert "Analyze (${{ matrix.language }})" not in codeql
+    assert "javascript-typescript" in codeql
+    assert "Analyze (${{ matrix.language }})" in codeql
 
     dependabot = (cfg.out_dir / ".github/dependabot.yml").read_text(encoding="utf-8")
     assert 'package-ecosystem: "github-actions"' in dependabot


### PR DESCRIPTION
## 🧾 Title
fix(ci): add react/javascript-typescript to CodeQL and include codeql.yml in apply ci

## 🧠 Description
This pull request fixes two related bugs in `apply ci` that caused React projects to have their PRs permanently blocked by CodeQL branch protection rules.

## 🧩 Changes Included
- [x] Implemented fix: map `react` to `javascript-typescript` in `_render_codeql_yaml`
- [x] Implemented fix: add `codeql.yml` to the path filter in `build_ci_files`
- [x] Updated test: `test_react_only_codeql_is_noop` -> `test_react_only_codeql_scans_javascript`

## 🎯 Purpose
React projects scaffolded with repo-scaffold had PRs permanently blocked because:
1. `_render_codeql_yaml` did not recognise `react` as a CodeQL language, emitting a no-op skip workflow
2. `build_ci_files` filtered to only `ci.yml`, so `codeql.yml` was never written by `apply ci`
3. Branch protection rules requiring CodeQL results then blocked all PRs forever

## 🔗 Related Issues / Epics
- **Closes:** Fixes #98

## 🧪 Testing
1. `poetry run pytest tests/test_generation.py` — all tests pass
2. `poetry run repo-scaffold apply ci --path <react-repo> --languages react`
3. Verify both `ci.yml` and `codeql.yml` are generated
4. Verify `codeql.yml` contains `javascript-typescript` under `matrix.language`

## 🧰 Developer Notes
- [ ] Verify environment variables are configured properly
- [ ] Ensure code runs under both local and CI/CD environments