### PR TITLE
fix(backlog): fix issue number resolution in _gh_issue_create

### DIFF
--- a/src/repo_scaffold/backlog_ops.py
+++ b/src/repo_scaffold/backlog_ops.py
@@ -575,7 +575,7 @@ def _gh_issue_create(args: list[str], token: str) -> subprocess.CompletedProcess
                 pass
 
     cp = rest("POST", f"/repos/{repo}/issues", token, payload)
-    if cp.returncode not in (200, 201):
+    if cp.returncode != 0:
         return cp
     try:
         url = json.loads(cp.stdout).get("html_url", "")


### PR DESCRIPTION
## 🧾 Title
fix(backlog): fix issue number resolution in _gh_issue_create

## 🧠 Description
\`_gh_issue_create\` guarded with \`if cp.returncode not in (200, 201)\`, but \`rest()\`/\`_http()\` returns \`returncode=0\` on success (via \`_ok()\`). Since 0 is not in (200, 201), every successful issue creation was treated as a failure: raw JSON was returned instead of the extracted \`html_url\`.

This caused \`apply backlog\` to always emit "Created issue but could not resolve its number" for every issue, leaving \`epic_numbers\` unset, which cascaded into "Failed to resolve epic issue number for ticket" for all child tickets.

## 🩹 Changes Included
- Change guard from \`not in (200, 201)\` to \`!= 0\` to match the success convention used by \`_http\`/\`_ok\` throughout the codebase

## 🎯 Purpose
Makes \`apply backlog\` reliably create all issues and link tickets to their epics.

## 🔗 Related Issues
- **Closes:** #132

## 🧪 Testing
1. \`poetry run pytest tests/ -m "not e2e_github"\` -- 192 passed, 2 skipped
2. \`poetry run tox -e precommit\` -- passes at 70.28% coverage
3. Manually verified: re-running \`apply backlog\` against \`blairg23/toolshed\` creates all 9 issues (1 epic + 8 tickets) with correct epic references and project board items