### PR TITLE
feat(agent): add pr update command (#100)

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -27,6 +27,7 @@ from .github_api import (
     pr_create,
     pr_list,
     pr_resolve_thread,
+    pr_update,
     pr_view,
     token_from_repo,
 )
@@ -865,6 +866,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--base", default="main", help="Target branch (default: main)"
     )
     pr_create_cmd.add_argument("--draft", action="store_true")
+
+    pr_update_cmd = pr_sub.add_parser("update", help="Update an existing pull request")
+    pr_update_cmd.add_argument("--repo", required=True)
+    pr_update_cmd.add_argument("--pr-number", required=True, type=int, dest="pr_number")
+    pr_update_cmd.add_argument("--title", default=None)
+    pr_update_cmd.add_argument("--body", default=None)
 
     pr_resolve_cmd = pr_sub.add_parser(
         "resolve-thread", help="Resolve a PR review thread"
@@ -1855,6 +1862,28 @@ def main(argv: list[str] | None = None) -> int:
             created = _json.loads(cp.stdout)
             print(f"PR created: #{created['number']} {created['title']}")
             print(f"URL: {created['html_url']}")
+            return 0
+
+        if ns.pr_command == "update":
+            if ns.title is None and ns.body is None:
+                print(
+                    "Error: at least one of --title or --body is required.",
+                    file=sys.stderr,
+                )
+                return 2
+            cp = pr_update(
+                target_repo,
+                pr_number=ns.pr_number,
+                token=token,
+                title=ns.title,
+                body=ns.body,
+            )
+            if cp.returncode != 0:
+                print(cp.stderr.strip() or "Failed updating PR.", file=sys.stderr)
+                return 1
+            updated = _json.loads(cp.stdout)
+            print(f"PR updated: #{updated['number']} {updated['title']}")
+            print(f"URL: {updated['html_url']}")
             return 0
 
     parser.error("Unsupported command.")

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -924,6 +924,21 @@ def pr_create(
     return rest("POST", f"/repos/{repo}/pulls", token, payload)
 
 
+def pr_update(
+    repo: str,
+    pr_number: int,
+    token: str,
+    title: str | None = None,
+    body: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    payload: dict[str, object] = {}
+    if title is not None:
+        payload["title"] = title
+    if body is not None:
+        payload["body"] = body
+    return rest("PATCH", f"/repos/{repo}/pulls/{pr_number}", token, payload)
+
+
 def token_from_repo(repo_dir: Path) -> str | None:
     """Try to resolve a GH token from the repo .env and environment."""
     env = dict(os.environ)

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -345,3 +345,53 @@ def test_token_from_repo_returns_none_without_token(
     monkeypatch.chdir(tmp_path)  # avoid picking up project-root .env
     token = github_api.token_from_repo(tmp_path)
     assert token is None
+
+
+# ---------------------------------------------------------------------------
+# pr_update
+# ---------------------------------------------------------------------------
+
+
+def test_pr_update_body_only() -> None:
+    response = {
+        "number": 42,
+        "title": "My PR",
+        "html_url": "https://github.com/a/b/pull/42",
+    }
+    with patch(
+        "urllib.request.urlopen", return_value=_mock_resp(200, json.dumps(response))
+    ):
+        cp = github_api.pr_update(
+            "owner/repo", pr_number=42, token="tok", body="new body"
+        )
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert result["number"] == 42
+
+
+def test_pr_update_title_only() -> None:
+    response = {
+        "number": 7,
+        "title": "New Title",
+        "html_url": "https://github.com/a/b/pull/7",
+    }
+    with patch(
+        "urllib.request.urlopen", return_value=_mock_resp(200, json.dumps(response))
+    ):
+        cp = github_api.pr_update(
+            "owner/repo", pr_number=7, token="tok", title="New Title"
+        )
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert result["title"] == "New Title"
+
+
+def test_pr_update_title_and_body() -> None:
+    response = {"number": 3, "title": "T", "html_url": "https://github.com/a/b/pull/3"}
+    with patch(
+        "urllib.request.urlopen", return_value=_mock_resp(200, json.dumps(response))
+    ):
+        cp = github_api.pr_update(
+            "owner/repo", pr_number=3, token="tok", title="T", body="B"
+        )
+    assert cp.returncode == 0


### PR DESCRIPTION
## 🧾 Title
feat(agent): add pr update command

## 🧠 Description
This pull request adds `repo-scaffold pr update` so agents and users can update the title and/or body of an existing pull request without leaving the CLI or touching the GitHub UI.

## 🧩 Changes Included
- [x] Added `pr_update()` to `github_api.py` — PATCH `/repos/{repo}/pulls/{n}`
- [x] Wired `repo-scaffold pr update --repo --pr-number [--title] [--body]` in `cli.py`
- [x] Error if neither `--title` nor `--body` is provided
- [x] Added unit tests: body-only, title-only, and combined

## 🎯 Purpose
Without this command, updating a PR body required either the GitHub UI or raw API calls — both bypassing repo-scaffold's portable, token-based approach. This closes the gap and makes PR lifecycle management fully available through the CLI.

## 🔗 Related Issues / Epics
- **Epic:** #48
- **Issue:** #100
- **Closes:** Fixes #100

## 🧪 Testing
1. `poetry run pytest tests/test_github_api.py` — all new tests pass
2. `poetry run repo-scaffold pr update --repo owner/repo --pr-number N --body "new body"`
3. Verify PR body updated on GitHub

## 🧰 Developer Notes
- [ ] Verify environment variables are configured properly
- [ ] Ensure code runs under both local and CI/CD environments