### PR TITLE
fix(ci): remove invalid env.LANGUAGES and hashFiles from job-level conditions

### DIFF
--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -192,14 +192,17 @@ def _render_ci_yaml(languages: Iterable[str]) -> str:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install pre-commit
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pre-commit
       - name: Run non-tox pre-commit hooks
         env:
           SKIP: tox-suite
-        run: pre-commit run --all-files --show-diff-on-failure
+        run: |
+          if [ ! -f .pre-commit-config.yaml ]; then
+            echo "No .pre-commit-config.yaml found; skipping."
+            exit 0
+          fi
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure
 
 """)
 

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -178,20 +178,14 @@ contact_links:
 
 
 def _render_ci_yaml(languages: Iterable[str]) -> str:
-    joined = ",".join(languages)
-    return f"""name: CI
+    selected = set(languages)
+    parts: list[str] = [
+        "name: CI\n\non: [push, pull_request]\n\npermissions:\n  contents: read\n\njobs:\n",
+    ]
 
-on: [push, pull_request]
-
-permissions:
-  contents: read
-
-env:
-  LANGUAGES: "{joined}"
-
-jobs:
+    if "python" in selected:
+        parts.append("""\
   pre-commit-hooks:
-    if: hashFiles('.pre-commit-config.yaml') != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -207,8 +201,11 @@ jobs:
           SKIP: tox-suite
         run: pre-commit run --all-files --show-diff-on-failure
 
+""")
+
+    if "go" in selected:
+        parts.append("""\
   go:
-    if: contains(env.LANGUAGES, 'go') && hashFiles('go.mod') != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -230,8 +227,11 @@ jobs:
         with:
           version: v1.61
 
+""")
+
+    if "gin" in selected:
+        parts.append("""\
   gin:
-    if: contains(env.LANGUAGES, 'gin') && hashFiles('go.mod') != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -255,8 +255,11 @@ jobs:
         with:
           version: v1.61
 
+""")
+
+    if "python" in selected:
+        parts.append("""\
   python:
-    if: contains(env.LANGUAGES, 'python') && hashFiles('pyproject.toml') != ''
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -271,8 +274,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox
-      - name: Run tox (${{{{ matrix.tox-env }}}})
-        run: tox -e ${{{{ matrix.tox-env }}}}
+      - name: Run tox (${{ matrix.tox-env }})
+        run: tox -e ${{ matrix.tox-env }}
       - name: Upload coverage.xml artifact
         if: matrix.tox-env == 'coverage'
         uses: actions/upload-artifact@v4
@@ -287,10 +290,13 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: false
         env:
-          CODECOV_TOKEN: ${{{{ secrets.CODECOV_TOKEN }}}}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+""")
+
+    if "react" in selected:
+        parts.append("""\
   react:
-    if: contains(env.LANGUAGES, 'react') && hashFiles('web/package.json') != ''
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -320,7 +326,9 @@ jobs:
           else
             echo "No test script defined; skipping tests."
           fi
-"""
+""")
+
+    return "".join(parts)
 
 
 def _render_codeql_yaml(languages: Iterable[str]) -> str:

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -91,7 +91,7 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     )
     ci_yaml = (out_dir / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     assert "pre-commit-hooks:" in ci_yaml
-    assert "name: Install pre-commit" in ci_yaml
+    assert "pip install pre-commit" in ci_yaml
     assert "SKIP: tox-suite" in ci_yaml
     assert "pre-commit run --all-files --show-diff-on-failure" in ci_yaml
     assert "tox-env: [lint, type, coverage]" in ci_yaml

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -319,8 +319,10 @@ def test_react_vite_scaffold_file_contents(tmp_path: Path) -> None:
     assert "eslint-plugin-react-refresh" in eslint_cfg
 
     ci = (cfg.out_dir / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    assert "contains(env.LANGUAGES, 'react')" in ci
-    assert "hashFiles('web/package.json')" in ci
+    assert "react:" in ci
+    assert "working-directory: web" in ci
+    assert "contains(env.LANGUAGES" not in ci
+    assert "hashFiles(" not in ci
 
     gitignore = (cfg.out_dir / ".gitignore").read_text(encoding="utf-8")
     assert "web/node_modules/" in gitignore


### PR DESCRIPTION
## Summary

- Rewrite `_render_ci_yaml()` to emit job blocks only for the selected languages, removing the invalid `env.LANGUAGES` top-level variable and all job-level `if` conditions that used `env` context or `hashFiles()`
- GitHub Actions does not allow `env` context or `hashFiles()` in job-level `if` conditions -- they are only valid at step level
- The generator has been emitting invalid workflow YAML since the `env.LANGUAGES` pattern was introduced
- Update two test assertions that checked for the now-removed patterns

## Motivation

Every repo generated with `apply ci` had a broken workflow file that would fail at parse time with:

```
Unrecognized function: 'hashFiles'. Located at position 1 within expression: hashFiles('.pre-commit-config.yaml') != ''
Unrecognized named-value: 'env'. Located at position 10 within expression: contains(env.LANGUAGES, 'go') && hashFiles('go.mod') != ''
```

The fix is elegant: since the generator already knows which languages are selected at generation time, there is no need for runtime detection in the workflow at all. Just don't emit job blocks for languages that aren't selected.

## Test plan

- [ ] `poetry run pytest tests/test_generation.py` passes
- [ ] Generated react-only workflow contains only the `react` job with no job-level `if`
- [ ] Generated python+go workflow contains `pre-commit-hooks`, `go`, `python` jobs -- no `gin` or `react`

## Notes / Links

- Closes #121
- Companion fix applied directly to MusterDeck CI: ThePRIMEForge/muster-deck#92

🤖 Generated with [Claude Code](https://claude.com/claude-code)
