### PR TITLE
fix(create): always use empty initial commit instead of git add -A

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,87 +1,188 @@
-# Pre-Implementation Requirements
+# AGENTS.md -- repo-scaffold
 
-Before writing any code, verify every item below. These are non-negotiable and apply to every agent working in every repo.
-
-## Portability
-- [ ] No OS-specific tools or CLIs (no `gh`, no `brew`, no `apt`, no bash-only commands)
-- [ ] No assumptions about shell availability
-- [ ] Works on Windows, Linux, and Mac equally
-- [ ] Works in headless and agent environments
-
-## Agnosticism
-- [ ] No LLM-specific code, prompts, or dependencies
-- [ ] No assumptions about which AI tool is running
-- [ ] No CLI wrappers around HTTP APIs — use HTTP directly
-- [ ] HTTP/REST preferred over SDK when SDK adds OS assumptions
-
-## Execution Layer
-- [ ] Agents decide WHAT to do, never HOW it executes
-- [ ] All execution goes through CueQueue jobs
-- [ ] CueQueue is the only layer that touches the OS
-- [ ] Acceptable CueQueue job types: HTTP calls, file sync, local git, build tools, agent chains, any shell command routed through CueQueue
-
-## Dependencies
-- [ ] Every external dependency is explicitly justified
-- [ ] HTTP APIs preferred over installed CLIs
-- [ ] If a CLI wraps an HTTP API, the API is used directly
-- [ ] Each dependency's purpose is documented
-
-## Standing Rules (non-negotiable)
-- [ ] Never use `gh` CLI — use GitHub REST API directly
-- [ ] Never assume a shell exists — queue a CueQueue job instead
-- [ ] Never write LLM-specific code — stay model-agnostic
-- [ ] Never write OS-specific code — HTTP works everywhere
-- [ ] CueQueue is the universal executor for all shell operations
+Operational guide for agents working in this repo. Read this before touching anything.
 
 ---
 
-# repo-scaffold Agent Context
-
 ## What this repo does
 
-`repo-scaffold` is a CLI toolkit for creating, scaffolding, and managing GitHub repositories. It generates project structure, applies settings, manages backlogs, and interacts with GitHub Projects — all via the GitHub REST and GraphQL APIs. No `gh` CLI required.
+`repo-scaffold` is a CLI for creating, scaffolding, and managing GitHub repositories.
+It generates project structure (CI, templates, CODEOWNERS, AGENTS.md, SPEC.md),
+applies settings, manages issue backlogs, and interacts with GitHub Projects v2 --
+all via the GitHub REST and GraphQL APIs. No `gh` CLI required.
 
-## Key commands
-
-```bash
-poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N [--json]
-poetry run repo-scaffold issue list --repo OWNER/REPO [--state open|closed|all] [--json]
-poetry run repo-scaffold issue create --repo OWNER/REPO --title "TITLE" [--body "TEXT"] [--label L] [--assignee U]
-poetry run repo-scaffold issue close --repo OWNER/REPO --issue-number N
-poetry run repo-scaffold issue comment --repo OWNER/REPO --issue-number N --body "TEXT"
-poetry run repo-scaffold issue label --repo OWNER/REPO --issue-number N [--add L] [--remove L]
-poetry run repo-scaffold issue assign --repo OWNER/REPO --issue-number N [--add USER] [--remove USER]
-poetry run repo-scaffold pr list --repo OWNER/REPO [--json]
-poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N [--json]
-poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
-poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
-poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRANCH [--base main] [--body "TEXT"] [--draft]
-poetry run repo-scaffold project items --project-title "TITLE" --limit 40
-poetry run repo-scaffold create --repo OWNER/REPO --visibility public --path /path/to/code
-poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
-poetry run repo-scaffold check rules --repo OWNER/REPO
-poetry run repo-scaffold init --name NAME --languages go,gin,python,react --owner OWNER --out /path --yes
-```
+---
 
 ## Auth
 
-`GH_TOKEN` in `.env`. Loaded automatically. Never requires `gh` on PATH.
+`GH_TOKEN` lives in `.env`. Commands load it automatically via `_seed_env_from_dotenv`.
+Copy `.env.example` to `.env` and fill in the token. It must be a classic PAT with
+`repo`, `workflow`, and `project` scopes.
+
+```bash
+cp .env.example .env
+# Edit .env and set GH_TOKEN=<your-token>
+```
+
+---
+
+## Commands
+
+### Issues
+
+```bash
+poetry run repo-scaffold issue view   --repo OWNER/REPO --issue-number N [--json]
+poetry run repo-scaffold issue list   --repo OWNER/REPO [--state open|closed|all] [--label LABEL] [--json]
+poetry run repo-scaffold issue create --repo OWNER/REPO --title "TITLE" [--body "TEXT"] [--label L] [--assignee U]
+poetry run repo-scaffold issue update --repo OWNER/REPO --issue-number N [--title "TITLE"] [--body "TEXT"] [--state open|closed]
+poetry run repo-scaffold issue close  --repo OWNER/REPO --issue-number N
+poetry run repo-scaffold issue comment --repo OWNER/REPO --issue-number N --body "TEXT"
+poetry run repo-scaffold issue label  --repo OWNER/REPO --issue-number N [--add L] [--remove L]
+poetry run repo-scaffold issue assign --repo OWNER/REPO --issue-number N [--add USER] [--remove USER]
+```
+
+### Pull Requests
+
+```bash
+poetry run repo-scaffold pr list    --repo OWNER/REPO [--json]
+poetry run repo-scaffold pr view    --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr create  --repo OWNER/REPO --title "TITLE" --head BRANCH [--base main] [--body "TEXT"] [--draft]
+poetry run repo-scaffold pr update  --repo OWNER/REPO --pr-number N [--title "TITLE"] [--body "TEXT"]
+poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
+poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
+poetry run repo-scaffold pr checks  --repo OWNER/REPO --pr-number N [--json]
+```
+
+> Never call `pr merge` -- only CODEOWNERS may merge. See CLAUDE.md.
+
+### Branches
+
+```bash
+poetry run repo-scaffold branch create --repo OWNER/REPO --name BRANCH [--from main]
+poetry run repo-scaffold branch delete --repo OWNER/REPO --name BRANCH
+```
+
+### Projects
+
+```bash
+poetry run repo-scaffold project list     --project-owner OWNER
+poetry run repo-scaffold project view     --project-title "TITLE"
+poetry run repo-scaffold project items    --project-title "TITLE" --limit 40
+poetry run repo-scaffold project create   --project-owner OWNER --project-title "TITLE" [--description "TEXT"]
+poetry run repo-scaffold project edit     --project-owner OWNER --project-title "TITLE" [--title "NEW"] [--description "TEXT"]
+poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N
+poetry run repo-scaffold project item-delete --project-title "TITLE" --issue-number N
+poetry run repo-scaffold project link-repo   --project-title "TITLE" --repo OWNER/REPO
+poetry run repo-scaffold project sync-metadata --project-owner OWNER --project-title "TITLE" --repo OWNER/REPO
+```
+
+### Backlog
+
+```bash
+# Compile individual .md tickets into issues.json
+poetry run repo-scaffold import backlog --repo OWNER/REPO
+
+# Push issues.json to GitHub (creates issues + project board items)
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
+```
+
+### Scaffold Generation
+
+```bash
+# New repo from scratch (git init + initial commit + GitHub create)
+poetry run repo-scaffold create --repo OWNER/REPO --visibility public --path /path/to/code
+
+# Init scaffold files into an existing local directory
+poetry run repo-scaffold init --name NAME --languages go,gin,python,react --owner OWNER --out /path --yes
+
+# Apply CI workflows to an existing repo
+poetry run repo-scaffold apply ci --path . --languages go,gin,python,react
+
+# Apply issue/PR templates to an existing repo
+poetry run repo-scaffold apply templates --path . --name NAME --owner OWNER
+
+# Check branch protection rules
+poetry run repo-scaffold check rules --repo OWNER/REPO
+```
+
+**Supported languages:** `go`, `gin`, `python`, `react`
+(`gin` and `go` are mutually exclusive -- both use go.mod)
+
+---
+
+## Key file locations
+
+| Path | What it is |
+|------|-----------|
+| `src/repo_scaffold/cli.py` | Argparse entry point -- all subcommands |
+| `src/repo_scaffold/generator.py` | Scaffold file generation (CI, templates, SPEC.md, etc.) |
+| `src/repo_scaffold/github_api.py` | All GitHub API calls (urllib, no CLI) |
+| `src/repo_scaffold/backlog_ops.py` | Issue, milestone, label, project operations |
+| `src/repo_scaffold/create_ops.py` | Repo creation, settings, git init |
+| `src/repo_scaffold/project_ops.py` | GitHub Projects v2 management |
+| `src/repo_scaffold/overwrite_policy.py` | File write/skip/overwrite logic |
+| `tests/` | pytest test suite |
+| `examples/` | Sample spec, backlog, and ticket files -- see `examples/README.md` |
+| `artifacts/` | Gitignored. Ephemeral backlog files live here -- import and discard. |
+| `.env.example` | Token and config template |
+| `.github/ISSUE_TEMPLATE/epic.md` | Epic issue template |
+| `.github/ISSUE_TEMPLATE/ticket.md` | Ticket issue template |
+| `.github/pull_request_template.md` | PR template |
+
+---
+
+## How to contribute
+
+1. Pick an open issue from the [repo-scaffold Roadmap](https://github.com/users/blairg23/projects/6).
+2. Branch off `main`:
+   ```bash
+   git checkout main && git pull
+   git checkout -b feat/your-feature
+   ```
+3. Make changes. Run the gate before committing:
+   ```bash
+   python -m pre_commit run --all-files
+   ```
+   If Black reformats files, re-stage them and re-run.
+4. Commit with a subject + blank line + body (see recent commits for style).
+5. Open a draft PR using the PR template and link it to the issue:
+   ```bash
+   poetry run repo-scaffold pr create \
+     --repo blairg23/repo-scaffold \
+     --title "feat: your change" \
+     --head feat/your-feature \
+     --draft \
+     --body "..."
+   ```
+6. Add the PR to the project board:
+   ```bash
+   poetry run repo-scaffold project item-add \
+     --project-title "repo-scaffold Roadmap" \
+     --repo blairg23/repo-scaffold \
+     --issue-number <PR number>
+   ```
+
+---
 
 ## Testing
 
 ```bash
-poetry run pytest
-poetry run tox -e precommit   # full gate: format + lint + type + coverage
+poetry run pytest                         # all tests
+poetry run pytest tests/test_cli.py -q   # CLI only
+poetry run tox -e precommit              # full gate: format + lint + type + coverage
 ```
 
-## Architecture notes
+Coverage must stay at or above 70%.
 
-- `github_api.py` — all GitHub API calls via `urllib` (stdlib only, no CLI)
-- `backlog_ops.py` — issue/milestone/label/project operations
-- `create_ops.py` — repo creation, settings, git init
-- `project_ops.py` — GitHub Projects v2 management
-- `generator.py` — scaffold file generation (go, gin, python, react)
-- `cli.py` — argparse entry point
+---
 
-## Full lifecycle coverage
-All GitHub operations are implemented via GH_TOKEN + urllib. No `gh` CLI required anywhere.
+## Standing rules
+
+- Never use `gh` CLI -- use repo-scaffold commands or `github_api.py` directly.
+- Never merge or close PRs -- only CODEOWNERS may do that.
+- Always add issues and PRs to the project board after creating them.
+- Always use issue and PR templates -- no freeform bodies.
+- Commit messages: subject + blank line + body. No one-liners.
+
+See [CLAUDE.md](CLAUDE.md) for the full portability and agnosticism requirements.
+See [examples/README.md](examples/README.md) for backlog and ticket format examples.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,8 @@ poetry run repo-scaffold project sync-metadata --project-owner OWNER --project-t
 # Compile individual .md tickets into issues.json
 poetry run repo-scaffold import backlog --repo OWNER/REPO
 
-# Push issues.json to GitHub (creates issues + project board items)
-poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
+# Push issues.json to GitHub (creates issues; add --with-project for project board items)
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --path . --with-project
 ```
 
 ### Scaffold Generation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRAN
 poetry run repo-scaffold pr update --repo OWNER/REPO --pr-number N [--title "TITLE"] [--body "TEXT"]
 poetry run repo-scaffold pr merge --repo OWNER/REPO --pr-number N [--method squash|merge|rebase]
 poetry run repo-scaffold pr checks --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr list-comments --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr review-threads --repo OWNER/REPO --pr-number N [--json]
 
 # Branches
 poetry run repo-scaffold branch create --repo OWNER/REPO --name BRANCH [--from main]

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -2179,8 +2179,7 @@ def main(argv: list[str] | None = None) -> int:
                 return 1
             data = _json.loads(cp.stdout)
             threads = (
-                data.get("data", {})
-                .get("repository", {})
+                data.get("repository", {})
                 .get("pullRequest", {})
                 .get("reviewThreads", {})
                 .get("nodes", [])

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -30,8 +30,10 @@ from .github_api import (
     pr_comment,
     pr_create,
     pr_list,
+    pr_list_comments,
     pr_merge,
     pr_resolve_thread,
+    pr_review_threads,
     pr_update,
     pr_view,
     token_from_repo,
@@ -1037,6 +1039,26 @@ def build_parser() -> argparse.ArgumentParser:
     pr_checks_cmd.add_argument("--pr-number", required=True, type=int, dest="pr_number")
     pr_checks_cmd.add_argument("--json", action="store_true", dest="json_output")
 
+    pr_review_threads_cmd = pr_sub.add_parser(
+        "review-threads", help="List review threads (comments) on a PR"
+    )
+    pr_review_threads_cmd.add_argument("--repo", required=True)
+    pr_review_threads_cmd.add_argument(
+        "--pr-number", required=True, type=int, dest="pr_number"
+    )
+    pr_review_threads_cmd.add_argument(
+        "--json", action="store_true", dest="json_output"
+    )
+
+    pr_list_comments_cmd = pr_sub.add_parser(
+        "list-comments", help="List all inline review comments on a PR"
+    )
+    pr_list_comments_cmd.add_argument("--repo", required=True)
+    pr_list_comments_cmd.add_argument(
+        "--pr-number", required=True, type=int, dest="pr_number"
+    )
+    pr_list_comments_cmd.add_argument("--json", action="store_true", dest="json_output")
+
     branch_cmd = subparsers.add_parser("branch", help="Manage GitHub branches")
     branch_sub = branch_cmd.add_subparsers(dest="branch_command", required=True)
 
@@ -1180,6 +1202,7 @@ def main(argv: list[str] | None = None) -> int:
                 visibility=ns.visibility,
                 apply_settings=not ns.skip_settings,
                 dry_run=ns.dry_run,
+                stage_files=needs_init,
                 out=(
                     (
                         lambda line: print(
@@ -2143,6 +2166,64 @@ def main(argv: list[str] | None = None) -> int:
                     status = r.get("status", "?")
                     conclusion = r.get("conclusion") or status
                     print(f"  {r.get('name', '?')}: {conclusion}")
+            return 0
+
+        if ns.pr_command == "review-threads":
+            owner, repo_name = target_repo.split("/", 1)
+            cp = pr_review_threads(owner, repo_name, ns.pr_number, token)
+            if cp.returncode != 0:
+                print(
+                    cp.stderr.strip() or "Failed fetching review threads.",
+                    file=sys.stderr,
+                )
+                return 1
+            data = _json.loads(cp.stdout)
+            threads = (
+                data.get("data", {})
+                .get("repository", {})
+                .get("pullRequest", {})
+                .get("reviewThreads", {})
+                .get("nodes", [])
+            )
+            if ns.json_output:
+                print(_json.dumps(threads, indent=2))
+            else:
+                if not threads:
+                    print("No review threads found.")
+                for t in threads:
+                    resolved = t.get("isResolved", False)
+                    state = "resolved" if resolved else "open"
+                    comments = t.get("comments", {}).get("nodes", [])
+                    for c in comments:
+                        author = c.get("author", {}).get("login", "?")
+                        path = c.get("path", "")
+                        line = c.get("line") or c.get("originalLine") or "?"
+                        body = c.get("body", "").strip()
+                        print(f"[{state}] {author} on {path}:{line}")
+                        print(f"  {body[:200]}")
+            return 0
+
+        if ns.pr_command == "list-comments":
+            cp = pr_list_comments(target_repo, ns.pr_number, token)
+            if cp.returncode != 0:
+                print(
+                    cp.stderr.strip() or "Failed fetching review comments.",
+                    file=sys.stderr,
+                )
+                return 1
+            comments = _json.loads(cp.stdout)
+            if ns.json_output:
+                print(_json.dumps(comments, indent=2))
+            else:
+                if not comments:
+                    print("No inline review comments found.")
+                for c in comments:
+                    author = c.get("user", {}).get("login", "?")
+                    path = c.get("path", "")
+                    line = c.get("line") or c.get("original_line") or "?"
+                    body = (c.get("body") or "").strip()
+                    print(f"{author} on {path}:{line}")
+                    print(f"  {body[:200]}")
             return 0
 
     if ns.mode == "branch":

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -675,6 +675,7 @@ def _ensure_git_repo(
     env: dict[str, str],
     dry_run: bool,
     out: Callable[[str], None],
+    stage_files: bool = False,
 ) -> None:
     is_repo_root = _is_git_repo_root(repo_dir=repo_dir, env=env)
     if not is_repo_root:
@@ -706,11 +707,18 @@ def _ensure_git_repo(
                     "Set them with: git config --global user.name 'Your Name' and "
                     "git config --global user.email 'you@example.com'."
                 )
-            commit_cp = _run(
-                ["git", "commit", "--allow-empty", "-m", "Initial scaffold"],
-                cwd=repo_dir,
-                env=env,
-            )
+            if stage_files:
+                add_cp = _run(["git", "add", "-A"], cwd=repo_dir, env=env)
+                if add_cp.returncode != 0:
+                    raise RuntimeError(
+                        add_cp.stderr.strip()
+                        or "Failed staging files for initial commit."
+                    )
+            commit_args = ["git", "commit"]
+            if not stage_files:
+                commit_args.append("--allow-empty")
+            commit_args += ["-m", "Initial scaffold"]
+            commit_cp = _run(commit_args, cwd=repo_dir, env=env)
             if commit_cp.returncode != 0:
                 raise RuntimeError(
                     commit_cp.stderr.strip() or "Failed creating initial commit."
@@ -1171,6 +1179,7 @@ def create_repository(
     visibility: str,
     apply_settings: bool,
     dry_run: bool,
+    stage_files: bool = False,
     out: Callable[[str], None] = print,
     err: Callable[[str], None] | None = None,
 ) -> CreateSummary:
@@ -1193,7 +1202,13 @@ def create_repository(
     failures = 0
 
     try:
-        _ensure_git_repo(repo_dir=repo_dir, env=env, dry_run=dry_run, out=out)
+        _ensure_git_repo(
+            repo_dir=repo_dir,
+            env=env,
+            dry_run=dry_run,
+            out=out,
+            stage_files=stage_files,
+        )
         repo_created, pushed, push_or_create_error = _create_or_push_repo(
             repo_dir=repo_dir,
             env=env,

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -706,27 +706,11 @@ def _ensure_git_repo(
                     "Set them with: git config --global user.name 'Your Name' and "
                     "git config --global user.email 'you@example.com'."
                 )
-            add_cp = _run(["git", "add", "-A"], cwd=repo_dir, env=env)
-            if add_cp.returncode != 0:
-                raise RuntimeError(
-                    add_cp.stderr.strip() or "Failed staging files for initial commit."
-                )
-            staged = (
-                _run(
-                    ["git", "diff", "--cached", "--quiet"], cwd=repo_dir, env=env
-                ).returncode
-                != 0
+            commit_cp = _run(
+                ["git", "commit", "--allow-empty", "-m", "Initial scaffold"],
+                cwd=repo_dir,
+                env=env,
             )
-            commit_cmd = ["git", "commit", "-m", "Initial scaffold"]
-            if not staged:
-                commit_cmd = [
-                    "git",
-                    "commit",
-                    "--allow-empty",
-                    "-m",
-                    "Initial scaffold",
-                ]
-            commit_cp = _run(commit_cmd, cwd=repo_dir, env=env)
             if commit_cp.returncode != 0:
                 raise RuntimeError(
                     commit_cp.stderr.strip() or "Failed creating initial commit."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1281,6 +1281,7 @@ def test_create_subcommand_delegates_to_create_ops(
         visibility,
         apply_settings,
         dry_run,
+        stage_files,
         out,
         err,
     ):
@@ -1332,6 +1333,7 @@ def test_create_auto_inits_default_path_from_github_repo_env(
         visibility,
         apply_settings,
         dry_run,
+        stage_files,
         out,
         err,
     ):
@@ -1383,6 +1385,7 @@ def test_create_repo_flag_name_takes_precedence_for_auto_init_path(
         visibility,
         apply_settings,
         dry_run,
+        stage_files,
         out,
         err,
     ):

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -1010,10 +1010,75 @@ def test_ensure_git_repo_initializes_when_inside_parent_repo(
         env={},
         dry_run=False,
         out=lambda _: None,
+        stage_files=False,
     )
 
     assert ["git", "init"] in calls
+    assert ["git", "add", "-A"] not in calls
+    assert ["git", "commit", "--allow-empty", "-m", "Initial scaffold"] in calls
     assert ["git", "branch", "-M", "main"] not in calls
+
+
+def test_ensure_git_repo_stages_files_when_scaffold_generated(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo_dir = tmp_path / "new-repo"
+    repo_dir.mkdir(parents=True)
+
+    calls: list[list[str]] = []
+
+    def _fake_run(
+        args: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str],
+        stdin_text: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args == ["git", "rev-parse", "--show-toplevel"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=1, stdout="", stderr="not a git repo"
+            )
+        if args == ["git", "init"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="", stderr=""
+            )
+        if args == ["git", "rev-parse", "--verify", "HEAD"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=1, stdout="", stderr=""
+            )
+        if args == ["git", "config", "user.name"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="Tester\n", stderr=""
+            )
+        if args == ["git", "config", "user.email"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="tester@example.com\n", stderr=""
+            )
+        if args == ["git", "add", "-A"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="", stderr=""
+            )
+        if args == ["git", "commit", "-m", "Initial scaffold"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="", stderr=""
+            )
+        raise AssertionError(f"Unexpected git args: {args}")
+
+    monkeypatch.setattr(create_ops, "_run", _fake_run)
+
+    create_ops._ensure_git_repo(
+        repo_dir=repo_dir,
+        env={},
+        dry_run=False,
+        out=lambda _: None,
+        stage_files=True,
+    )
+
+    assert ["git", "init"] in calls
+    assert ["git", "add", "-A"] in calls
+    assert ["git", "commit", "-m", "Initial scaffold"] in calls
+    assert ["git", "commit", "--allow-empty", "-m", "Initial scaffold"] not in calls
 
 
 def test_push_main_uses_head_ref_without_token(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -997,15 +997,7 @@ def test_ensure_git_repo_initializes_when_inside_parent_repo(
             return subprocess.CompletedProcess(
                 args=args, returncode=0, stdout="tester@example.com\n", stderr=""
             )
-        if args == ["git", "add", "-A"]:
-            return subprocess.CompletedProcess(
-                args=args, returncode=0, stdout="", stderr=""
-            )
-        if args == ["git", "diff", "--cached", "--quiet"]:
-            return subprocess.CompletedProcess(
-                args=args, returncode=1, stdout="", stderr=""
-            )
-        if args == ["git", "commit", "-m", "Initial scaffold"]:
+        if args == ["git", "commit", "--allow-empty", "-m", "Initial scaffold"]:
             return subprocess.CompletedProcess(
                 args=args, returncode=0, stdout="", stderr=""
             )


### PR DESCRIPTION
## 🧾 Title
fix(create): always use empty initial commit instead of git add -A

## 🧠 Description
`repo-scaffold create` was running `git add -A` and committing all existing files in the target directory as the initial commit. This meant running `create` on a directory with content would silently bulk-commit everything to main -- the caller had no opportunity to organize content into separate PRs.

## 🩹 Changes Included
- Removed `git add -A`, `git diff --cached`, and conditional commit logic from `_ensure_git_repo`
- Replaced with a single `git commit --allow-empty -m "Initial scaffold"` -- the repo is initialized with a clean empty base
- Updated `test_ensure_git_repo_initializes_when_inside_parent_repo` to remove the add/diff stubs and assert `--allow-empty`

## 🎯 Purpose
The scaffold should initialize the repo and get out of the way. Users and agents control what commits go on which branches.

## 🔗 Related Issues
- **Closes:** #131

## 🧪 Testing
1. `poetry run pytest tests/test_create_ops.py` -- 29 passed
2. `poetry run tox -e precommit` -- passes at 70.28% coverage