### PR TITLE
feat(guardrails): add typecheck CI step and apply settings command

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -1611,11 +1611,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1 if backlog_summary.failures > 0 else 0
 
     if ns.mode == "apply" and ns.apply_command == "settings":
-        langs = (
-            [lang.strip() for lang in ns.languages.split(",") if lang.strip()]
-            if ns.languages
-            else []
-        )
+        langs: tuple[str, ...] = ()
+        if ns.languages:
+            langs = _parse_languages_or_die(parser, ns.languages)
         try:
             apply_repository_settings(
                 repo_dir=Path.cwd(),
@@ -1623,7 +1621,7 @@ def main(argv: list[str] | None = None) -> int:
                 dry_run=getattr(ns, "dry_run", False),
                 out=print,
                 warn=lambda line: print(line, file=sys.stderr),
-                languages=langs or None,
+                languages=list(langs) if langs else None,
             )
         except RuntimeError as exc:
             print(str(exc), file=sys.stderr)

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -577,6 +577,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Execute commands instead of only printing them",
     )
 
+    apply_settings_cmd = apply_sub.add_parser(
+        "settings",
+        parents=[apply_parent],
+        help="Apply repository settings including required status checks",
+    )
+    apply_settings_cmd.add_argument(
+        "--repo",
+        required=True,
+        help="Target GitHub repo (owner/repo)",
+    )
+    apply_settings_cmd.add_argument(
+        "--languages",
+        default="",
+        help="Comma-separated language list (go, gin, python, react) to require as status checks",
+    )
+
     check = subparsers.add_parser(
         "check",
         help="Check GitHub settings/capabilities for drift",
@@ -1593,6 +1609,36 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  project items skipped: {backlog_summary.project_items_skipped}")
         print(f"  failures: {backlog_summary.failures}")
         return 1 if backlog_summary.failures > 0 else 0
+
+    if ns.mode == "apply" and ns.apply_command == "settings":
+        langs = (
+            [lang.strip() for lang in ns.languages.split(",") if lang.strip()]
+            if ns.languages
+            else []
+        )
+        try:
+            apply_repository_settings(
+                repo_dir=Path.cwd(),
+                repo=ns.repo,
+                dry_run=getattr(ns, "dry_run", False),
+                out=print,
+                warn=lambda line: print(line, file=sys.stderr),
+                languages=langs or None,
+            )
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+
+        print("")
+        print("Summary:")
+        if getattr(ns, "dry_run", False):
+            print("  mode: dry-run")
+            print("  settings planned: True")
+        else:
+            print("  settings applied: True")
+            if langs:
+                print(f"  required status checks: {', '.join(langs)}")
+        return 0
 
     if ns.mode == "apply" and ns.apply_command == "rules":
         target_repo, repo_error = _resolve_repo_from_args_or_env(

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -73,7 +73,17 @@ def _repo_patch_payload() -> str:
     )
 
 
-def _default_branch_ruleset_payload() -> str:
+_LANGUAGE_CI_CONTEXT: dict[str, str] = {
+    "react": "react",
+    "python": "python",
+    "go": "go",
+    "gin": "go",
+}
+
+
+def _default_branch_ruleset_payload(
+    languages: list[str] | None = None,
+) -> str:
     rules: list[dict[str, object]] = [
         {"type": "deletion"},
         {"type": "non_fast_forward"},
@@ -109,6 +119,27 @@ def _default_branch_ruleset_payload() -> str:
             },
         },
     ]
+
+    if languages:
+        contexts = list(
+            dict.fromkeys(
+                _LANGUAGE_CI_CONTEXT[lang]
+                for lang in languages
+                if lang in _LANGUAGE_CI_CONTEXT
+            )
+        )
+        if contexts:
+            rules.append(
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "required_status_checks": [
+                            {"context": ctx} for ctx in contexts
+                        ],
+                        "strict_required_status_checks_policy": False,
+                    },
+                }
+            )
     return json.dumps(
         {
             "name": _SETTINGS_RULESET_NAME,
@@ -326,13 +357,14 @@ def _sync_default_branch_ruleset(
     env: dict[str, str],
     repo: str,
     out: Callable[[str], None],
+    languages: list[str] | None = None,
 ) -> None:
     managed_rulesets = [
         item
         for item in _list_repo_rulesets(repo_dir=repo_dir, env=env, repo=repo)
         if _is_managed_ruleset_name(item.get("name"))
     ]
-    payload = _default_branch_ruleset_payload()
+    payload = _default_branch_ruleset_payload(languages=languages)
 
     if managed_rulesets:
         ruleset_id = managed_rulesets[0].get("id")
@@ -859,6 +891,7 @@ def apply_repository_settings(
     dry_run: bool,
     out: Callable[[str], None] = print,
     warn: Callable[[str], None] | None = None,
+    languages: list[str] | None = None,
 ) -> None:
     _ensure_tools()
     env = _build_env(repo_dir)
@@ -872,6 +905,7 @@ def apply_repository_settings(
         dry_run=dry_run,
         out=out,
         warn=emit_warn,
+        languages=languages,
     )
 
 
@@ -946,6 +980,7 @@ def _apply_settings(
     dry_run: bool,
     out: Callable[[str], None],
     warn: Callable[[str], None],
+    languages: list[str] | None = None,
 ) -> None:
     out(f"{'[dry-run] ' if dry_run else ''}apply repository settings: {repo}")
     if dry_run:
@@ -980,7 +1015,9 @@ def _apply_settings(
         )
     out("Applied repository merge settings.")
 
-    _sync_default_branch_ruleset(repo_dir=repo_dir, env=env, repo=repo, out=out)
+    _sync_default_branch_ruleset(
+        repo_dir=repo_dir, env=env, repo=repo, out=out, languages=languages
+    )
 
     _clear_legacy_branch_protection(
         repo_dir=repo_dir,

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -320,6 +320,8 @@ def _render_ci_yaml(languages: Iterable[str]) -> str:
         run: npm ci
       - name: Lint
         run: npm run lint --if-present
+      - name: Typecheck
+        run: npm run typecheck --if-present
       - name: Build
         run: npm run build
       - name: Test (optional)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1239,11 +1239,21 @@ def test_apply_settings_forwards_languages(
     )
     assert rc == 0
     assert captured["repo"] == "acme/repo"
-    assert captured["languages"] == ["react", "python"]
+    assert captured["languages"] == ["python", "react"]
     assert captured["dry_run"] is False
     stdout = capsys.readouterr().out
     assert "settings applied: True" in stdout
-    assert "react, python" in stdout
+    assert "python, react" in stdout
+
+
+def test_apply_settings_rejects_unknown_language(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("repo_scaffold.cli.apply_repository_settings", lambda **_: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["apply", "settings", "--repo", "acme/repo", "--languages", "pyhton"])
+    assert exc_info.value.code != 0
 
 
 def test_apply_settings_dry_run(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1222,6 +1222,47 @@ def test_apply_rules_dry_run_does_not_execute(
     assert "settings planned: True" in stdout
 
 
+def test_apply_settings_forwards_languages(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_apply(*, repo_dir, repo, dry_run, out, warn, languages):
+        captured["repo"] = repo
+        captured["languages"] = languages
+        captured["dry_run"] = dry_run
+
+    monkeypatch.setattr("repo_scaffold.cli.apply_repository_settings", _fake_apply)
+
+    rc = main(
+        ["apply", "settings", "--repo", "acme/repo", "--languages", "react,python"]
+    )
+    assert rc == 0
+    assert captured["repo"] == "acme/repo"
+    assert captured["languages"] == ["react", "python"]
+    assert captured["dry_run"] is False
+    stdout = capsys.readouterr().out
+    assert "settings applied: True" in stdout
+    assert "react, python" in stdout
+
+
+def test_apply_settings_dry_run(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_apply(*, repo_dir, repo, dry_run, out, warn, languages):
+        captured["dry_run"] = dry_run
+
+    monkeypatch.setattr("repo_scaffold.cli.apply_repository_settings", _fake_apply)
+
+    rc = main(["apply", "settings", "--repo", "acme/repo", "--dry-run"])
+    assert rc == 0
+    assert captured["dry_run"] is True
+    stdout = capsys.readouterr().out
+    assert "settings planned: True" in stdout
+
+
 def test_check_rules_resolves_repo_from_dotenv(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -149,6 +149,64 @@ def test_default_branch_ruleset_payload_uses_zero_review_baseline() -> None:
     assert copilot_code_review_rule["parameters"]["review_on_push"] is True
 
 
+def test_default_branch_ruleset_payload_without_languages_has_no_required_status_checks() -> (
+    None
+):
+    payload = json.loads(create_ops._default_branch_ruleset_payload())
+    types = [rule["type"] for rule in payload["rules"]]
+    assert "required_status_checks" not in types
+
+
+def test_default_branch_ruleset_payload_with_react_adds_required_status_checks() -> (
+    None
+):
+    payload = json.loads(
+        create_ops._default_branch_ruleset_payload(languages=["react"])
+    )
+    rule = next(
+        (r for r in payload["rules"] if r["type"] == "required_status_checks"), None
+    )
+    assert rule is not None
+    contexts = [c["context"] for c in rule["parameters"]["required_status_checks"]]
+    assert contexts == ["react"]
+    assert rule["parameters"]["strict_required_status_checks_policy"] is False
+
+
+def test_default_branch_ruleset_payload_deduplicates_go_gin_context() -> None:
+    payload = json.loads(
+        create_ops._default_branch_ruleset_payload(languages=["go", "gin"])
+    )
+    rule = next(r for r in payload["rules"] if r["type"] == "required_status_checks")
+    contexts = [c["context"] for c in rule["parameters"]["required_status_checks"]]
+    assert contexts == ["go"]
+
+
+def test_apply_repository_settings_forwards_languages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(create_ops, "_ensure_tools", lambda: None)
+    monkeypatch.setattr(create_ops, "_build_env", lambda _repo_dir: {"GH_TOKEN": "x"})
+    monkeypatch.setattr(create_ops, "_ensure_gh_auth", lambda _repo_dir, _env: None)
+    monkeypatch.setattr(
+        create_ops,
+        "_apply_settings",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    create_ops.apply_repository_settings(
+        repo_dir=repo_dir,
+        repo="acme/repo",
+        dry_run=False,
+        languages=["react", "python"],
+    )
+
+    assert captured["languages"] == ["react", "python"]
+
+
 def test_branch_protection_endpoint_url_encodes_branch_name() -> None:
     assert (
         create_ops._branch_protection_endpoint(

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -324,6 +324,12 @@ def test_react_vite_scaffold_file_contents(tmp_path: Path) -> None:
     assert "working-directory: web" in ci
     assert "contains(env.LANGUAGES" not in ci
     assert "hashFiles(" not in ci
+    assert "npm run typecheck --if-present" in ci
+    react_job = ci[ci.index("react:") :]
+    lint_pos = react_job.index("name: Lint")
+    typecheck_pos = react_job.index("name: Typecheck")
+    build_pos = react_job.index("name: Build")
+    assert lint_pos < typecheck_pos < build_pos
 
     gitignore = (cfg.out_dir / ".gitignore").read_text(encoding="utf-8")
     assert "web/node_modules/" in gitignore


### PR DESCRIPTION
## 🧾 Title

feat(guardrails): add typecheck CI step and apply settings command

## 🧠 Description

This pull request adds two guardrail improvements: an explicit Typecheck step to the generated react CI job, and a new apply settings command that enforces required status checks on the default branch ruleset.

## 🧩 Changes Included

- [x] Implemented new feature or enhancement

## 🎯 Purpose

**Issue #139 -- typecheck CI step:** The react job previously ran npm run build which surfaces type errors only as part of the build output, making them hard to distinguish from other failures. A dedicated Typecheck step (npm run typecheck --if-present) is now inserted between Lint and Build. The --if-present flag means repos without a typecheck script skip it silently.

**Issue #140 -- apply settings command:** _apply_settings() existed internally but was only called from create. There was no way to re-apply settings (including required status checks) to an existing repo without recreating it. The managed ruleset also had no required_status_checks rule, so CI failures did not block merges.

Changes:
- generator.py: add Typecheck step to react job in generated ci.yml
- create_ops.py: _LANGUAGE_CI_CONTEXT mapping; _default_branch_ruleset_payload accepts optional languages list; when languages provided, appends required_status_checks rule with the corresponding CI job context (react, python, go -- go and gin both map to go); _sync_default_branch_ruleset, _apply_settings, and apply_repository_settings all forward languages through
- cli.py: new apply settings subcommand -- poetry run repo-scaffold apply settings --repo OWNER/REPO [--languages react,python,...] [--dry-run]

## 🔗 Related Issues / Epics

- **Closes:** Fixes #139
- **Closes:** Fixes #140

## 🧪 Testing

1. Run poetry run pytest -- all tests pass, 70.34% coverage
2. Check generated ci.yml for react: npm run typecheck --if-present appears between Lint and Build steps
3. Run poetry run repo-scaffold apply settings --repo ThePRIMEForge/muster-deck --languages react --dry-run to preview required_status_checks rule addition
4. Run without --dry-run to apply: verify ruleset in GitHub Settings > Rules includes react as a required check

## 🧰 Developer Notes

- go and gin are mutually exclusive in the generator but both map to the go CI job context in the ruleset -- the deduplication handles this via dict.fromkeys
- strict_required_status_checks_policy is set to False (branches do not need to be up-to-date before merging)
- The existing apply rules command is unchanged; apply settings is the new idempotent command