### PR TITLE
feat(project): project management commands — link-repo, item-status (#104 #108)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ poetry run repo-scaffold project edit --project-owner OWNER --project-title "TIT
 poetry run repo-scaffold project sync-metadata --project-owner OWNER --project-title "TITLE" --repo OWNER/REPO
 poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N
 poetry run repo-scaffold project item-delete --project-title "TITLE" --issue-number N
+poetry run repo-scaffold project link-repo --project-title "TITLE" --repo OWNER/REPO
 poetry run repo-scaffold project delete --project-owner OWNER --project-title "TITLE"  # dangerous — requires backup
 poetry run repo-scaffold project undo --project-owner OWNER  # restore from last backup
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Subcommands:
 - `delete (--project-number N | --project-title T) [--project-owner OWNER] --danger [--yes] [--dry-run] [--backup-dir PATH]`: delete a project with automatic backup + undo snapshot
 - `item-add (--project-number N | --project-title T) [--project-owner OWNER] --repo OWNER/REPO --issue-number N`: add an existing issue to a project
 - `item-delete (--project-number N | --project-title T) [--project-owner OWNER] (--item-id ID | --issue-number N) --danger [--yes] [--dry-run] [--backup-dir PATH]`: delete a project item with automatic backup + undo snapshot
+- `link-repo (--project-number N | --project-title T) [--project-owner OWNER] --repo OWNER/REPO`: link a project to a repository so it appears in the repo's Projects tab
 - `undo --backup-file PATH [--dry-run]`: restore a destructive backup snapshot
 
 Behavior:

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -67,6 +67,7 @@ from .project_ops import (
     list_projects,
     sync_project_metadata,
     undo_project_backup,
+    update_project_item_status,
     view_project,
 )
 
@@ -702,6 +703,34 @@ def build_parser() -> argparse.ArgumentParser:
         "--repo",
         required=True,
         help="Repo containing the issue (owner/repo)",
+    )
+
+    project_item_status_cmd = project_sub.add_parser(
+        "item-status",
+        help="Move a project board card to a different status column",
+    )
+    project_item_status_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution (default: .)",
+    )
+    _add_project_target_args(project_item_status_cmd)
+    project_item_status_cmd.add_argument(
+        "--repo",
+        required=True,
+        help="Repo containing the issue (owner/repo)",
+    )
+    project_item_status_cmd.add_argument(
+        "--issue-number",
+        required=True,
+        type=int,
+        dest="issue_number",
+        help="Issue number to update",
+    )
+    project_item_status_cmd.add_argument(
+        "--status",
+        required=True,
+        help="Target status column name (e.g. 'In Progress', 'Done')",
     )
 
     project_item_delete_cmd = project_sub.add_parser(
@@ -1549,6 +1578,17 @@ def main(argv: list[str] | None = None) -> int:
                     project_title=ns.project_title,
                     issue_repo=ns.repo,
                     issue_number=ns.issue_number,
+                    out=print,
+                )
+            elif ns.project_command == "item-status":
+                mutation_summary = update_project_item_status(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
+                    issue_repo=ns.repo,
+                    issue_number=ns.issue_number,
+                    status=ns.status,
                     out=print,
                 )
             elif ns.project_command == "item-delete":

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -62,6 +62,7 @@ from .project_ops import (
     delete_project,
     delete_project_item,
     edit_project,
+    link_project_repo,
     list_project_items,
     list_projects,
     sync_project_metadata,
@@ -724,6 +725,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Linked GitHub issue number for the project item to delete",
     )
     _add_danger_args(project_item_delete_cmd)
+
+    project_link_repo_cmd = project_sub.add_parser(
+        "link-repo", help="Link a project to a GitHub repository"
+    )
+    project_link_repo_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution (default: .)",
+    )
+    _add_project_target_args(project_link_repo_cmd)
+    project_link_repo_cmd.add_argument(
+        "--repo",
+        required=True,
+        help="Repository to link (owner/repo)",
+    )
 
     project_undo_cmd = project_sub.add_parser(
         "undo", help="Undo a destructive project backup snapshot"
@@ -1558,6 +1574,15 @@ def main(argv: list[str] | None = None) -> int:
                     is_tty=sys.stdin.isatty(),
                     out=print,
                     err=lambda line: print(line, file=sys.stderr),
+                )
+            elif ns.project_command == "link-repo":
+                mutation_summary = link_project_repo(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
+                    repo=ns.repo,
+                    out=print,
                 )
             elif ns.project_command == "undo":
                 backup_file = Path(ns.backup_file)

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -325,6 +325,37 @@ mutation($projectId: ID!, $itemId: ID!) {
 }
 """
 
+_GQL_PROJECT_FIELDS = """
+query($projectId: ID!) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      fields(first: 30) {
+        nodes {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            options { id name }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_GQL_UPDATE_ITEM_FIELD = """
+mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $projectId
+    itemId: $itemId
+    fieldId: $fieldId
+    value: { singleSelectOptionId: $optionId }
+  }) {
+    projectV2Item { id }
+  }
+}
+"""
+
 
 def _project_nodes_from_data(data: dict[str, object]) -> list[dict[str, object]]:
     for key in ("user", "organization"):
@@ -515,6 +546,42 @@ def project_item_list(
             break
     payload = {"items": all_items, "totalCount": len(all_items)}
     return _ok(json.dumps(payload))
+
+
+def project_fields(
+    project_id: str,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    """Return single-select fields with their options for a project."""
+    cp = graphql(_GQL_PROJECT_FIELDS, {"projectId": project_id}, token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        data = json.loads(cp.stdout)
+        nodes = data.get("node", {}).get("fields", {}).get("nodes", [])
+        fields = [n for n in nodes if isinstance(n, dict) and "options" in n]
+        return _ok(json.dumps({"fields": fields}))
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response fetching project fields.")
+
+
+def project_item_update_field(
+    project_id: str,
+    item_id: str,
+    field_id: str,
+    option_id: str,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    return graphql(
+        _GQL_UPDATE_ITEM_FIELD,
+        {
+            "projectId": project_id,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "optionId": option_id,
+        },
+        token,
+    )
 
 
 def project_item_add(

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -496,6 +496,48 @@ def add_project_item(
     )
 
 
+def link_project_repo(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+    repo: str,
+    out: Callable[[str], None] = print,
+) -> ProjectMutationSummary:
+    from .github_api import link_project_to_repository, token_from_repo
+
+    token = token_from_repo(repo_dir) or ""
+    project = _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+    if not project.id:
+        raise RuntimeError(f"Could not resolve project ID for '{project.title}'.")
+
+    repo_parts = repo.split("/", 1)
+    if len(repo_parts) != 2:
+        raise RuntimeError(f"--repo must be in owner/repo format, got: {repo}")
+    repo_owner, repo_name = repo_parts
+
+    cp = link_project_to_repository(project.id, repo_owner, repo_name, token)
+    if cp.returncode != 0:
+        raise RuntimeError(cp.stderr.strip() or "Failed linking project to repository.")
+
+    out(f"Linked project '{project.title}' to {repo}.")
+    return ProjectMutationSummary(
+        action="link-repo",
+        owner=project.owner,
+        project_number=project.number,
+        project_title=project.title,
+        failures=0,
+        changed=True,
+        metadata_file=None,
+    )
+
+
 def create_project(
     *,
     repo_dir: Path,

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -496,6 +496,98 @@ def add_project_item(
     )
 
 
+def update_project_item_status(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+    issue_repo: str,
+    issue_number: int,
+    status: str,
+    out: Callable[[str], None] = print,
+) -> ProjectMutationSummary:
+    from .github_api import (
+        project_fields,
+        project_item_list,
+        project_item_update_field,
+        token_from_repo,
+    )
+
+    token = token_from_repo(repo_dir) or ""
+    project = _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+    if not project.id:
+        raise RuntimeError(f"Could not resolve project ID for '{project.title}'.")
+
+    cp = project_item_list(project.id, token, limit=500)
+    if cp.returncode != 0:
+        raise RuntimeError(cp.stderr.strip() or "Failed fetching project items.")
+    items_data: list[dict[str, object]] = json.loads(cp.stdout).get("items", [])
+    item_id: str | None = None
+    for raw_item in items_data:
+        content = raw_item.get("content")
+        if isinstance(content, dict) and content.get("number") == issue_number:
+            raw_id = raw_item.get("id")
+            item_id = str(raw_id) if raw_id is not None else None
+            break
+    if not item_id:
+        raise RuntimeError(
+            f"Issue #{issue_number} not found in project '{project.title}'."
+        )
+
+    cp = project_fields(project.id, token)
+    if cp.returncode != 0:
+        raise RuntimeError(cp.stderr.strip() or "Failed fetching project fields.")
+    fields: list[dict[str, object]] = json.loads(cp.stdout).get("fields", [])
+    status_field: dict[str, object] | None = None
+    for f in fields:
+        fname = f.get("name")
+        if isinstance(fname, str) and fname.lower() == "status":
+            status_field = f
+            break
+    if not status_field:
+        raise RuntimeError("No 'Status' single-select field found on this project.")
+
+    option_id: str | None = None
+    raw_options = status_field.get("options")
+    options: list[dict[str, object]] = (
+        raw_options if isinstance(raw_options, list) else []
+    )
+    for opt in options:
+        opt_name = opt.get("name")
+        if isinstance(opt_name, str) and opt_name.lower() == status.lower():
+            raw_oid = opt.get("id")
+            option_id = str(raw_oid) if raw_oid is not None else None
+            break
+    if not option_id:
+        available = [str(o.get("name", "")) for o in options]
+        raise RuntimeError(
+            f"Status '{status}' not found. Available: {', '.join(available)}"
+        )
+
+    cp = project_item_update_field(
+        project.id, item_id, str(status_field["id"]), option_id, token
+    )
+    if cp.returncode != 0:
+        raise RuntimeError(cp.stderr.strip() or "Failed updating item status.")
+
+    out(f"#{issue_number} in '{project.title}' -> {status}")
+    return ProjectMutationSummary(
+        action="item-status",
+        owner=project.owner,
+        project_number=project.number,
+        project_title=project.title,
+        failures=0,
+        changed=True,
+        metadata_file=None,
+    )
+
+
 def create_project(
     *,
     repo_dir: Path,

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -615,17 +615,23 @@ def link_project_repo(
     repo_owner, repo_name = repo_parts
 
     cp = link_project_to_repository(project.id, repo_owner, repo_name, token)
-    if cp.returncode != 0:
+    already_linked = cp.returncode != 0 and (
+        "already" in (cp.stderr or "").lower() and "link" in (cp.stderr or "").lower()
+    )
+    if cp.returncode != 0 and not already_linked:
         raise RuntimeError(cp.stderr.strip() or "Failed linking project to repository.")
 
-    out(f"Linked project '{project.title}' to {repo}.")
+    if already_linked:
+        out(f"Project '{project.title}' already linked to {repo} (no-op).")
+    else:
+        out(f"Linked project '{project.title}' to {repo}.")
     return ProjectMutationSummary(
         action="link-repo",
         owner=project.owner,
         project_number=project.number,
         project_title=project.title,
         failures=0,
-        changed=True,
+        changed=not already_linked,
         metadata_file=None,
     )
 

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -438,3 +438,43 @@ def test_issue_update_title_and_body() -> None:
     ):
         cp = github_api.issue_update("owner/repo", 3, "tok", title="T", body="B")
     assert cp.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# project_fields / project_item_update_field
+# ---------------------------------------------------------------------------
+
+
+def test_project_fields_returns_single_select_fields() -> None:
+    data = {
+        "node": {
+            "fields": {
+                "nodes": [
+                    {
+                        "id": "F_1",
+                        "name": "Status",
+                        "options": [
+                            {"id": "opt_todo", "name": "Todo"},
+                            {"id": "opt_prog", "name": "In Progress"},
+                            {"id": "opt_done", "name": "Done"},
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    with patch("urllib.request.urlopen", return_value=_graphql_ok(data)):
+        cp = github_api.project_fields("PV2_1", "tok")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert len(result["fields"]) == 1
+    assert result["fields"][0]["name"] == "Status"
+
+
+def test_project_item_update_field_success() -> None:
+    data = {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "PVTI_1"}}}
+    with patch("urllib.request.urlopen", return_value=_graphql_ok(data)):
+        cp = github_api.project_item_update_field(
+            "PV2_1", "PVTI_1", "F_1", "opt_prog", "tok"
+        )
+    assert cp.returncode == 0

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -395,3 +395,29 @@ def test_pr_update_title_and_body() -> None:
             "owner/repo", pr_number=3, token="tok", title="T", body="B"
         )
     assert cp.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# link_project_to_repository
+# ---------------------------------------------------------------------------
+
+
+def test_link_project_to_repository_success() -> None:
+    repo_id_data = {"repository": {"id": "R_abc"}}
+    link_data = {"linkProjectV2ToRepository": {"repository": {"id": "R_abc"}}}
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            _graphql_ok(repo_id_data),
+            _graphql_ok(link_data),
+        ],
+    ):
+        cp = github_api.link_project_to_repository("PV2_1", "acme", "my-repo", "tok")
+    assert cp.returncode == 0
+
+
+def test_link_project_to_repository_no_repo_id() -> None:
+    repo_id_data: dict = {"repository": None}
+    with patch("urllib.request.urlopen", return_value=_graphql_ok(repo_id_data)):
+        cp = github_api.link_project_to_repository("PV2_1", "acme", "missing", "tok")
+    assert cp.returncode != 0

--- a/tests/test_project_ops.py
+++ b/tests/test_project_ops.py
@@ -512,3 +512,158 @@ def test_undo_project_item_delete_restores_item(
 
     assert summary.failures == 0
     assert any(args[:2] == ["project", "item-add"] for args in calls)
+
+
+# ---------------------------------------------------------------------------
+# update_project_item_status
+# ---------------------------------------------------------------------------
+
+
+def _cp_err(stderr: str = "error") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+def _make_item_list_payload(issue_number: int, item_id: str) -> str:
+    return json.dumps(
+        {
+            "items": [
+                {
+                    "id": item_id,
+                    "content": {"type": "Issue", "number": issue_number},
+                }
+            ]
+        }
+    )
+
+
+def _make_fields_payload(field_id: str, options: list[dict]) -> str:
+    return json.dumps(
+        {"fields": [{"id": field_id, "name": "Status", "options": options}]}
+    )
+
+
+def _make_update_payload() -> str:
+    return json.dumps(
+        {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "PVTI_1"}}}
+    )
+
+
+def test_update_project_item_status_success(
+    tmp_path: pytest.MonkeyPatch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    options = [{"id": "opt_prog", "name": "In Progress"}]
+
+    calls: list[str] = []
+
+    def fake_find(repo_dir, owner, number, limit):
+        return [{"id": "PVTI_1", "content": {"type": "Issue", "number": 17}}]
+
+    def fake_project_item_list(project_id, token, limit=100):
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=_make_item_list_payload(17, "PVTI_1"),
+            stderr="",
+        )
+
+    def fake_project_fields(project_id, token):
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=_make_fields_payload("F_status", options),
+            stderr="",
+        )
+
+    def fake_project_item_update_field(project_id, item_id, field_id, option_id, token):
+        calls.append(option_id)
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=_make_update_payload(), stderr=""
+        )
+
+    def fake_find_project(*, repo_dir, owner, project_number, project_title):
+        from repo_scaffold.project_ops import ProjectInfo
+
+        return ProjectInfo(owner="acme", number=1, title="Roadmap", id="PV2_1")
+
+    def fake_token(repo_dir):
+        return "tok"
+
+    monkeypatch.setattr(project_ops, "_find_existing_project", fake_find_project)
+    import repo_scaffold.github_api as _ga
+
+    monkeypatch.setattr(_ga, "project_item_list", fake_project_item_list)
+    monkeypatch.setattr(_ga, "project_fields", fake_project_fields)
+    monkeypatch.setattr(
+        _ga, "project_item_update_field", fake_project_item_update_field
+    )
+    monkeypatch.setattr(_ga, "token_from_repo", fake_token)
+
+    summary = project_ops.update_project_item_status(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=1,
+        project_title="Roadmap",
+        issue_repo="acme/repo",
+        issue_number=17,
+        status="In Progress",
+        out=lambda _: None,
+    )
+
+    assert summary.failures == 0
+    assert summary.action == "item-status"
+    assert calls == ["opt_prog"]
+
+
+def test_update_project_item_status_bad_status(
+    tmp_path: pytest.MonkeyPatch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    options = [{"id": "opt_todo", "name": "Todo"}]
+
+    def fake_find_project(*, repo_dir, owner, project_number, project_title):
+        from repo_scaffold.project_ops import ProjectInfo
+
+        return ProjectInfo(owner="acme", number=1, title="Roadmap", id="PV2_1")
+
+    def fake_project_item_list(project_id, token, limit=100):
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=_make_item_list_payload(17, "PVTI_1"),
+            stderr="",
+        )
+
+    def fake_project_fields(project_id, token):
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=_make_fields_payload("F_status", options),
+            stderr="",
+        )
+
+    def fake_token(repo_dir):
+        return "tok"
+
+    monkeypatch.setattr(project_ops, "_find_existing_project", fake_find_project)
+    import repo_scaffold.github_api as _ga
+
+    monkeypatch.setattr(_ga, "project_item_list", fake_project_item_list)
+    monkeypatch.setattr(_ga, "project_fields", fake_project_fields)
+    monkeypatch.setattr(_ga, "token_from_repo", fake_token)
+
+    with pytest.raises(RuntimeError, match="not found"):
+        project_ops.update_project_item_status(
+            repo_dir=repo_dir,
+            owner="acme",
+            project_number=1,
+            project_title="Roadmap",
+            issue_repo="acme/repo",
+            issue_number=17,
+            status="Nonexistent",
+            out=lambda _: None,
+        )


### PR DESCRIPTION
## 🧾 Title
feat(project): project management commands — link-repo, item-status (#104 #108)

## 🧠 Description
Two missing project management commands needed for the agentic dev loop:

1. **`project link-repo`** — links a GitHub Project to a repository via `linkProjectV2ToRepository` so it appears in the repo's Projects tab
2. **`project item-status`** — moves a project board card between columns (e.g. Todo → In Progress → Done) via `updateProjectV2ItemFieldValue`

## 🧩 Changes Included
- [x] Added `_GQL_PROJECT_FIELDS` and `_GQL_UPDATE_ITEM_FIELD` GraphQL to `github_api.py`
- [x] Added `project_fields()` and `project_item_update_field()` to `github_api.py`
- [x] Added `update_project_item_status()` to `project_ops.py`
- [x] Added `link_project_repo()` to `project_ops.py`
- [x] Added `project link-repo` and `project item-status` subcommands to `cli.py`
- [x] Unit tests for all new API functions and project_ops orchestration
- [x] Updated README.md and CLAUDE.md

## 🎯 Purpose
The agentic dev loop needs to move board cards as work progresses. Without `item-status`, agents can pick up tickets and create PRs but can't advance the board. Without `link-repo`, projects created by `apply backlog` don't appear in the repo's Projects tab.

## 🔗 Related Issues / Epics
- **Closes:** #104, #108

## 🧪 Testing
1. `poetry run pytest tests/test_github_api.py -k "link_project or item_status or project_fields"` -- passes
2. `poetry run pytest tests/test_project_ops.py -k item_status` -- passes
3. `poetry run repo-scaffold project item-status --project-title "MusterDeck Roadmap" --project-owner ThePRIMEForge --repo ThePRIMEForge/muster-deck --issue-number 17 --status "In Progress"`

## 🧰 Developer Notes
- [ ] Verify environment variables are configured properly
- [ ] Ensure code runs under both local and CI/CD environments
