### PR TITLE
feat(issue): add issue update command (#105)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N [--json]
 poetry run repo-scaffold issue list --repo OWNER/REPO [--state open|closed|all] [--json]
 poetry run repo-scaffold issue create --repo OWNER/REPO --title "TITLE" [--body "TEXT"] [--label L] [--assignee U]
 poetry run repo-scaffold issue close --repo OWNER/REPO --issue-number N
+poetry run repo-scaffold issue update --repo OWNER/REPO --issue-number N [--title "TITLE"] [--body "TEXT"]
 poetry run repo-scaffold issue comment --repo OWNER/REPO --issue-number N --body "TEXT"
 poetry run repo-scaffold issue label --repo OWNER/REPO --issue-number N [--add L] [--remove L]
 poetry run repo-scaffold issue assign --repo OWNER/REPO --issue-number N [--add USER] [--remove USER]

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ poetry run repo-scaffold issue list --repo OWNER/REPO [--state open|closed|all] 
 poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N [--json]
 poetry run repo-scaffold issue create --repo OWNER/REPO --title "TITLE" [--body "TEXT"] [--label L] [--assignee U]
 poetry run repo-scaffold issue close --repo OWNER/REPO --issue-number N
+poetry run repo-scaffold issue update --repo OWNER/REPO --issue-number N [--title "TITLE"] [--body "TEXT"]
 poetry run repo-scaffold issue comment --repo OWNER/REPO --issue-number N --body "TEXT"
 poetry run repo-scaffold issue label --repo OWNER/REPO --issue-number N [--add L] [--remove L]
 poetry run repo-scaffold issue assign --repo OWNER/REPO --issue-number N [--add USER] [--remove USER]

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -23,6 +23,7 @@ from .github_api import (
     issue_create,
     issue_label,
     issue_list,
+    issue_update,
     pr_comment,
     pr_create,
     pr_list,
@@ -856,6 +857,14 @@ def build_parser() -> argparse.ArgumentParser:
     issue_assign_cmd.add_argument(
         "--remove", action="append", dest="remove_users", metavar="USER"
     )
+
+    issue_update_cmd = issue_sub.add_parser("update", help="Update an existing issue")
+    issue_update_cmd.add_argument("--repo", required=True)
+    issue_update_cmd.add_argument(
+        "--issue-number", type=int, required=True, dest="issue_number"
+    )
+    issue_update_cmd.add_argument("--title", default=None)
+    issue_update_cmd.add_argument("--body", default=None)
 
     pr_cmd = subparsers.add_parser("pr", help="Interact with GitHub pull requests")
     pr_sub = pr_cmd.add_subparsers(dest="pr_command", required=True)
@@ -1806,6 +1815,25 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 return 1
             print(f"Assignees updated on #{ns.issue_number}.")
+            return 0
+
+        if ns.issue_command == "update":
+            if ns.title is None and ns.body is None:
+                print("Provide at least --title or --body.", file=sys.stderr)
+                return 2
+            cp = issue_update(
+                target_repo,
+                ns.issue_number,
+                token,
+                title=ns.title,
+                body=ns.body,
+            )
+            if cp.returncode != 0:
+                print(cp.stderr.strip() or "Failed updating issue.", file=sys.stderr)
+                return 1
+            updated = _json.loads(cp.stdout)
+            print(f"Issue updated: #{updated['number']} {updated['title']}")
+            print(f"URL: {updated['html_url']}")
             return 0
 
     if ns.mode == "pr":

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -736,6 +736,21 @@ def issue_close(repo: str, number: int, token: str) -> subprocess.CompletedProce
     return rest("PATCH", f"/repos/{repo}/issues/{number}", token, {"state": "closed"})
 
 
+def issue_update(
+    repo: str,
+    number: int,
+    token: str,
+    title: str | None = None,
+    body: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    payload: dict[str, object] = {}
+    if title is not None:
+        payload["title"] = title
+    if body is not None:
+        payload["body"] = body
+    return rest("PATCH", f"/repos/{repo}/issues/{number}", token, payload)
+
+
 def issue_comment(
     repo: str, number: int, body: str, token: str
 ) -> subprocess.CompletedProcess[str]:

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -395,3 +395,46 @@ def test_pr_update_title_and_body() -> None:
             "owner/repo", pr_number=3, token="tok", title="T", body="B"
         )
     assert cp.returncode == 0
+
+
+def test_issue_update_body_only() -> None:
+    response = {
+        "number": 42,
+        "title": "My Issue",
+        "html_url": "https://github.com/a/b/issues/42",
+    }
+    with patch(
+        "urllib.request.urlopen", return_value=_mock_resp(200, json.dumps(response))
+    ):
+        cp = github_api.issue_update("owner/repo", 42, "tok", body="new body")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert result["number"] == 42
+
+
+def test_issue_update_title_only() -> None:
+    response = {
+        "number": 7,
+        "title": "New Title",
+        "html_url": "https://github.com/a/b/issues/7",
+    }
+    with patch(
+        "urllib.request.urlopen", return_value=_mock_resp(200, json.dumps(response))
+    ):
+        cp = github_api.issue_update("owner/repo", 7, "tok", title="New Title")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert result["title"] == "New Title"
+
+
+def test_issue_update_title_and_body() -> None:
+    response = {
+        "number": 3,
+        "title": "T",
+        "html_url": "https://github.com/a/b/issues/3",
+    }
+    with patch(
+        "urllib.request.urlopen", return_value=_mock_resp(200, json.dumps(response))
+    ):
+        cp = github_api.issue_update("owner/repo", 3, "tok", title="T", body="B")
+    assert cp.returncode == 0


### PR DESCRIPTION
🧾 Title
Add `issue update` command to repo-scaffold

## 🧠 Description
Adds `issue update` subcommand so issue bodies and titles can be updated via the CLI without bypassing repo-scaffold. Required to reformat 59 muster-deck issues and 4 repo-scaffold issues to match ISSUE_TEMPLATE.

## 🧩 Changes Included
- [x] Added `issue_update()` to `github_api.py` -- PATCH `/repos/{repo}/issues/{n}` with optional title/body
- [x] Added `issue update` subcommand to `cli.py` (mirrors `pr update` pattern)
- [x] Added 3 unit tests: body-only, title-only, title+body

## 🎯 Purpose
Without this command, updating issue bodies requires bypassing repo-scaffold with raw API calls, violating the portability and agnosticism rules.

## 🔗 Related Issues / Epics
- **Issue:** #105
- **Closes:** Fixes #105

## 🧪 Testing
1. `poetry run pytest tests/test_github_api.py -q` -- all 28 tests pass
2. `poetry run repo-scaffold issue update --repo blairg23/repo-scaffold --issue-number 105 --body "new body"` updates issue body

## 🧰 Developer Notes
- [ ] Verify environment variables are configured properly
- [ ] Ensure code runs under both local and CI/CD environments
