### PR TITLE
feat(project): fix ProjectV2 visibility field + add project item-add command (#102)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,11 +59,19 @@ poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N [--json]
 poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
 poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
 poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRANCH [--base main] [--body "TEXT"] [--draft]
+poetry run repo-scaffold pr update --repo OWNER/REPO --pr-number N [--title "TITLE"] [--body "TEXT"]
 
 # Projects
-poetry run repo-scaffold project items --project-title "TITLE" --limit 40
 poetry run repo-scaffold project list --project-owner OWNER
 poetry run repo-scaffold project view --project-title "TITLE"
+poetry run repo-scaffold project items --project-title "TITLE" --limit 40
+poetry run repo-scaffold project create --project-owner OWNER --project-title "TITLE" [--description "TEXT"]
+poetry run repo-scaffold project edit --project-owner OWNER --project-title "TITLE" [--title "NEW"] [--description "TEXT"]
+poetry run repo-scaffold project sync-metadata --project-owner OWNER --project-title "TITLE" --repo OWNER/REPO
+poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N
+poetry run repo-scaffold project item-delete --project-title "TITLE" --issue-number N
+poetry run repo-scaffold project delete --project-owner OWNER --project-title "TITLE"  # dangerous — requires backup
+poetry run repo-scaffold project undo --project-owner OWNER  # restore from last backup
 
 # Backlog
 poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
@@ -91,8 +99,9 @@ poetry run repo-scaffold check rules --repo OWNER/REPO
 ## GitHub auth
 Token lives in `.env` as `GH_TOKEN`. Commands pick it up automatically via `_seed_env_from_dotenv`.
 
-## Nothing missing — full lifecycle coverage
+## Coverage
 All GitHub operations (repos, issues, PRs, projects, backlog) are implemented via GH_TOKEN + urllib. No `gh` CLI required.
+
 
 ## Running tests
 ```bash

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Subcommands:
 - `create --project-title T [--project-owner OWNER] [--description TEXT] [--readme MD] [--visibility PUBLIC|PRIVATE] [--dry-run]`: create a project
 - `edit (--project-number N | --project-title T) [--project-owner OWNER] [--title T] [--description TEXT] [--readme MD] [--visibility PUBLIC|PRIVATE] [--dry-run]`: update project metadata
 - `delete (--project-number N | --project-title T) [--project-owner OWNER] --danger [--yes] [--dry-run] [--backup-dir PATH]`: delete a project with automatic backup + undo snapshot
+- `item-add (--project-number N | --project-title T) [--project-owner OWNER] --repo OWNER/REPO --issue-number N`: add an existing issue to a project
 - `item-delete (--project-number N | --project-title T) [--project-owner OWNER] (--item-id ID | --issue-number N) --danger [--yes] [--dry-run] [--backup-dir PATH]`: delete a project item with automatic backup + undo snapshot
 - `undo --backup-file PATH [--dry-run]`: restore a destructive backup snapshot
 
@@ -203,6 +204,37 @@ poetry run repo-scaffold project items --project-owner acme --project-title "Roa
 poetry run repo-scaffold project item-delete --project-owner acme --project-title "Roadmap" --issue-number 42 --danger --yes
 poetry run repo-scaffold project undo --backup-file /path/to/artifacts/project-backups/project-item-delete-<timestamp>-<suffix>.json
 ```
+
+### `issue`
+
+Query and manage GitHub issues.
+
+```bash
+poetry run repo-scaffold issue list --repo OWNER/REPO [--state open|closed|all] [--json]
+poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N [--json]
+poetry run repo-scaffold issue create --repo OWNER/REPO --title "TITLE" [--body "TEXT"] [--label L] [--assignee U]
+poetry run repo-scaffold issue close --repo OWNER/REPO --issue-number N
+poetry run repo-scaffold issue comment --repo OWNER/REPO --issue-number N --body "TEXT"
+poetry run repo-scaffold issue label --repo OWNER/REPO --issue-number N [--add L] [--remove L]
+poetry run repo-scaffold issue assign --repo OWNER/REPO --issue-number N [--add USER] [--remove USER]
+```
+
+---
+
+### `pr`
+
+Query and manage GitHub pull requests.
+
+```bash
+poetry run repo-scaffold pr list --repo OWNER/REPO [--json]
+poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRANCH [--base main] [--body "TEXT"] [--draft]
+poetry run repo-scaffold pr update --repo OWNER/REPO --pr-number N [--title "TITLE"] [--body "TEXT"]
+poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
+poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
+```
+
+---
 
 ### `delete`
 

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -57,6 +57,7 @@ from .project_ops import (
     ProjectItemsSummary,
     ProjectListSummary,
     ProjectMutationSummary,
+    add_project_item,
     create_project,
     delete_project,
     delete_project_item,
@@ -678,6 +679,29 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_project_target_args(project_delete_cmd)
     _add_danger_args(project_delete_cmd)
+
+    project_item_add_cmd = project_sub.add_parser(
+        "item-add",
+        help="Add an existing issue to a project",
+    )
+    project_item_add_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution (default: .)",
+    )
+    _add_project_target_args(project_item_add_cmd)
+    project_item_add_cmd.add_argument(
+        "--issue-number",
+        required=True,
+        type=int,
+        dest="issue_number",
+        help="GitHub issue number to add to the project",
+    )
+    project_item_add_cmd.add_argument(
+        "--repo",
+        required=True,
+        help="Repo containing the issue (owner/repo)",
+    )
 
     project_item_delete_cmd = project_sub.add_parser(
         "item-delete",
@@ -1507,6 +1531,16 @@ def main(argv: list[str] | None = None) -> int:
                     is_tty=sys.stdin.isatty(),
                     out=print,
                     err=lambda line: print(line, file=sys.stderr),
+                )
+            elif ns.project_command == "item-add":
+                mutation_summary = add_project_item(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
+                    issue_repo=ns.repo,
+                    issue_number=ns.issue_number,
+                    out=print,
                 )
             elif ns.project_command == "item-delete":
                 mutation_summary = delete_project_item(

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -198,7 +198,7 @@ query($login: String!, $first: Int!, $after: String) {
       pageInfo { hasNextPage endCursor }
       nodes {
         id number title closed url
-        shortDescription readme
+        public shortDescription readme
       }
     }
   }
@@ -216,7 +216,7 @@ query($login: String!, $first: Int!, $after: String) {
       pageInfo { hasNextPage endCursor }
       nodes {
         id number title closed url
-        shortDescription readme
+        public shortDescription readme
       }
     }
   }
@@ -228,7 +228,7 @@ query($login: String!, $number: Int!) {
   user(login: $login) {
     projectV2(number: $number) {
       id number title closed url
-      visibility shortDescription readme
+      public shortDescription readme
     }
   }
 }
@@ -239,7 +239,7 @@ query($login: String!, $number: Int!) {
   organization(login: $login) {
     projectV2(number: $number) {
       id number title closed url
-      visibility shortDescription readme
+      public shortDescription readme
     }
   }
 }
@@ -249,7 +249,7 @@ _GQL_CREATE_PROJECT = """
 mutation($ownerId: ID!, $title: String!) {
   createProjectV2(input: {ownerId: $ownerId, title: $title}) {
     projectV2 {
-      id number title closed url shortDescription readme
+      id number title closed url public shortDescription readme
     }
   }
 }
@@ -271,7 +271,7 @@ mutation(
     public: $public
   }) {
     projectV2 {
-      id number title closed url shortDescription readme
+      id number title closed url public shortDescription readme
     }
   }
 }

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -198,7 +198,7 @@ query($login: String!, $first: Int!, $after: String) {
       pageInfo { hasNextPage endCursor }
       nodes {
         id number title closed url
-        visibility shortDescription readme
+        shortDescription readme
       }
     }
   }
@@ -216,7 +216,7 @@ query($login: String!, $first: Int!, $after: String) {
       pageInfo { hasNextPage endCursor }
       nodes {
         id number title closed url
-        visibility shortDescription readme
+        shortDescription readme
       }
     }
   }
@@ -249,7 +249,7 @@ _GQL_CREATE_PROJECT = """
 mutation($ownerId: ID!, $title: String!) {
   createProjectV2(input: {ownerId: $ownerId, title: $title}) {
     projectV2 {
-      id number title closed url visibility shortDescription readme
+      id number title closed url shortDescription readme
     }
   }
 }
@@ -271,7 +271,7 @@ mutation(
     public: $public
   }) {
     projectV2 {
-      id number title closed url visibility shortDescription readme
+      id number title closed url shortDescription readme
     }
   }
 }

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -446,6 +446,56 @@ def sync_project_metadata(
     )
 
 
+def add_project_item(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+    issue_repo: str,
+    issue_number: int,
+    out: Callable[[str], None] = print,
+) -> ProjectMutationSummary:
+    from .github_api import issue_node_id, project_item_add, token_from_repo
+
+    token = token_from_repo(repo_dir) or ""
+    project = _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+    if not project.id:
+        raise RuntimeError(f"Could not resolve project ID for '{project.title}'.")
+
+    repo_parts = issue_repo.split("/", 1)
+    if len(repo_parts) != 2:
+        raise RuntimeError(f"--repo must be in owner/repo format, got: {issue_repo}")
+    repo_owner, repo_name = repo_parts
+
+    content_id = issue_node_id(repo_owner, repo_name, issue_number, token)
+    if not content_id:
+        raise RuntimeError(
+            f"Could not resolve node ID for {issue_repo}#{issue_number}. "
+            "Check the issue number and repo."
+        )
+
+    cp = project_item_add(project.id, content_id, token)
+    if cp.returncode != 0:
+        raise RuntimeError(cp.stderr.strip() or "Failed adding item to project.")
+
+    out(f"Added {issue_repo}#{issue_number} to project '{project.title}'.")
+    return ProjectMutationSummary(
+        action="item-add",
+        owner=project.owner,
+        project_number=project.number,
+        project_title=project.title,
+        failures=0,
+        changed=True,
+        metadata_file=None,
+    )
+
+
 def create_project(
     *,
     repo_dir: Path,


### PR DESCRIPTION
## 🧾 Title
feat(project): fix ProjectV2 visibility field + add project item-add command

## 🧠 Description
This pull request fixes all project commands broken by GitHub removing the `visibility` field from `ProjectV2`, and adds the missing `project item-add` command for linking existing issues to a project. Also updates CLAUDE.md and README with complete issue, PR, and project command documentation.

## 🧩 Changes Included
- [x] Removed `visibility` from all 6 `ProjectV2` GraphQL return fragments
- [x] Added `add_project_item()` to `project_ops.py`
- [x] Wired `repo-scaffold project item-add --project-title T --repo R --issue-number N` in CLI
- [x] Updated CLAUDE.md: added `pr update`, full project command list
- [x] Updated README.md: added `issue` and `pr` command sections, added `item-add` to project docs

## 🎯 Purpose
All project commands (`list`, `view`, `create`, `edit`) were broken by a GitHub GraphQL API change. Additionally there was no CLI way to add an existing issue to a project without using the raw API. This unblocks both problems and closes the documentation gap.

## 🔗 Related Issues / Epics
- **Closes:** Fixes #102

## 🧪 Testing
1. `poetry run repo-scaffold project list --project-owner <org>` succeeds
2. `poetry run repo-scaffold project create --project-owner <org> --project-title "Test"` succeeds
3. `poetry run repo-scaffold project item-add --project-title "Test" --repo owner/repo --issue-number N` adds the issue

## 🧰 Developer Notes
- [ ] Verify environment variables are configured properly
- [ ] Ensure code runs under both local and CI/CD environments