### PR TITLE
feat(project): add setup-statuses command and auto-configure on project create

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,12 +72,13 @@ poetry run repo-scaffold branch delete --repo OWNER/REPO --name BRANCH
 poetry run repo-scaffold project list --project-owner OWNER
 poetry run repo-scaffold project view --project-title "TITLE"
 poetry run repo-scaffold project items --project-title "TITLE" --limit 40
-poetry run repo-scaffold project create --project-owner OWNER --project-title "TITLE" [--description "TEXT"]
+poetry run repo-scaffold project create --project-owner OWNER --project-title "TITLE" [--description "TEXT"] [--repo OWNER/REPO]
 poetry run repo-scaffold project edit --project-owner OWNER --project-title "TITLE" [--title "NEW"] [--description "TEXT"]
 poetry run repo-scaffold project sync-metadata --project-owner OWNER --project-title "TITLE" --repo OWNER/REPO
 poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N
 poetry run repo-scaffold project item-delete --project-title "TITLE" --issue-number N
 poetry run repo-scaffold project link-repo --project-title "TITLE" --repo OWNER/REPO
+poetry run repo-scaffold project setup-statuses --project-title "TITLE"
 poetry run repo-scaffold project delete --project-owner OWNER --project-title "TITLE"  # dangerous — requires backup
 poetry run repo-scaffold project undo --project-owner OWNER  # restore from last backup
 

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -70,6 +70,7 @@ from .project_ops import (
     link_project_repo,
     list_project_items,
     list_projects,
+    setup_project_statuses,
     sync_project_metadata,
     undo_project_backup,
     update_project_item_status,
@@ -656,10 +657,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional project visibility override",
     )
     project_create_cmd.add_argument(
+        "--repo",
+        help="Link this repo (owner/repo) as the project default repository and setup standard statuses",
+    )
+    project_create_cmd.add_argument(
         "--dry-run",
         action="store_true",
         help="Preview the project creation without changing state",
     )
+
+    project_setup_statuses_cmd = project_sub.add_parser(
+        "setup-statuses",
+        help="Configure the standard Status field options on an existing project",
+    )
+    project_setup_statuses_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution (default: .)",
+    )
+    _add_project_target_args(project_setup_statuses_cmd)
 
     project_edit_cmd = project_sub.add_parser(
         "edit", help="Edit metadata for an existing project"
@@ -1650,7 +1666,16 @@ def main(argv: list[str] | None = None) -> int:
                     description=ns.description,
                     readme=ns.readme,
                     visibility=ns.visibility,
+                    repo=getattr(ns, "repo", None),
                     dry_run=ns.dry_run,
+                    out=print,
+                )
+            elif ns.project_command == "setup-statuses":
+                mutation_summary = setup_project_statuses(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
                     out=print,
                 )
             elif ns.project_command == "edit":

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -619,7 +619,13 @@ def setup_project_status_field(
     token: str,
     options: list[dict[str, str]] | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Replace the Status single-select field options with the standard set."""
+    """Replace the Status single-select field options with the standard set.
+
+    Options that already exist on the field are matched by name and their IDs
+    are forwarded to the mutation so GitHub can update them in place rather than
+    recreating them, which would clear any item field values pointing at the old
+    option IDs.
+    """
     cp = project_fields(project_id, token)
     if cp.returncode != 0:
         return cp
@@ -639,10 +645,28 @@ def setup_project_status_field(
     if not field_id:
         return _err("Could not resolve Status field ID.")
 
+    existing_ids: dict[str, str] = {
+        o["name"]: o["id"]
+        for o in status_field.get("options", [])
+        if isinstance(o, dict) and "name" in o and "id" in o
+    }
+
     chosen = options if options is not None else STANDARD_STATUS_OPTIONS
+    merged: list[dict[str, str]] = []
+    for opt in chosen:
+        entry: dict[str, str] = {
+            "name": opt["name"],
+            "color": opt["color"],
+            "description": opt.get("description", ""),
+        }
+        existing_id = existing_ids.get(opt["name"])
+        if existing_id:
+            entry["id"] = existing_id
+        merged.append(entry)
+
     cp2 = graphql(
         _GQL_UPDATE_STATUS_FIELD,
-        {"fieldId": field_id, "options": chosen},
+        {"fieldId": field_id, "options": merged},
         token,
     )
     if cp2.returncode != 0:

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -356,6 +356,36 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
 }
 """
 
+_GQL_UPDATE_STATUS_FIELD = """
+mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+  updateProjectV2Field(input: {
+    fieldId: $fieldId
+    singleSelectOptions: $options
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField {
+        id name
+        options { id name color description }
+      }
+    }
+  }
+}
+"""
+
+STANDARD_STATUS_OPTIONS: list[dict[str, str]] = [
+    {"name": "Todo", "color": "GRAY", "description": "This item hasn't been started"},
+    {
+        "name": "In Progress",
+        "color": "YELLOW",
+        "description": "This is actively being worked on",
+    },
+    {"name": "To Review", "color": "BLUE", "description": "This is awaiting review"},
+    {"name": "Done", "color": "GREEN", "description": "This has been completed"},
+    {"name": "Won't Do", "color": "GRAY", "description": "This won't be done"},
+    {"name": "Duplicate", "color": "BLUE", "description": "This is a duplicate"},
+    {"name": "Blocked", "color": "RED", "description": "This is blocked"},
+]
+
 
 def _project_nodes_from_data(data: dict[str, object]) -> list[dict[str, object]]:
     for key in ("user", "organization"):
@@ -582,6 +612,47 @@ def project_item_update_field(
         },
         token,
     )
+
+
+def setup_project_status_field(
+    project_id: str,
+    token: str,
+    options: list[dict[str, str]] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Replace the Status single-select field options with the standard set."""
+    cp = project_fields(project_id, token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        fields = json.loads(cp.stdout).get("fields", [])
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Could not parse project fields.")
+
+    status_field = next(
+        (f for f in fields if isinstance(f, dict) and f.get("name") == "Status"),
+        None,
+    )
+    if status_field is None:
+        return _err("No Status field found on project.")
+
+    field_id = status_field.get("id", "")
+    if not field_id:
+        return _err("Could not resolve Status field ID.")
+
+    chosen = options if options is not None else STANDARD_STATUS_OPTIONS
+    cp2 = graphql(
+        _GQL_UPDATE_STATUS_FIELD,
+        {"fieldId": field_id, "options": chosen},
+        token,
+    )
+    if cp2.returncode != 0:
+        return cp2
+    try:
+        data = json.loads(cp2.stdout)
+        field = data.get("updateProjectV2Field", {}).get("projectV2Field") or {}
+        return _ok(json.dumps(field))
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response setting status field options.")
 
 
 def project_item_add(

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -636,6 +636,44 @@ def link_project_repo(
     )
 
 
+def setup_project_statuses(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+    out: Callable[[str], None] = print,
+) -> ProjectMutationSummary:
+    from .github_api import setup_project_status_field, token_from_repo
+
+    token = token_from_repo(repo_dir) or ""
+    project = _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+    if not project.id:
+        raise RuntimeError(f"Could not resolve project ID for '{project.title}'.")
+
+    cp = setup_project_status_field(project.id, token)
+    if cp.returncode != 0:
+        raise RuntimeError(
+            cp.stderr.strip() or "Failed setting up project status field."
+        )
+
+    out(f"Status field configured on project '{project.title}'.")
+    return ProjectMutationSummary(
+        action="setup-statuses",
+        owner=project.owner,
+        project_number=project.number,
+        project_title=project.title,
+        failures=0,
+        changed=True,
+        metadata_file=None,
+    )
+
+
 def create_project(
     *,
     repo_dir: Path,
@@ -644,6 +682,7 @@ def create_project(
     description: str | None,
     readme: str | None,
     visibility: str | None,
+    repo: str | None = None,
     dry_run: bool,
     out: Callable[[str], None] = print,
 ) -> ProjectMutationSummary:
@@ -660,6 +699,9 @@ def create_project(
             out(f"[dry-run] set project readme: {title}")
         if visibility:
             out(f"[dry-run] set project visibility: {visibility.upper()}")
+        if repo:
+            out(f"[dry-run] link project to repo: {repo}")
+            out(f"[dry-run] setup status field: {title}")
         return ProjectMutationSummary(
             action="create",
             owner=project_owner,
@@ -739,6 +781,30 @@ def create_project(
             source="project_create",
         )
         out(f"Synced project metadata: {metadata_file}")
+
+    if repo:
+        try:
+            link_project_repo(
+                repo_dir=repo_dir,
+                owner=project_owner,
+                project_number=number,
+                project_title=None,
+                repo=repo,
+                out=out,
+            )
+        except RuntimeError as exc:
+            out(f"Warning: could not link repo: {exc}")
+
+        try:
+            setup_project_statuses(
+                repo_dir=repo_dir,
+                owner=project_owner,
+                project_number=number,
+                project_title=None,
+                out=out,
+            )
+        except RuntimeError as exc:
+            out(f"Warning: could not setup status field: {exc}")
 
     return ProjectMutationSummary(
         action="create",

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -522,6 +522,97 @@ def test_project_item_update_field_success() -> None:
     assert cp.returncode == 0
 
 
+def test_setup_project_status_field_preserves_existing_ids() -> None:
+    fields_data = {
+        "node": {
+            "fields": {
+                "nodes": [
+                    {
+                        "id": "F_status",
+                        "name": "Status",
+                        "options": [
+                            {"id": "existing_todo", "name": "Todo"},
+                            {"id": "existing_done", "name": "Done"},
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    update_resp = {
+        "updateProjectV2Field": {
+            "projectV2Field": {
+                "id": "F_status",
+                "name": "Status",
+                "options": [],
+            }
+        }
+    }
+    calls: list[dict[str, object]] = []
+
+    def fake_urlopen(req: object) -> object:
+        import json as _json
+
+        body = _json.loads(getattr(req, "data", b"{}"))
+        calls.append(body)
+        if "updateProjectV2Field" in body.get("query", ""):
+            return _graphql_ok(update_resp)
+        return _graphql_ok(fields_data)
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        cp = github_api.setup_project_status_field("PV2_1", "tok")
+
+    assert cp.returncode == 0
+    update_call = next(c for c in calls if "updateProjectV2Field" in c.get("query", ""))
+    sent_options: list[dict[str, str]] = update_call["variables"]["options"]
+    todo_opt = next(o for o in sent_options if o["name"] == "Todo")
+    done_opt = next(o for o in sent_options if o["name"] == "Done")
+    in_progress_opt = next(o for o in sent_options if o["name"] == "In Progress")
+    assert todo_opt.get("id") == "existing_todo"
+    assert done_opt.get("id") == "existing_done"
+    assert "id" not in in_progress_opt
+
+
+def test_setup_project_status_field_new_project_no_ids() -> None:
+    fields_data = {
+        "node": {
+            "fields": {
+                "nodes": [
+                    {
+                        "id": "F_status",
+                        "name": "Status",
+                        "options": [],
+                    }
+                ]
+            }
+        }
+    }
+    update_resp = {
+        "updateProjectV2Field": {
+            "projectV2Field": {"id": "F_status", "name": "Status", "options": []}
+        }
+    }
+    calls: list[dict[str, object]] = []
+
+    def fake_urlopen(req: object) -> object:
+        import json as _json
+
+        body = _json.loads(getattr(req, "data", b"{}"))
+        calls.append(body)
+        if "updateProjectV2Field" in body.get("query", ""):
+            return _graphql_ok(update_resp)
+        return _graphql_ok(fields_data)
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        cp = github_api.setup_project_status_field("PV2_1", "tok")
+
+    assert cp.returncode == 0
+    update_call = next(c for c in calls if "updateProjectV2Field" in c.get("query", ""))
+    sent_options: list[dict[str, str]] = update_call["variables"]["options"]
+    assert all("id" not in o for o in sent_options)
+    assert len(sent_options) == len(github_api.STANDARD_STATUS_OPTIONS)
+
+
 # ---------------------------------------------------------------------------
 # branch_create / branch_delete / pr_merge / pr_checks / issue_list --label
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
feat(project): add setup-statuses command and auto-configure on project create

Adds project setup-statuses (configures Status field with 7 standard options via updateProjectV2Field) and project create --repo (auto-links repo + runs status setup). Standard statuses: Todo/GRAY, In Progress/YELLOW, To Review/BLUE, Done/GREEN, Won't Do/GRAY, Duplicate/BLUE, Blocked/RED.

Closes #134
