### PR TITLE
feat(generator): emit SPEC.md placeholder from build_scaffold_files()

### DIFF
--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -2930,6 +2930,143 @@ export default defineConfig({
 """
 
 
+def _render_spec_md(config: ScaffoldConfig) -> str:
+    selected = set(config.languages)
+    has_fe = "react" in selected
+    has_be = "python" in selected or "go" in selected or "gin" in selected
+    has_go = "go" in selected or "gin" in selected
+
+    parts: list[str] = [
+        f"# {config.name} -- SPEC\n\n"
+        "> Fill this in before creating any tickets. "
+        "Agents and contributors read this as the authoritative project description.\n\n"
+        "---\n\n"
+        "## Goal\n\n"
+        "<!-- One paragraph. What is this and why does it exist. -->\n\n"
+        "---\n\n"
+        "## Users\n\n"
+        "<!-- Who uses it and what do they need. -->\n\n"
+        "---\n\n"
+    ]
+
+    if has_fe:
+        parts.append(
+            "## Screens\n\n"
+            "<!-- List every screen with a one-line description. -->\n\n"
+            "| Screen | Description |\n"
+            "|--------|-------------|\n"
+            "| Home | ... |\n\n"
+            "---\n\n"
+        )
+    else:
+        parts.append(
+            "## Commands\n\n"
+            "<!-- List every CLI command or API endpoint with a one-line description. -->\n\n"
+            "| Command / Endpoint | Description |\n"
+            "|--------------------|-------------|\n"
+            "| ... | ... |\n\n"
+            "---\n\n"
+        )
+
+    parts.append("## Architecture\n\n")
+
+    if has_fe:
+        parts.append(
+            "### Frontend\n\n"
+            "- Framework: React + Vite\n"
+            "- Styling: Tailwind CSS\n"
+            "- Auth: Supabase Auth (JWT)\n"
+            "- Deploy: Netlify (preview on PR, production on merge to main)\n\n"
+        )
+
+    if has_be:
+        if has_go:
+            lang_line = "- Language: Go"
+            if "gin" in selected:
+                lang_line += " (Gin)"
+            parts.append(
+                "### Backend\n\n"
+                f"{lang_line}\n"
+                "- API style: REST\n"
+                "- Deploy: Coolify (Docker, self-hosted)\n\n"
+            )
+        else:
+            parts.append(
+                "### Backend\n\n"
+                "- Language: Python\n"
+                "- API style: REST\n"
+                "- Auth: Supabase Auth (JWT validation)\n"
+                "- Deploy: Coolify (Docker, self-hosted)\n\n"
+            )
+
+    if has_fe or has_be:
+        parts.append(
+            "### Data\n\n"
+            "- DB: Supabase (Postgres)\n"
+            "- Storage: Supabase Storage\n"
+            "- Migrations: Supabase CLI\n\n"
+        )
+
+    parts.append(
+        "### Infrastructure\n\n"
+        "- CI: GitHub Actions (lint, type check, build, test)\n"
+        "- Secrets: GitHub repository secrets\n"
+        "- Environments: preview (PR) + production (main branch)\n\n"
+        "---\n\n"
+        "## Data Model\n\n"
+        "<!-- Key entities and relationships. -->\n\n"
+        "```mermaid\n"
+        "erDiagram\n"
+        "    USER {\n"
+        "        uuid id PK\n"
+        "        string email\n"
+        "        timestamp created_at\n"
+        "    }\n"
+        "```\n\n"
+        "---\n\n"
+        "## Flows\n\n"
+        "<!-- Critical user flows. -->\n\n"
+        "```mermaid\n"
+        "sequenceDiagram\n"
+        "    participant User\n"
+        "    participant App\n"
+        "    participant API\n"
+        "    participant DB\n"
+        "    User->>App: Action\n"
+        "    App->>API: Request\n"
+        "    API->>DB: Query\n"
+        "    DB-->>API: Result\n"
+        "    API-->>App: Response\n"
+        "    App-->>User: Updated UI\n"
+        "```\n\n"
+        "---\n\n"
+        "## Non-functional Requirements\n\n"
+        "- Performance: ...\n"
+        "- Security: ...\n"
+    )
+
+    if has_fe:
+        parts.append("- Accessibility: WCAG 2.1 AA\n")
+
+    parts.append("- Platforms: ...\n\n" "---\n\n" "## Design\n\n")
+
+    if has_fe:
+        parts.append("<!-- Paste v0.dev link or Penpot link here. -->\n\n")
+    else:
+        parts.append(
+            "<!-- Mermaid diagrams above are sufficient for non-UI projects. -->\n\n"
+        )
+
+    parts.append(
+        "---\n\n"
+        "## Out of Scope (MVP)\n\n"
+        "<!-- Explicitly list what is NOT being built in v1. -->\n\n"
+        "- ...\n"
+    )
+
+    return "".join(parts)
+
+
 def build_scaffold_files(config: ScaffoldConfig) -> list[ScaffoldFile]:
     _ensure_license_supported(config.license_id)
 
@@ -2979,6 +3116,7 @@ def build_scaffold_files(config: ScaffoldConfig) -> list[ScaffoldFile]:
             _render_claude_settings_local(),
         ),
         ScaffoldFile(config.out_dir / "AGENTS.md", _render_agents_md(config)),
+        ScaffoldFile(config.out_dir / "SPEC.md", _render_spec_md(config)),
         ScaffoldFile(config.out_dir / "README.md", _render_repo_readme(config)),
         ScaffoldFile(config.out_dir / "LICENSE", _apache_2_license()),
         ScaffoldFile(

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -2980,7 +2980,17 @@ def _render_spec_md(config: ScaffoldConfig) -> str:
         )
 
     if has_be:
-        if has_go:
+        has_python_be = "python" in selected
+        if has_go and has_python_be:
+            go_lang = "Go (Gin)" if "gin" in selected else "Go"
+            parts.append(
+                "### Backend\n\n"
+                f"- Language: {go_lang}, Python\n"
+                "- API style: REST\n"
+                "- Auth: Supabase Auth (JWT validation)\n"
+                "- Deploy: Coolify (Docker, self-hosted)\n\n"
+            )
+        elif has_go:
             lang_line = "- Language: Go"
             if "gin" in selected:
                 lang_line += " (Gin)"

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 import repo_scaffold.generator as generator_module
-from repo_scaffold.generator import ScaffoldConfig, generate_scaffold
+from repo_scaffold.generator import ScaffoldConfig, _render_spec_md, generate_scaffold
 
 
 def _tree_hash(root: Path) -> str:
@@ -59,6 +59,7 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
         ".editorconfig",
         "Makefile",
         "scripts/first_time_setup.sh",
+        "SPEC.md",
         "go.mod",
         "cmd/demo/main.go",
         "internal/.gitkeep",
@@ -466,6 +467,77 @@ def test_gin_scaffold_generates_expected_files(tmp_path: Path) -> None:
     assert "gin" in readme.lower()
     assert ":8080" in readme
     assert "/health" in readme
+
+
+def _make_cfg(tmp_path: Path, languages: tuple[str, ...]) -> ScaffoldConfig:
+    return ScaffoldConfig(
+        name="testapp",
+        languages=languages,
+        owner="acme",
+        license_id="apache-2.0",
+        out_dir=tmp_path / "testapp",
+    )
+
+
+def test_spec_md_react_has_frontend_section(tmp_path: Path) -> None:
+    spec = _render_spec_md(_make_cfg(tmp_path, ("react",)))
+    assert "### Frontend" in spec
+    assert "React + Vite" in spec
+    assert "Tailwind CSS" in spec
+    assert "Netlify" in spec
+    assert "### Backend" not in spec
+    assert "## Screens" in spec
+    assert "## Commands" not in spec
+    assert "v0.dev" in spec
+    assert "erDiagram" in spec
+    assert "sequenceDiagram" in spec
+
+
+def test_spec_md_python_has_backend_section(tmp_path: Path) -> None:
+    spec = _render_spec_md(_make_cfg(tmp_path, ("python",)))
+    assert "### Backend" in spec
+    assert "Python" in spec
+    assert "Coolify" in spec
+    assert "Supabase Auth" in spec
+    assert "### Frontend" not in spec
+    assert "## Commands" in spec
+    assert "## Screens" not in spec
+    assert "Mermaid diagrams above are sufficient" in spec
+
+
+def test_spec_md_go_has_backend_section(tmp_path: Path) -> None:
+    spec = _render_spec_md(_make_cfg(tmp_path, ("go",)))
+    assert "### Backend" in spec
+    assert "Language: Go" in spec
+    assert "### Frontend" not in spec
+
+
+def test_spec_md_gin_has_gin_backend(tmp_path: Path) -> None:
+    spec = _render_spec_md(_make_cfg(tmp_path, ("gin",)))
+    assert "### Backend" in spec
+    assert "Go (Gin)" in spec
+    assert "### Frontend" not in spec
+
+
+def test_spec_md_react_python_has_both_sections(tmp_path: Path) -> None:
+    spec = _render_spec_md(_make_cfg(tmp_path, ("react", "python")))
+    assert "### Frontend" in spec
+    assert "### Backend" in spec
+    assert "### Data" in spec
+    assert "### Infrastructure" in spec
+    assert "GitHub Actions" in spec
+    assert "WCAG 2.1 AA" in spec
+
+
+def test_spec_md_generated_by_scaffold(tmp_path: Path) -> None:
+    cfg = _make_cfg(tmp_path, ("react",))
+    generate_scaffold(cfg)
+    spec_path = cfg.out_dir / "SPEC.md"
+    assert spec_path.exists()
+    content = spec_path.read_text(encoding="utf-8")
+    assert "testapp" in content
+    assert "### Frontend" in content
+    assert "erDiagram" in content
 
 
 def test_detect_languages_gin(tmp_path: Path) -> None:

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -519,6 +519,14 @@ def test_spec_md_gin_has_gin_backend(tmp_path: Path) -> None:
     assert "### Frontend" not in spec
 
 
+def test_spec_md_go_python_has_both_in_backend(tmp_path: Path) -> None:
+    spec = _render_spec_md(_make_cfg(tmp_path, ("go", "python")))
+    assert "### Backend" in spec
+    assert "Go" in spec
+    assert "Python" in spec
+    assert spec.count("### Backend") == 1
+
+
 def test_spec_md_react_python_has_both_sections(tmp_path: Path) -> None:
     spec = _render_spec_md(_make_cfg(tmp_path, ("react", "python")))
     assert "### Frontend" in spec


### PR DESCRIPTION
## 🧾 Title
feat(generator): emit SPEC.md placeholder from build_scaffold_files()

## 🧠 Description
Adds SPEC.md generation to `build_scaffold_files()` so every repo initialized by `repo-scaffold init` ships with a pre-filled, agent-readable spec placeholder. The template includes Architecture section with stack defaults per selected languages, Mermaid ERD and sequence diagram stubs, and all standard SPEC.md sections.

## 🧩 Changes Included
- [ ] Added SPEC.md template to `build_scaffold_files()` in generator.py
- [ ] Architecture section defaults per language: react (Vite + Tailwind + Netlify), python (REST + Coolify), go/gin (Coolify), data (Supabase), infra (GitHub Actions)
- [ ] Only emits sections relevant to selected languages
- [ ] Does not overwrite existing SPEC.md
- [ ] Tests added for each language combination

## 🎯 Purpose
Agents and developers landing in a new repo need an authoritative spec file to understand what gets built and what stack defaults apply. This makes every initialized repo immediately legible without any manual setup.

## 🔗 Related Issues / Epics
- **Epic:** #123
- **Issue:** #124
- **Closes:** Fixes #124

## 🧪 Testing
1. Run `repo-scaffold init --languages react,python --owner OWNER --name test-app --out /tmp/test-app`
2. Verify SPEC.md is created with Frontend + Backend + Data + Infra sections
3. Run `repo-scaffold init --languages go --owner OWNER --name test-go --out /tmp/test-go`
4. Verify SPEC.md has Backend (Go) only, no Frontend section
5. Run tests: `poetry run pytest tests/test_generation.py`

## 🧰 Developer Notes
- [ ] Follow existing pattern in build_scaffold_files() for file emission
- [ ] Mermaid stubs must be minimal but valid (render on GitHub)