### PR TITLE
chore(github): add CODEOWNERS listing @blairg23

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# blairg23/repo-scaffold - Code Owners
+#
+# Listed owners are automatically requested for review on every PR.
+# Branch protection requires at least 1 code-owner approval before merge.
+#
+# To enable GitHub Copilot auto-review:
+#   Repository Settings > Copilot > Code review > Enable
+# (Cannot be configured via the GitHub REST API as of mid-2025 -- UI only.)
+* @blairg23


### PR DESCRIPTION
## 🧾 Title
chore(github): add CODEOWNERS listing @blairg23

## 🧠 Description
This pull request adds `.github/CODEOWNERS` so GitHub automatically requests @blairg23 as reviewer on every PR opened against this repo.

## 🧩 Changes Included
- [x] Added `.github/CODEOWNERS`

## 🎯 Purpose
Without a CODEOWNERS file, no reviewer is ever auto-requested, making it easy to merge PRs without a human review. This wires up @blairg23 as the required code owner across all files.

## 🔗 Related Issues / Epics
- **Closes:** Fixes #145

## 🧪 Testing
1. Merge this PR
2. Open any subsequent PR targeting main
3. Verify @blairg23 is automatically added as a reviewer

## 🧰 Developer Notes
- [ ] Branch protection should require 1 code-owner approval before merge
- [ ] CODEOWNERS `*` pattern covers all files in the repo