### PR TITLE
feat(pr): add pr annotations and pr rerun commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRAN
 poetry run repo-scaffold pr update --repo OWNER/REPO --pr-number N [--title "TITLE"] [--body "TEXT"]
 poetry run repo-scaffold pr merge --repo OWNER/REPO --pr-number N [--method squash|merge|rebase]
 poetry run repo-scaffold pr checks --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr annotations --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr rerun --repo OWNER/REPO --pr-number N [--failed-only]
 poetry run repo-scaffold pr list-comments --repo OWNER/REPO --pr-number N [--json]
 poetry run repo-scaffold pr review-threads --repo OWNER/REPO --pr-number N [--json]
 

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -28,12 +28,14 @@ from .github_api import (
     issue_label,
     issue_list,
     issue_update,
+    pr_annotations,
     pr_checks,
     pr_comment,
     pr_create,
     pr_list,
     pr_list_comments,
     pr_merge,
+    pr_rerun,
     pr_resolve_thread,
     pr_review_threads,
     pr_update,
@@ -1125,6 +1127,26 @@ def build_parser() -> argparse.ArgumentParser:
     pr_checks_cmd.add_argument("--repo", required=True)
     pr_checks_cmd.add_argument("--pr-number", required=True, type=int, dest="pr_number")
     pr_checks_cmd.add_argument("--json", action="store_true", dest="json_output")
+
+    pr_annotations_cmd = pr_sub.add_parser(
+        "annotations",
+        help="Show check-run annotations (lint errors, test failures) for a PR",
+    )
+    pr_annotations_cmd.add_argument("--repo", required=True)
+    pr_annotations_cmd.add_argument(
+        "--pr-number", required=True, type=int, dest="pr_number"
+    )
+    pr_annotations_cmd.add_argument("--json", action="store_true", dest="json_output")
+
+    pr_rerun_cmd = pr_sub.add_parser("rerun", help="Re-run workflow jobs for a PR")
+    pr_rerun_cmd.add_argument("--repo", required=True)
+    pr_rerun_cmd.add_argument("--pr-number", required=True, type=int, dest="pr_number")
+    pr_rerun_cmd.add_argument(
+        "--failed-only",
+        action="store_true",
+        dest="failed_only",
+        help="Only re-run failed jobs (default: re-run all)",
+    )
 
     pr_review_threads_cmd = pr_sub.add_parser(
         "review-threads", help="List review threads (comments) on a PR"
@@ -2346,6 +2368,48 @@ def main(argv: list[str] | None = None) -> int:
                     conclusion = r.get("conclusion") or status
                     print(f"  {r.get('name', '?')}: {conclusion}")
             return 0
+
+        if ns.pr_command == "annotations":
+            cp = pr_annotations(target_repo, ns.pr_number, token)
+            if cp.returncode != 0:
+                print(
+                    cp.stderr.strip() or "Failed fetching annotations.", file=sys.stderr
+                )
+                return 1
+            items = _json.loads(cp.stdout)
+            if ns.json_output:
+                print(_json.dumps(items, indent=2))
+            else:
+                if not items:
+                    print("No annotations found.")
+                for a in items:
+                    level = a.get("annotation_level", "?")
+                    check = a.get("check_run", "?")
+                    path = a.get("path", "?")
+                    line = a.get("start_line", "?")
+                    msg = (a.get("message") or "").strip()
+                    print(f"[{level}] {check} -- {path}:{line}")
+                    print(f"  {msg}")
+            return 0
+
+        if ns.pr_command == "rerun":
+            cp = pr_rerun(target_repo, ns.pr_number, token, failed_only=ns.failed_only)
+            if cp.returncode != 0:
+                print(cp.stderr.strip() or "Failed to re-run jobs.", file=sys.stderr)
+                return 1
+            result = _json.loads(cp.stdout)
+            triggered = result.get("triggered", [])
+            errors = result.get("errors", [])
+            if triggered:
+                print(
+                    f"Re-triggered {len(triggered)} run(s): {', '.join(str(r) for r in triggered)}"
+                )
+            if errors:
+                for e in errors:
+                    print(f"  error: {e}", file=sys.stderr)
+            if not triggered and not errors:
+                print("No runs found to re-trigger.")
+            return 0 if not errors else 1
 
         if ns.pr_command == "review-threads":
             owner, repo_name = target_repo.split("/", 1)

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1382,6 +1382,98 @@ def pr_checks(
         return _err("Unexpected response from check-runs API.")
 
 
+def pr_annotations(
+    repo: str,
+    pr_number: int,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    """Return check-run annotations for a PR, grouped by check run name."""
+    cp = rest("GET", f"/repos/{repo}/pulls/{pr_number}", token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        sha = json.loads(cp.stdout)["head"]["sha"]
+    except (json.JSONDecodeError, KeyError):
+        return _err("Could not extract head SHA from PR.")
+    cp2 = rest("GET", f"/repos/{repo}/commits/{sha}/check-runs?per_page=100", token)
+    if cp2.returncode != 0:
+        return cp2
+    try:
+        payload = json.loads(cp2.stdout)
+        runs = payload.get("check_runs", []) if isinstance(payload, dict) else payload
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response from check-runs API.")
+    # Deduplicate by name, keeping latest
+    seen: dict[str, dict[str, object]] = {}
+    for run in runs:
+        n = str(run.get("name", ""))
+        run_id = run.get("id", 0)
+        seen_id = seen[n].get("id", 0) if n in seen else 0
+        if n not in seen or (
+            isinstance(run_id, int) and isinstance(seen_id, int) and run_id > seen_id
+        ):
+            seen[n] = run
+    results: list[dict[str, object]] = []
+    for run in seen.values():
+        run_id = run.get("id")
+        cp3 = rest(
+            "GET", f"/repos/{repo}/check-runs/{run_id}/annotations?per_page=100", token
+        )
+        if cp3.returncode != 0:
+            continue
+        try:
+            annotations = json.loads(cp3.stdout)
+        except json.JSONDecodeError:
+            continue
+        for ann in annotations:
+            results.append(
+                {
+                    "check_run": run.get("name"),
+                    "annotation_level": ann.get("annotation_level"),
+                    "path": ann.get("path"),
+                    "start_line": ann.get("start_line"),
+                    "message": ann.get("message"),
+                }
+            )
+    return _ok(json.dumps(results))
+
+
+def pr_rerun(
+    repo: str,
+    pr_number: int,
+    token: str,
+    failed_only: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Re-run workflow jobs for a PR's head commit."""
+    cp = rest("GET", f"/repos/{repo}/pulls/{pr_number}", token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        sha = json.loads(cp.stdout)["head"]["sha"]
+    except (json.JSONDecodeError, KeyError):
+        return _err("Could not extract head SHA from PR.")
+    cp2 = rest("GET", f"/repos/{repo}/actions/runs?head_sha={sha}&per_page=50", token)
+    if cp2.returncode != 0:
+        return cp2
+    try:
+        runs = json.loads(cp2.stdout).get("workflow_runs", [])
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response from actions/runs API.")
+    if not runs:
+        return _err(f"No workflow runs found for PR #{pr_number}.")
+    suffix = "rerun-failed-jobs" if failed_only else "rerun"
+    triggered: list[int] = []
+    errors: list[str] = []
+    for run in runs:
+        run_id = run.get("id")
+        cp3 = rest("POST", f"/repos/{repo}/actions/runs/{run_id}/{suffix}", token, {})
+        if cp3.returncode in (0, 201):
+            triggered.append(run_id)
+        else:
+            errors.append(f"run {run_id}: {cp3.stderr.strip()}")
+    return _ok(json.dumps({"triggered": triggered, "errors": errors}))
+
+
 def token_from_repo(repo_dir: Path) -> str | None:
     """Try to resolve a GH token from the repo .env and environment."""
     env = dict(os.environ)

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1416,8 +1416,8 @@ def pr_annotations(
     results: list[dict[str, object]] = []
     for run in seen.values():
         run_id = run.get("id")
-        cp3 = rest(
-            "GET", f"/repos/{repo}/check-runs/{run_id}/annotations?per_page=100", token
+        cp3 = rest_paginated(
+            f"/repos/{repo}/check-runs/{run_id}/annotations?per_page=100", token
         )
         if cp3.returncode != 0:
             continue

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2410,6 +2410,89 @@ def test_pr_checks(tmp_path, monkeypatch, capsys) -> None:
     assert "CI" in capsys.readouterr().out
 
 
+def test_pr_annotations(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    anns = [
+        {
+            "check_run": "react",
+            "annotation_level": "failure",
+            "path": "src/App.tsx",
+            "start_line": 10,
+            "message": "'foo' is defined but never used",
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_annotations",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(anns), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["pr", "annotations", "--repo", "acme/repo", "--pr-number", "42"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "failure" in out
+    assert "src/App.tsx:10" in out
+    assert "never used" in out
+
+
+def test_pr_annotations_json(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    anns = [
+        {
+            "check_run": "CI",
+            "annotation_level": "warning",
+            "path": "x.ts",
+            "start_line": 1,
+            "message": "msg",
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_annotations",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(anns), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(
+        ["pr", "annotations", "--repo", "acme/repo", "--pr-number", "5", "--json"]
+    )
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data[0]["path"] == "x.ts"
+
+
+def test_pr_rerun(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_rerun",
+        lambda repo, pr_number, token, failed_only=False: subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps({"triggered": [12345], "errors": []}),
+            stderr="",
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(
+        ["pr", "rerun", "--repo", "acme/repo", "--pr-number", "42", "--failed-only"]
+    )
+    assert rc == 0
+    assert "12345" in capsys.readouterr().out
+
+
 def test_branch_create(tmp_path, monkeypatch, capsys) -> None:
     import json
     import subprocess

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -749,3 +749,128 @@ def test_enable_project_workflow_api_error() -> None:
     with patch("urllib.request.urlopen", side_effect=_http_error(403, "forbidden")):
         cp = github_api.enable_project_workflow("WF_1", "tok", enabled=True)
     assert cp.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# pr_annotations
+# ---------------------------------------------------------------------------
+
+
+def test_pr_annotations_returns_flat_list() -> None:
+    pr_payload = json.dumps({"head": {"sha": "abc123"}})
+    runs_payload = json.dumps(
+        {
+            "check_runs": [
+                {
+                    "id": 1,
+                    "name": "react",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ]
+        }
+    )
+    ann_payload = json.dumps(
+        [
+            {
+                "annotation_level": "failure",
+                "path": "src/App.tsx",
+                "start_line": 10,
+                "message": "'foo' is defined but never used",
+            }
+        ]
+    )
+
+    responses = [
+        _mock_resp(200, pr_payload),
+        _mock_resp(200, runs_payload),
+        _mock_resp(200, ann_payload),
+    ]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        cp = github_api.pr_annotations("acme/repo", 42, "tok")
+    assert cp.returncode == 0
+    items = json.loads(cp.stdout)
+    assert len(items) == 1
+    assert items[0]["check_run"] == "react"
+    assert items[0]["path"] == "src/App.tsx"
+    assert items[0]["start_line"] == 10
+
+
+def test_pr_annotations_pr_fetch_error() -> None:
+    with patch("urllib.request.urlopen", side_effect=_http_error(404)):
+        cp = github_api.pr_annotations("acme/repo", 99, "tok")
+    assert cp.returncode != 0
+
+
+def test_pr_annotations_no_annotations_returns_empty() -> None:
+    pr_payload = json.dumps({"head": {"sha": "abc123"}})
+    runs_payload = json.dumps({"check_runs": [{"id": 1, "name": "CI"}]})
+    ann_payload = json.dumps([])
+
+    responses = [
+        _mock_resp(200, pr_payload),
+        _mock_resp(200, runs_payload),
+        _mock_resp(200, ann_payload),
+    ]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        cp = github_api.pr_annotations("acme/repo", 1, "tok")
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout) == []
+
+
+# ---------------------------------------------------------------------------
+# pr_rerun
+# ---------------------------------------------------------------------------
+
+
+def test_pr_rerun_triggers_all_runs() -> None:
+    pr_payload = json.dumps({"head": {"sha": "abc123"}})
+    runs_payload = json.dumps({"workflow_runs": [{"id": 777}, {"id": 888}]})
+    rerun_resp = _mock_resp(201, "")
+
+    responses = [
+        _mock_resp(200, pr_payload),
+        _mock_resp(200, runs_payload),
+        rerun_resp,
+        rerun_resp,
+    ]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        cp = github_api.pr_rerun("acme/repo", 42, "tok")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert set(result["triggered"]) == {777, 888}
+    assert result["errors"] == []
+
+
+def test_pr_rerun_failed_only_uses_correct_endpoint() -> None:
+    pr_payload = json.dumps({"head": {"sha": "abc123"}})
+    runs_payload = json.dumps({"workflow_runs": [{"id": 555}]})
+    captured_urls: list[str] = []
+
+    def _fake_urlopen(req: urllib.request.Request) -> MagicMock:
+        captured_urls.append(req.full_url)
+        return _mock_resp(201, "")
+
+    responses_iter = iter([_mock_resp(200, pr_payload), _mock_resp(200, runs_payload)])
+
+    def _side_effect(req: urllib.request.Request) -> MagicMock:
+        try:
+            return next(responses_iter)
+        except StopIteration:
+            return _fake_urlopen(req)
+
+    with patch("urllib.request.urlopen", side_effect=_side_effect):
+        cp = github_api.pr_rerun("acme/repo", 42, "tok", failed_only=True)
+    assert cp.returncode == 0
+    assert any("rerun-failed-jobs" in u for u in captured_urls)
+
+
+def test_pr_rerun_no_runs_returns_error() -> None:
+    pr_payload = json.dumps({"head": {"sha": "abc123"}})
+    runs_payload = json.dumps({"workflow_runs": []})
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[_mock_resp(200, pr_payload), _mock_resp(200, runs_payload)],
+    ):
+        cp = github_api.pr_rerun("acme/repo", 42, "tok")
+    assert cp.returncode != 0


### PR DESCRIPTION
## Summary

- Adds `pr annotations` command to surface check-run annotation details (lint errors, test failures, CodeQL findings) directly from the CLI without opening GitHub UI
- Adds `pr rerun` command to re-trigger workflow runs for a PR, with `--failed-only` flag to target only failed jobs -- useful for recovering from transient CI failures

Closes #142, closes #143

## Test plan

- [ ] `poetry run repo-scaffold pr annotations --repo OWNER/REPO --pr-number N` lists annotation level, file, line, and message
- [ ] `poetry run repo-scaffold pr annotations ... --json` emits raw JSON
- [ ] `poetry run repo-scaffold pr rerun --repo OWNER/REPO --pr-number N --failed-only` re-triggers only failed jobs
- [ ] All existing tests still pass; coverage at 70.51%

🤖 Generated with [Claude Code](https://claude.ai/claude-code)