### PR TITLE
feat(settings): add squash merge commit title/message defaults and disable auto-merge (#112)

### DIFF
--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -61,10 +61,12 @@ def _repo_patch_payload() -> str:
     return json.dumps(
         {
             "allow_squash_merge": True,
+            "squash_merge_commit_title": "PR_TITLE",
+            "squash_merge_commit_message": "PR_BODY",
             "allow_merge_commit": False,
             "allow_rebase_merge": False,
             "delete_branch_on_merge": True,
-            "allow_auto_merge": True,
+            "allow_auto_merge": False,
             "is_template": False,
         },
         indent=2,

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -1265,10 +1265,12 @@ gh api \
   --input - >/dev/null <<'JSON'
 {
   "allow_squash_merge": true,
+  "squash_merge_commit_title": "PR_TITLE",
+  "squash_merge_commit_message": "PR_BODY",
   "allow_merge_commit": false,
   "allow_rebase_merge": false,
   "delete_branch_on_merge": true,
-  "allow_auto_merge": true,
+  "allow_auto_merge": false,
   "is_template": false
 }
 JSON

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -747,8 +747,10 @@ def test_apply_settings_uses_ruleset_and_public_security_defaults(
     assert payload["allow_merge_commit"] is False
     assert payload["allow_rebase_merge"] is False
     assert payload["allow_squash_merge"] is True
+    assert payload["squash_merge_commit_title"] == "PR_TITLE"
+    assert payload["squash_merge_commit_message"] == "PR_BODY"
     assert payload["delete_branch_on_merge"] is True
-    assert payload["allow_auto_merge"] is True
+    assert payload["allow_auto_merge"] is False
     assert payload["is_template"] is False
     assert calls["default_branch"] == "main"
     assert calls["ruleset_repo"] == "acme/repo"


### PR DESCRIPTION
## 🧾 Title
feat(settings): add squash merge commit title/message defaults and disable auto-merge (#112)

## 🧠 Description
Two repo settings were missing from the baseline. This adds them to the payload applied by `repo-scaffold create` and validated by `check rules`.

## 🧩 Changes Included
- [x] `squash_merge_commit_title: "PR_TITLE"` — squash commits use the PR title
- [x] `squash_merge_commit_message: "PR_BODY"` — squash commits include the full PR description
- [x] `allow_auto_merge: False` — PRs require explicit manual merge
- [x] Updated `test_create_ops.py` to assert all three new fields

## 🎯 Purpose
Ensures every repo-scaffold'd repo gets consistent, clean squash commit messages (PR title + description) and doesn't allow auto-merge.

## 🔗 Related Issues / Epics
- **Closes:** Fixes #112

## 🧪 Testing
1. `poetry run pytest tests/test_create_ops.py -q` passes
2. All 183 tests pass

## 🧰 Developer Notes
- [ ] Verify environment variables are configured properly
- [ ] Ensure code runs under both local and CI/CD environments
