### PR TITLE
feat(examples): add spec.sample.md and workflow README to examples/

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,114 @@
+# examples/
+
+Reference artifacts for repo-scaffold. Read this if you are an agent or a new contributor
+trying to understand how to use this tool.
+
+---
+
+## Workflow
+
+```mermaid
+flowchart TD
+    A([You have an idea]) --> B[Write SPEC.md]
+    B --> C[repo-scaffold init / create]
+    C --> D[Generate backlog]
+    D --> E{Format?}
+    E -->|Batch| F[artifacts/backlog/issues.json]
+    E -->|Incremental| G[artifacts/tickets/*.md]
+    G --> H[repo-scaffold import backlog]
+    H --> F
+    F --> I[repo-scaffold apply backlog]
+    I --> J[(GitHub Issues + Project Board)]
+    J --> K[Agents pick up issues, submit PRs]
+    K --> L([MVP])
+```
+
+---
+
+## Artifacts in this directory
+
+| File | What it is |
+|------|-----------|
+| [spec.sample.md](spec.sample.md) | Fully filled-out SPEC.md for a realistic project (TaskFlow). Copy and adapt for your own project. |
+| [backlog/issues.sample.json](backlog/issues.sample.json) | A minimal issues.json showing the epic + ticket structure expected by `apply backlog`. |
+| [tickets/epic.sample.md](tickets/epic.sample.md) | A filled-out epic using the `.github/ISSUE_TEMPLATE/epic.md` format. |
+| [tickets/ticket.sample.md](tickets/ticket.sample.md) | A filled-out ticket using the `.github/ISSUE_TEMPLATE/ticket.md` format. |
+
+---
+
+## Where does the backlog live?
+
+`artifacts/` at the repo root (gitignored -- ephemeral, upload-once).
+
+```
+your-repo/
+  artifacts/
+    backlog/
+      issues.json          # compiled backlog -- apply this to GitHub
+    tickets/
+      my-feature.md        # individual ticket drafts -- import these first
+```
+
+Generate with: `poetry run repo-scaffold import backlog --repo OWNER/REPO`
+
+Apply with: `poetry run repo-scaffold apply backlog --repo OWNER/REPO`
+
+---
+
+## How to create issues
+
+**Option A -- Batch JSON (greenfield, all at once):**
+
+Write or generate `artifacts/backlog/issues.json` following the structure in
+[backlog/issues.sample.json](backlog/issues.sample.json), then:
+
+```bash
+poetry run repo-scaffold apply backlog --repo OWNER/REPO
+```
+
+**Option B -- Individual markdown files (incremental):**
+
+Drop one or more `.md` files into `artifacts/tickets/`. Use the templates in
+[tickets/epic.sample.md](tickets/epic.sample.md) and [tickets/ticket.sample.md](tickets/ticket.sample.md).
+Then compile and push:
+
+```bash
+poetry run repo-scaffold import backlog --repo OWNER/REPO
+poetry run repo-scaffold apply backlog --repo OWNER/REPO
+```
+
+Both paths create GitHub issues and add them to the project board.
+
+---
+
+## How to contribute to repo-scaffold
+
+1. Check [AGENTS.md](../AGENTS.md) for the full command reference and auth setup.
+2. Pick an open issue from the [repo-scaffold Roadmap](https://github.com/users/blairg23/projects/6).
+3. Branch off `main`: `git checkout -b feat/your-feature`.
+4. Run the gate before committing: `python -m pre_commit run --all-files`.
+5. Open a draft PR referencing the issue -- use the PR template.
+
+---
+
+## Quick reference
+
+```bash
+# Auth: set GH_TOKEN in .env (see .env.example)
+
+# Issues
+poetry run repo-scaffold issue create --repo OWNER/REPO --title "Title" --body "Body"
+poetry run repo-scaffold issue list --repo OWNER/REPO
+
+# PRs
+poetry run repo-scaffold pr create --repo OWNER/REPO --title "Title" --head feat/branch
+poetry run repo-scaffold pr list --repo OWNER/REPO
+
+# Backlog
+poetry run repo-scaffold import backlog --repo OWNER/REPO
+poetry run repo-scaffold apply backlog --repo OWNER/REPO
+
+# Scaffold
+poetry run repo-scaffold init --name NAME --languages react,python --owner OWNER --out ./NAME
+poetry run repo-scaffold create --repo OWNER/NAME --visibility public --path .
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,9 +49,18 @@ your-repo/
       my-feature.md        # individual ticket drafts -- import these first
 ```
 
-Generate with: `poetry run repo-scaffold import backlog --repo OWNER/REPO`
+Compile tickets from `artifacts/tickets/*.md` into JSON:
 
-Apply with: `poetry run repo-scaffold apply backlog --repo OWNER/REPO`
+```bash
+poetry run repo-scaffold import backlog --repo OWNER/REPO
+# writes to local/backlog/OWNER/REPO/issues.json
+```
+
+Apply with:
+
+```bash
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
+```
 
 ---
 
@@ -74,10 +83,12 @@ Then compile and push:
 
 ```bash
 poetry run repo-scaffold import backlog --repo OWNER/REPO
-poetry run repo-scaffold apply backlog --repo OWNER/REPO
+# writes to local/backlog/OWNER/REPO/issues.json
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
 ```
 
-Both paths create GitHub issues and add them to the project board.
+Both paths create GitHub issues. To also add them to the project board, pass
+`--with-project` (or `--project-title`) to `apply backlog`.
 
 ---
 

--- a/examples/spec.sample.md
+++ b/examples/spec.sample.md
@@ -1,0 +1,177 @@
+# TaskFlow -- SPEC
+
+> This is a filled-out example. Copy it, rename it SPEC.md, and replace the content with your own project.
+
+---
+
+## Goal
+
+TaskFlow is a lightweight task management web app for small teams. It lets users create tasks,
+assign them to teammates, track status across a shared board, and get daily digest emails.
+It exists because Jira is too heavy and plain GitHub issues lack status lanes and email digests.
+
+---
+
+## Users
+
+**Team member** -- Creates and updates tasks, drags them across status lanes, comments on tasks.
+
+**Team lead** -- Assigns tasks to members, sets deadlines, views the full board for any member.
+
+**Observer** -- Read-only access to the board; receives the daily digest but cannot edit tasks.
+
+---
+
+## Screens
+
+| Screen | Description |
+|--------|-------------|
+| Login | Supabase Auth email/password or magic link |
+| Board | Kanban board: Todo, In Progress, Done lanes |
+| Task detail | Title, description, assignee, due date, comments |
+| Team settings | Invite members, set roles, configure digest schedule |
+| Profile | Display name, avatar, notification preferences |
+
+---
+
+## Architecture
+
+### Frontend
+
+- Framework: React + Vite
+- Styling: Tailwind CSS
+- Auth: Supabase Auth (JWT)
+- Deploy: Netlify (preview on PR, production on merge to main)
+
+### Backend
+
+- Language: Python
+- API style: REST
+- Auth: Supabase Auth (JWT validation)
+- Deploy: Coolify (Docker, self-hosted)
+
+### Data
+
+- DB: Supabase (Postgres)
+- Storage: Supabase Storage (task attachments)
+- Migrations: Supabase CLI
+
+### Infrastructure
+
+- CI: GitHub Actions (lint, type check, build, test)
+- Secrets: GitHub repository secrets
+- Environments: preview (PR) + production (main branch)
+
+---
+
+## Data Model
+
+```mermaid
+erDiagram
+    USER {
+        uuid id PK
+        string email
+        string display_name
+        string avatar_url
+        timestamp created_at
+    }
+    TEAM {
+        uuid id PK
+        string name
+        timestamp created_at
+    }
+    TEAM_MEMBER {
+        uuid team_id FK
+        uuid user_id FK
+        string role
+    }
+    TASK {
+        uuid id PK
+        uuid team_id FK
+        uuid assignee_id FK
+        string title
+        text description
+        string status
+        date due_date
+        timestamp created_at
+    }
+    COMMENT {
+        uuid id PK
+        uuid task_id FK
+        uuid author_id FK
+        text body
+        timestamp created_at
+    }
+
+    TEAM ||--o{ TEAM_MEMBER : has
+    USER ||--o{ TEAM_MEMBER : belongs_to
+    TEAM ||--o{ TASK : owns
+    USER ||--o{ TASK : assigned_to
+    TASK ||--o{ COMMENT : has
+    USER ||--o{ COMMENT : authors
+```
+
+---
+
+## Flows
+
+### Create and assign a task
+
+```mermaid
+sequenceDiagram
+    participant Lead
+    participant App
+    participant API
+    participant DB
+    participant Member
+
+    Lead->>App: Click "New Task", fill form
+    App->>API: POST /tasks {title, assignee_id, due_date}
+    API->>DB: INSERT task
+    DB-->>API: task row
+    API-->>App: 201 Created {task}
+    App-->>Lead: Task appears on board
+    API->>Member: Email notification (async)
+```
+
+### Daily digest
+
+```mermaid
+sequenceDiagram
+    participant Scheduler
+    participant API
+    participant DB
+    participant Email
+
+    Scheduler->>API: POST /digest/send (cron, 7am)
+    API->>DB: SELECT open tasks per user
+    DB-->>API: task rows
+    API->>Email: Send digest per user
+    Email-->>API: Delivery receipt
+```
+
+---
+
+## Non-functional Requirements
+
+- Performance: Board load under 500ms for up to 200 tasks
+- Security: All API routes require valid Supabase JWT; no PII in logs
+- Accessibility: WCAG 2.1 AA
+- Platforms: Web (desktop + mobile browser); no native app in MVP
+
+---
+
+## Design
+
+<!-- v0.dev link: https://v0.dev/t/abc123 -->
+
+---
+
+## Out of Scope (MVP)
+
+- Native mobile app
+- Recurring tasks
+- Time tracking
+- Third-party integrations (Slack, GitHub)
+- File attachments (post-MVP Supabase Storage addition)
+- Billing or seat limits

--- a/examples/tickets/epic.sample.md
+++ b/examples/tickets/epic.sample.md
@@ -1,0 +1,61 @@
+---
+name: Epic
+about: Track a multi-ticket initiative
+title: "[EPIC] "
+labels: ["epic", "needs-triage"]
+assignees: []
+---
+
+## 🧾 Title
+Task board -- core CRUD and Kanban lanes
+
+## 🧠 Summary
+Users need to create, assign, and move tasks across status lanes on a shared Kanban board.
+This epic covers the full task lifecycle from creation to completion, including the board UI,
+task detail view, assignment, and status transitions. It is the primary value driver for MVP.
+
+## 📦 Scope
+- Task creation form (title, description, assignee, due date)
+- Kanban board with Todo / In Progress / Done lanes
+- Drag-and-drop status transitions
+- Task detail modal with comment thread
+- REST API endpoints: GET /tasks, POST /tasks, PATCH /tasks/:id, DELETE /tasks/:id
+- Assignee email notification on task creation
+
+## 🚫 Out of Scope
+- File attachments (separate epic)
+- Recurring tasks
+- Time tracking
+- Task labels or tags
+
+## ✅ Acceptance Criteria
+- [ ] Team member can create a task and see it appear on the board immediately
+- [ ] Team lead can assign a task to any team member
+- [ ] Dragging a task card changes its status in the DB
+- [ ] Task detail shows full history of status changes and comments
+- [ ] Assignee receives an email when a task is assigned to them
+
+## 🗂️ Milestones / Phases
+- [ ] Phase 1: API endpoints + DB schema
+- [ ] Phase 2: Board UI + drag-and-drop
+- [ ] Phase 3: Task detail + comments
+- [ ] Phase 4: Email notifications
+
+## 🧪 Testing / Validation
+- [ ] API: pytest covers create, read, update, delete, auth guard
+- [ ] UI: manual smoke test of board load, drag-and-drop, and task detail on Chrome + mobile Safari
+- [ ] Email: verify digest and assignment notifications arrive in staging
+
+## 🔗 Child Tickets
+- [ ] #4 -- Create task API endpoint
+- [ ] #5 -- Board UI with Kanban lanes
+- [ ] #6 -- Task detail modal and comment thread
+- [ ] #7 -- Assignee email notification
+
+## 🧰 Notes / Links
+- See SPEC.md ## Flows for the create-and-assign sequence diagram
+- Drag-and-drop: use dnd-kit (MIT, no jQuery)
+
+## ✅ Addendum: Bugs Found/Fixed
+
+## ⏳ Addendum: Pending

--- a/examples/tickets/ticket.sample.md
+++ b/examples/tickets/ticket.sample.md
@@ -1,0 +1,53 @@
+---
+name: Ticket
+about: Describe one implementation task
+title: "[Ticket] "
+labels: ["needs-triage"]
+assignees: []
+---
+
+## 🧾 Title
+Create task API endpoint (POST /tasks)
+
+## 🧠 Summary
+The board UI needs a backend endpoint to persist new tasks. This ticket implements
+POST /tasks with input validation, DB insert, and the assignee notification trigger.
+It is the first API ticket in the task board epic and unblocks the board UI ticket.
+
+## 📦 Scope
+- `POST /tasks` endpoint in `src/taskflow/routes/tasks.py`
+- Request body: `title` (required), `description`, `assignee_id`, `due_date`
+- Validates JWT, extracts team_id from token claims
+- Inserts task row into Supabase via supabase-py
+- Returns 201 with the created task object
+- Enqueues assignee notification email (fire-and-forget, does not block response)
+
+## 🚫 Out of Scope
+- File attachment upload (separate ticket)
+- GET /tasks or PATCH /tasks (separate tickets)
+- Frontend form (separate ticket)
+
+## ✅ Acceptance Criteria
+- [ ] `POST /tasks` with valid JWT and required fields returns 201 + task object
+- [ ] Missing `title` returns 422 with field-level error
+- [ ] Invalid or expired JWT returns 401
+- [ ] Task row appears in DB with correct team_id, assignee_id, status="todo"
+- [ ] Assignee notification is enqueued (verify via mock in tests)
+
+## 🧪 Testing / Validation
+- [ ] `pytest tests/test_tasks.py` passes (create success, missing title, bad auth)
+- [ ] Manual: POST via curl with valid staging JWT -- verify row in Supabase dashboard
+
+## 🧰 Implementation Notes
+- Use `supabase.table("tasks").insert({...}).execute()` pattern
+- Notification: call `notify_assignee.delay(task_id)` (Celery task, already wired)
+- Keep route thin -- business logic in `src/taskflow/services/task_service.py`
+
+## 🧰 Notes / Links
+- Epic: #3
+- SPEC.md ## Flows -- "Create and assign a task" sequence diagram
+- Supabase Python docs: https://supabase.com/docs/reference/python
+
+## ✅ Addendum: Bugs Found/Fixed
+
+## ⏳ Addendum: Pending


### PR DESCRIPTION
## 🧾 Title
feat(examples): add spec.sample.md and workflow README to examples/

## 🧠 Description
Makes examples/ immediately useful as a reference for agents and contributors. Adds a fully filled-out spec sample, realistic backlog examples, and a README with a Mermaid workflow diagram so anyone landing in the repo knows exactly how to contribute without reading anything else.

## 🧩 Changes Included
- [ ] Added examples/spec.sample.md (complete, realistic -- not lorem ipsum)
- [ ] Added or improved examples/backlog/ with issues.json and individual .md ticket examples
- [ ] Added filled epic.md and ticket.md examples covering every template field
- [ ] Added examples/README.md with Mermaid workflow diagram and artifact pointers

## 🎯 Purpose
A developer or agent landing in the repo cold should be able to read examples/ and immediately know: where the backlog goes, what a ticket looks like, and how to start contributing.

## 🔗 Related Issues / Epics
- **Epic:** #123
- **Issue:** #125
- **Closes:** Fixes #125

## 🧪 Testing
1. Read examples/README.md cold -- verify it answers where the backlog goes, what a ticket looks like, how to contribute
2. Verify Mermaid diagrams render on GitHub
3. Verify spec.sample.md is a complete realistic example (not a template)

## 🧰 Developer Notes
- [ ] spec.sample.md should use a realistic fictional project -- not placeholder text