### PR TITLE
feat(branch/pr): add branch create/delete, pr merge/checks, issue list --label (#109 #110)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Before writing any code, verify every item below. These are non-negotiable and a
 ```bash
 # Issues
 poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N [--json]
-poetry run repo-scaffold issue list --repo OWNER/REPO [--state open|closed|all] [--json]
+poetry run repo-scaffold issue list --repo OWNER/REPO [--state open|closed|all] [--label LABEL] [--json]
 poetry run repo-scaffold issue create --repo OWNER/REPO --title "TITLE" [--body "TEXT"] [--label L] [--assignee U]
 poetry run repo-scaffold issue close --repo OWNER/REPO --issue-number N
 poetry run repo-scaffold issue update --repo OWNER/REPO --issue-number N [--title "TITLE"] [--body "TEXT"]
@@ -61,6 +61,12 @@ poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT
 poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
 poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRANCH [--base main] [--body "TEXT"] [--draft]
 poetry run repo-scaffold pr update --repo OWNER/REPO --pr-number N [--title "TITLE"] [--body "TEXT"]
+poetry run repo-scaffold pr merge --repo OWNER/REPO --pr-number N [--method squash|merge|rebase]
+poetry run repo-scaffold pr checks --repo OWNER/REPO --pr-number N [--json]
+
+# Branches
+poetry run repo-scaffold branch create --repo OWNER/REPO --name BRANCH [--from main]
+poetry run repo-scaffold branch delete --repo OWNER/REPO --name BRANCH
 
 # Projects
 poetry run repo-scaffold project list --project-owner OWNER

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ poetry run repo-scaffold project undo --backup-file /path/to/artifacts/project-b
 Query and manage GitHub issues.
 
 ```bash
-poetry run repo-scaffold issue list --repo OWNER/REPO [--state open|closed|all] [--json]
+poetry run repo-scaffold issue list --repo OWNER/REPO [--state open|closed|all] [--label LABEL] [--json]
 poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N [--json]
 poetry run repo-scaffold issue create --repo OWNER/REPO --title "TITLE" [--body "TEXT"] [--label L] [--assignee U]
 poetry run repo-scaffold issue close --repo OWNER/REPO --issue-number N
@@ -234,6 +234,19 @@ poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRAN
 poetry run repo-scaffold pr update --repo OWNER/REPO --pr-number N [--title "TITLE"] [--body "TEXT"]
 poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
 poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
+poetry run repo-scaffold pr merge --repo OWNER/REPO --pr-number N [--method squash|merge|rebase]
+poetry run repo-scaffold pr checks --repo OWNER/REPO --pr-number N [--json]
+```
+
+---
+
+### `branch`
+
+Create and delete GitHub branches via the API.
+
+```bash
+poetry run repo-scaffold branch create --repo OWNER/REPO --name BRANCH [--from main]
+poetry run repo-scaffold branch delete --repo OWNER/REPO --name BRANCH
 ```
 
 ---

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -17,6 +17,8 @@ from .backlog_ops import (
     resolve_project_target_for_auth_check,
 )
 from .github_api import (
+    branch_create,
+    branch_delete,
     issue_assign,
     issue_close,
     issue_comment,
@@ -24,9 +26,11 @@ from .github_api import (
     issue_label,
     issue_list,
     issue_update,
+    pr_checks,
     pr_comment,
     pr_create,
     pr_list,
+    pr_merge,
     pr_resolve_thread,
     pr_update,
     pr_view,
@@ -855,6 +859,7 @@ def build_parser() -> argparse.ArgumentParser:
     issue_list_cmd.add_argument(
         "--state", default="open", choices=["open", "closed", "all"]
     )
+    issue_list_cmd.add_argument("--label", default=None, help="Filter by label name")
     issue_list_cmd.add_argument("--json", action="store_true", dest="json_output")
 
     issue_create_cmd = issue_sub.add_parser("create", help="Create a new issue")
@@ -957,6 +962,35 @@ def build_parser() -> argparse.ArgumentParser:
     pr_resolve_cmd.add_argument("--repo", required=True)
     pr_resolve_cmd.add_argument("--thread-id", required=True, dest="thread_id")
 
+    pr_merge_cmd = pr_sub.add_parser("merge", help="Merge a pull request")
+    pr_merge_cmd.add_argument("--repo", required=True)
+    pr_merge_cmd.add_argument("--pr-number", required=True, type=int, dest="pr_number")
+    pr_merge_cmd.add_argument(
+        "--method",
+        default="squash",
+        choices=["squash", "merge", "rebase"],
+        help="Merge method (default: squash)",
+    )
+
+    pr_checks_cmd = pr_sub.add_parser("checks", help="Show CI check statuses for a PR")
+    pr_checks_cmd.add_argument("--repo", required=True)
+    pr_checks_cmd.add_argument("--pr-number", required=True, type=int, dest="pr_number")
+    pr_checks_cmd.add_argument("--json", action="store_true", dest="json_output")
+
+    branch_cmd = subparsers.add_parser("branch", help="Manage GitHub branches")
+    branch_sub = branch_cmd.add_subparsers(dest="branch_command", required=True)
+
+    branch_create_cmd = branch_sub.add_parser("create", help="Create a new branch")
+    branch_create_cmd.add_argument("--repo", required=True)
+    branch_create_cmd.add_argument("--name", required=True, help="New branch name")
+    branch_create_cmd.add_argument(
+        "--from", default="main", dest="base", help="Base branch (default: main)"
+    )
+
+    branch_delete_cmd = branch_sub.add_parser("delete", help="Delete a branch")
+    branch_delete_cmd.add_argument("--repo", required=True)
+    branch_delete_cmd.add_argument("--name", required=True, help="Branch to delete")
+
     return parser
 
 
@@ -974,6 +1008,7 @@ def _normalize_argv(argv: list[str] | None) -> list[str]:
         "project",
         "issue",
         "pr",
+        "branch",
     }:
         return raw
     # Backward-compatible behavior: previous root command maps to init.
@@ -1802,7 +1837,7 @@ def main(argv: list[str] | None = None) -> int:
         token = token_from_repo(Path.cwd()) or ""
 
         if ns.issue_command == "list":
-            cp = issue_list(target_repo, token, state=ns.state)
+            cp = issue_list(target_repo, token, state=ns.state, label=ns.label)
             if cp.returncode != 0:
                 print(cp.stderr.strip() or "Failed listing issues.", file=sys.stderr)
                 return 1
@@ -2011,6 +2046,61 @@ def main(argv: list[str] | None = None) -> int:
             updated = _json.loads(cp.stdout)
             print(f"PR updated: #{updated['number']} {updated['title']}")
             print(f"URL: {updated['html_url']}")
+            return 0
+
+        if ns.pr_command == "merge":
+            cp = pr_merge(target_repo, ns.pr_number, token, method=ns.method)
+            if cp.returncode not in (0, 200):
+                print(cp.stderr.strip() or "Failed merging PR.", file=sys.stderr)
+                return 1
+            result = _json.loads(cp.stdout)
+            print(f"PR #{ns.pr_number} merged: {result.get('message', 'OK')}")
+            return 0
+
+        if ns.pr_command == "checks":
+            cp = pr_checks(target_repo, ns.pr_number, token)
+            if cp.returncode != 0:
+                print(cp.stderr.strip() or "Failed fetching checks.", file=sys.stderr)
+                return 1
+            runs = _json.loads(cp.stdout)
+            if ns.json_output:
+                print(_json.dumps(runs, indent=2))
+            else:
+                if not runs:
+                    print("No check runs found.")
+                for r in runs:
+                    status = r.get("status", "?")
+                    conclusion = r.get("conclusion") or status
+                    print(f"  {r.get('name', '?')}: {conclusion}")
+            return 0
+
+    if ns.mode == "branch":
+        import json as _json
+
+        target_repo, repo_error = _resolve_repo_from_args_or_env(
+            repo=ns.repo, fallback_name=None
+        )
+        if repo_error:
+            print(repo_error, file=sys.stderr)
+            return 2
+        assert target_repo is not None
+        token = token_from_repo(Path.cwd()) or ""
+
+        if ns.branch_command == "create":
+            cp = branch_create(target_repo, ns.name, token, base=ns.base)
+            if cp.returncode not in (0, 201):
+                print(cp.stderr.strip() or "Failed creating branch.", file=sys.stderr)
+                return 1
+            ref = _json.loads(cp.stdout)
+            print(f"Branch created: {ref.get('ref', ns.name)}")
+            return 0
+
+        if ns.branch_command == "delete":
+            cp = branch_delete(target_repo, ns.name, token)
+            if cp.returncode not in (0, 204):
+                print(cp.stderr.strip() or "Failed deleting branch.", file=sys.stderr)
+                return 1
+            print(f"Branch deleted: {ns.name}")
             return 0
 
     parser.error("Unsupported command.")

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -795,8 +795,12 @@ def issue_list(
     repo: str,
     token: str,
     state: str = "open",
+    label: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    return rest_paginated(f"/repos/{repo}/issues?state={state}&per_page=100", token)
+    qs = f"state={state}&per_page=100"
+    if label:
+        qs += f"&labels={urllib.parse.quote(label, safe='')}"
+    return rest_paginated(f"/repos/{repo}/issues?{qs}", token)
 
 
 def issue_close(repo: str, number: int, token: str) -> subprocess.CompletedProcess[str]:
@@ -1019,6 +1023,94 @@ def pr_update(
     if body is not None:
         payload["body"] = body
     return rest("PATCH", f"/repos/{repo}/pulls/{pr_number}", token, payload)
+
+
+def branch_get_sha(repo: str, branch: str, token: str) -> str | None:
+    """Return the HEAD SHA of a branch, or None if not found."""
+    cp = rest("GET", f"/repos/{repo}/git/refs/heads/{branch}", token)
+    if cp.returncode != 0:
+        return None
+    try:
+        data = json.loads(cp.stdout)
+        # API returns a list when using prefix match; exact name is first entry
+        entry = data[0] if isinstance(data, list) else data
+        return entry.get("object", {}).get("sha")
+    except (json.JSONDecodeError, IndexError, AttributeError):
+        return None
+
+
+def branch_create(
+    repo: str,
+    name: str,
+    token: str,
+    base: str = "main",
+) -> subprocess.CompletedProcess[str]:
+    sha = branch_get_sha(repo, base, token)
+    if not sha:
+        return _err(f"Could not resolve SHA for base branch '{base}'.")
+    return rest(
+        "POST",
+        f"/repos/{repo}/git/refs",
+        token,
+        {"ref": f"refs/heads/{name}", "sha": sha},
+    )
+
+
+def branch_delete(
+    repo: str,
+    name: str,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    return rest("DELETE", f"/repos/{repo}/git/refs/heads/{name}", token)
+
+
+def pr_merge(
+    repo: str,
+    pr_number: int,
+    token: str,
+    method: str = "squash",
+) -> subprocess.CompletedProcess[str]:
+    return rest(
+        "PUT",
+        f"/repos/{repo}/pulls/{pr_number}/merge",
+        token,
+        {"merge_method": method},
+    )
+
+
+def pr_checks(
+    repo: str,
+    pr_number: int,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    """Return check-run statuses for a PR's head commit."""
+    cp = rest("GET", f"/repos/{repo}/pulls/{pr_number}", token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        sha = json.loads(cp.stdout)["head"]["sha"]
+    except (json.JSONDecodeError, KeyError):
+        return _err("Could not extract head SHA from PR.")
+    cp2 = rest_paginated(f"/repos/{repo}/commits/{sha}/check-runs?per_page=100", token)
+    if cp2.returncode != 0:
+        return cp2
+    try:
+        items = json.loads(cp2.stdout)
+        # Deduplicate by name, keeping latest by id
+        seen: dict[str, dict[str, object]] = {}
+        for run in items:
+            n = str(run.get("name", ""))
+            run_id = run.get("id", 0)
+            seen_id = seen[n].get("id", 0) if n in seen else 0
+            if n not in seen or (
+                isinstance(run_id, int)
+                and isinstance(seen_id, int)
+                and run_id > seen_id
+            ):
+                seen[n] = run
+        return _ok(json.dumps(list(seen.values())))
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response from check-runs API.")
 
 
 def token_from_repo(repo_dir: Path) -> str | None:

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1091,11 +1091,12 @@ def pr_checks(
         sha = json.loads(cp.stdout)["head"]["sha"]
     except (json.JSONDecodeError, KeyError):
         return _err("Could not extract head SHA from PR.")
-    cp2 = rest_paginated(f"/repos/{repo}/commits/{sha}/check-runs?per_page=100", token)
+    cp2 = rest("GET", f"/repos/{repo}/commits/{sha}/check-runs?per_page=100", token)
     if cp2.returncode != 0:
         return cp2
     try:
-        items = json.loads(cp2.stdout)
+        payload = json.loads(cp2.stdout)
+        items = payload.get("check_runs", []) if isinstance(payload, dict) else payload
         # Deduplicate by name, keeping latest by id
         seen: dict[str, dict[str, object]] = {}
         for run in items:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1775,7 +1775,7 @@ def test_issue_list(
     ]
     monkeypatch.setattr(
         "repo_scaffold.cli.issue_list",
-        lambda repo, token, state="open": subprocess.CompletedProcess(
+        lambda repo, token, state="open", label=None: subprocess.CompletedProcess(
             args=[], returncode=0, stdout=json.dumps(issues), stderr=""
         ),
     )
@@ -2069,3 +2069,87 @@ def test_pr_create(
     out = capsys.readouterr().out
     assert "PR created: #10" in out
     assert "https://github.com/acme/repo/pull/10" in out
+
+
+def test_pr_merge(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_merge",
+        lambda repo, pr_number, token, method="squash": subprocess.CompletedProcess(
+            args=[],
+            returncode=200,
+            stdout=json.dumps(
+                {
+                    "sha": "abc",
+                    "merged": True,
+                    "message": "Pull Request successfully merged",
+                }
+            ),
+            stderr="",
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["pr", "merge", "--repo", "acme/repo", "--pr-number", "42"])
+    assert rc == 0
+    assert "merged" in capsys.readouterr().out
+
+
+def test_pr_checks(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    runs = [{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_checks",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(runs), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["pr", "checks", "--repo", "acme/repo", "--pr-number", "42"])
+    assert rc == 0
+    assert "CI" in capsys.readouterr().out
+
+
+def test_branch_create(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.branch_create",
+        lambda repo, name, token, base="main": subprocess.CompletedProcess(
+            args=[],
+            returncode=201,
+            stdout=json.dumps({"ref": "refs/heads/feat/foo", "object": {"sha": "abc"}}),
+            stderr="",
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["branch", "create", "--repo", "acme/repo", "--name", "feat/foo"])
+    assert rc == 0
+    assert "feat/foo" in capsys.readouterr().out
+
+
+def test_branch_delete(tmp_path, monkeypatch, capsys) -> None:
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.branch_delete",
+        lambda repo, name, token: subprocess.CompletedProcess(
+            args=[], returncode=204, stdout="", stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["branch", "delete", "--repo", "acme/repo", "--name", "feat/foo"])
+    assert rc == 0
+    assert "feat/foo" in capsys.readouterr().out

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -555,12 +555,18 @@ def test_pr_merge_success() -> None:
 
 def test_pr_checks_success() -> None:
     pr_data = {"head": {"sha": "abc123"}}
-    runs = [{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}]
+    # Real API returns {total_count, check_runs: [...]} not a bare array
+    runs_payload = {
+        "total_count": 1,
+        "check_runs": [
+            {"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}
+        ],
+    }
     with patch(
         "urllib.request.urlopen",
         side_effect=[
             _mock_resp(200, json.dumps(pr_data)),
-            _mock_resp(200, json.dumps(runs)),
+            _mock_resp(200, json.dumps(runs_payload)),
         ],
     ):
         cp = github_api.pr_checks("owner/repo", 42, "tok")

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -504,3 +504,76 @@ def test_project_item_update_field_success() -> None:
             "PV2_1", "PVTI_1", "F_1", "opt_prog", "tok"
         )
     assert cp.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# branch_create / branch_delete / pr_merge / pr_checks / issue_list --label
+# ---------------------------------------------------------------------------
+
+
+def test_branch_create_success() -> None:
+    sha_data = [{"object": {"sha": "abc123"}}]
+    ref_data = {"ref": "refs/heads/feat/foo", "object": {"sha": "abc123"}}
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            _mock_resp(200, json.dumps(sha_data)),
+            _mock_resp(201, json.dumps(ref_data)),
+        ],
+    ):
+        cp = github_api.branch_create("owner/repo", "feat/foo", "tok", base="main")
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout)["ref"] == "refs/heads/feat/foo"
+
+
+def test_branch_create_bad_base() -> None:
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=_http_error(404, "not found"),
+    ):
+        cp = github_api.branch_create(
+            "owner/repo", "feat/foo", "tok", base="nonexistent"
+        )
+    assert cp.returncode != 0
+
+
+def test_branch_delete_success() -> None:
+    with patch("urllib.request.urlopen", return_value=_mock_resp(204, b"")):
+        cp = github_api.branch_delete("owner/repo", "feat/foo", "tok")
+    assert cp.returncode == 0
+
+
+def test_pr_merge_success() -> None:
+    resp = {"sha": "abc", "merged": True, "message": "Pull Request successfully merged"}
+    with patch(
+        "urllib.request.urlopen", return_value=_mock_resp(200, json.dumps(resp))
+    ):
+        cp = github_api.pr_merge("owner/repo", 42, "tok", method="squash")
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout)["merged"] is True
+
+
+def test_pr_checks_success() -> None:
+    pr_data = {"head": {"sha": "abc123"}}
+    runs = [{"id": 1, "name": "CI", "status": "completed", "conclusion": "success"}]
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            _mock_resp(200, json.dumps(pr_data)),
+            _mock_resp(200, json.dumps(runs)),
+        ],
+    ):
+        cp = github_api.pr_checks("owner/repo", 42, "tok")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert result[0]["name"] == "CI"
+
+
+def test_issue_list_with_label() -> None:
+    issues = [{"number": 1, "title": "MVP thing", "labels": [{"name": "mvp"}]}]
+    with patch(
+        "urllib.request.urlopen", return_value=_mock_resp(200, json.dumps(issues))
+    ):
+        cp = github_api.issue_list("owner/repo", "tok", label="mvp")
+    assert cp.returncode == 0
+    assert len(json.loads(cp.stdout)) == 1


### PR DESCRIPTION
## 🧾 Title
feat(branch/pr): add branch create/delete, pr merge/checks, issue list --label (#109 #110)

## 🧠 Description
Completes the agentic dev loop. Five new commands across three areas:

**Branch management (#109)**
- `branch create --repo OWNER/REPO --name BRANCH [--from main]` — creates a branch pointing to the base branch HEAD SHA
- `branch delete --repo OWNER/REPO --name BRANCH` — deletes a branch

**PR management (#110)**
- `pr merge --repo OWNER/REPO --pr-number N [--method squash|merge|rebase]` — merges a PR
- `pr checks --repo OWNER/REPO --pr-number N [--json]` — shows CI check run statuses, deduplicated by name

**Issue filtering (#110)**
- `issue list --label LABEL` — filters issues by label (e.g. `--label mvp`)

## 🧩 Changes Included
- [x] `branch_create()`, `branch_delete()`, `pr_merge()`, `pr_checks()` in `github_api.py`
- [x] `issue_list()` gains optional `label` param
- [x] All 5 subcommands wired into `cli.py`
- [x] Unit tests in `test_github_api.py` and `test_cli.py`
- [x] README.md and CLAUDE.md updated

## 🎯 Purpose
Agents can now: pick a ticket (`issue list --label mvp`), create a branch, implement, PR, check CI (`pr checks`), merge (`pr merge`), and delete the branch — entirely through repo-scaffold without touching a shell.

## 🔗 Related Issues / Epics
- **Closes:** #109, #110

## 🧪 Testing
1. `poetry run pytest tests/test_github_api.py -k "branch or pr_merge or pr_checks or issue_list"` -- passes
2. `poetry run pytest tests/test_cli.py -k "branch or pr_merge or pr_checks"` -- passes
3. All 183 tests pass, coverage at 70%

## 🧰 Developer Notes
- [ ] Verify environment variables are configured properly
- [ ] Ensure code runs under both local and CI/CD environments
