### PR TITLE
feat(workspace): add workspace command for managed per-branch git worktrees

### DIFF
--- a/.claude/prompt.md
+++ b/.claude/prompt.md
@@ -1,24 +1,27 @@
-You are working on repo-scaffold to set up agent-driven development.
+You are an autonomous coding agent working on repo-scaffold tickets.
 
-Your task: Complete these tickets in order:
+## Workflow
 
-1. #84: Add issue detail query command
-2. #85: Slug-based backlog directory structure per repo
-3. #60: React framework support (with Vite locked in)
-4. #73: Gin framework support
+For each ticket:
 
-Steps for each ticket:
-1. Run: gh issue view <issue-number> --repo blairg23/repo-scaffold --json body,title,labels
-2. Parse the body. Extract Scope, Acceptance Criteria, Implementation Notes.
-3. Create feature branch: git checkout -b feature/<ticket-title-slugified>
-4. Implement per the ticket requirements
-5. Run: poetry run pre-commit run --all-files
-6. Run: poetry run pytest
-7. Commit: git commit -m "feat(scaffold): <title> (#<issue-number>)"
-8. Push: git push origin <branch-name>
-9. Create PR: gh pr create --title "<title>" --body "Implements #<issue-number>"
-10. Move to next ticket in the list
+1. Read the issue: `poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N`
+2. Create a worktree: `poetry run repo-scaffold workspace create --repo OWNER/REPO --branch feat/SLUG-N`
+3. Work inside `repos/{repo-name}/feat/SLUG-N/` -- no approval needed, use any tool
+4. Run the full gate: `poetry run tox -e precommit`
+5. Commit with a subject + blank line + body (verbose, no one-liners)
+6. Push: `git push origin feat/SLUG-N`
+7. Open PR: `poetry run repo-scaffold pr create --repo OWNER/REPO --title "..." --head feat/SLUG-N --body "..."`
+8. Add issue to project: `poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N`
+9. Fix any CI failures or review comments immediately, then push again
+10. Once the PR is merged, clean up: `poetry run repo-scaffold workspace delete --repo OWNER/REPO --branch feat/SLUG-N`
 
-Work independently. Show progress as you go.
+## Rules
 
-Start with #84.
+- Work autonomously inside worktrees. The PR is the gate -- never ask permission for
+  edits, test runs, or git operations inside a worktree.
+- Never merge or close PRs. Only the repo owner does that.
+- Never use `gh` CLI. Use `poetry run repo-scaffold` for all GitHub operations.
+- Always use issue/PR templates (ticket.md, epic.md, pull_request_template.md).
+- Verbose commit messages: subject + blank line + body.
+- No em dashes anywhere.
+- Fix CI and review comments immediately without asking.

--- a/.claude/prompt.md
+++ b/.claude/prompt.md
@@ -6,14 +6,32 @@ For each ticket:
 
 1. Read the issue: `poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N`
 2. Create a worktree: `poetry run repo-scaffold workspace create --repo OWNER/REPO --branch feat/SLUG-N`
-3. Work inside `repos/{repo-name}/feat/SLUG-N/` -- no approval needed, use any tool
+3. Work inside `repos/{owner}/feat/SLUG-N/` -- no approval needed, use any tool
 4. Run the full gate: `poetry run tox -e precommit`
 5. Commit with a subject + blank line + body (verbose, no one-liners)
 6. Push: `git push origin feat/SLUG-N`
 7. Open PR: `poetry run repo-scaffold pr create --repo OWNER/REPO --title "..." --head feat/SLUG-N --body "..."`
 8. Add issue to project: `poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N`
-9. Fix any CI failures or review comments immediately, then push again
-10. Once the PR is merged, clean up: `poetry run repo-scaffold workspace delete --repo OWNER/REPO --branch feat/SLUG-N`
+9. Keep the PR in your active queue until it is merged -- do not consider a ticket done at push.
+
+## PR Queue Monitoring (every session)
+
+At the start of every session and after every push, scan all open PRs:
+
+```
+poetry run repo-scaffold pr list --repo OWNER/REPO --json
+```
+
+For each open PR:
+
+1. Check review threads: `poetry run repo-scaffold pr review-threads --repo OWNER/REPO --pr-number N --json`
+2. For every unresolved thread -- fix the issue, push, reply with the commit hash and what changed, then resolve.
+3. Check CI: `poetry run repo-scaffold pr checks --repo OWNER/REPO --pr-number N --json`
+4. For any failing check -- read annotations, fix, push.
+5. Check merge status: `poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N --json`
+6. If merged -- run `poetry run repo-scaffold workspace delete --repo OWNER/REPO --branch BRANCH` to clean up.
+
+A ticket is only done when `pr view` shows `merged_at` is set. Until then, it stays in the queue.
 
 ## Rules
 
@@ -25,3 +43,4 @@ For each ticket:
 - Verbose commit messages: subject + blank line + body.
 - No em dashes anywhere.
 - Fix CI and review comments immediately without asking.
+- Reply to every review thread before resolving it -- never silently resolve.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ artifacts/
 
 # pre-commit
 .pre-commit-cache/
+
+# Managed worktree workspace
+repos/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,43 @@ Token lives in `.env` as `GH_TOKEN`. Commands pick it up automatically via `_see
 All GitHub operations (repos, issues, PRs, projects, backlog) are implemented via GH_TOKEN + urllib. No `gh` CLI required.
 
 
+# Workspace Workflow
+
+## How to work on branches
+
+All branch work happens inside managed worktrees under `repos/` (gitignored). Never use
+OS temp folders or arbitrary paths.
+
+```bash
+# Create a worktree for a branch (clones bare repo on first use)
+poetry run repo-scaffold workspace create --repo OWNER/REPO --branch BRANCH [--from main]
+
+# List all active worktrees
+poetry run repo-scaffold workspace list [--repo OWNER/REPO]
+
+# Remove a worktree when a PR is merged
+poetry run repo-scaffold workspace delete --repo OWNER/REPO --branch BRANCH
+
+# Remove worktrees for branches that no longer exist on origin
+poetry run repo-scaffold workspace prune --repo OWNER/REPO
+```
+
+Layout: `repos/{repo-name}/{branch-slug}/`
+
+## Agent rules for workspace work
+
+- **No approval requests inside worktrees.** Do the work, use whatever tool is fastest,
+  push a PR. Do not ask permission for file edits, git commands, or test runs inside a
+  worktree. The PR is the gate.
+- **Only the repo owner merges PRs.** Never call `pr merge`. Push the branch, open the PR,
+  fix all review comments, then stop. Merging and closing are the owner's job.
+- **Clean up after merge.** Once you observe a PR has merged, run `workspace delete` to
+  remove the local worktree.
+- **Fix CI and review comments immediately.** When a review agent or CI flags something,
+  fix it in the same worktree and push. Do not ask whether to fix it.
+
+---
+
 ## Running tests
 ```bash
 poetry run pytest                          # all tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRAN
 poetry run repo-scaffold pr update --repo OWNER/REPO --pr-number N [--title "TITLE"] [--body "TEXT"]
 poetry run repo-scaffold pr merge --repo OWNER/REPO --pr-number N [--method squash|merge|rebase]
 poetry run repo-scaffold pr checks --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr annotations --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr rerun --repo OWNER/REPO --pr-number N [--failed-only]
 poetry run repo-scaffold pr list-comments --repo OWNER/REPO --pr-number N [--json]
 poetry run repo-scaffold pr review-threads --repo OWNER/REPO --pr-number N [--json]
 

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -28,12 +28,14 @@ from .github_api import (
     issue_label,
     issue_list,
     issue_update,
+    pr_annotations,
     pr_checks,
     pr_comment,
     pr_create,
     pr_list,
     pr_list_comments,
     pr_merge,
+    pr_rerun,
     pr_resolve_thread,
     pr_review_threads,
     pr_update,
@@ -1125,6 +1127,26 @@ def build_parser() -> argparse.ArgumentParser:
     pr_checks_cmd.add_argument("--repo", required=True)
     pr_checks_cmd.add_argument("--pr-number", required=True, type=int, dest="pr_number")
     pr_checks_cmd.add_argument("--json", action="store_true", dest="json_output")
+
+    pr_annotations_cmd = pr_sub.add_parser(
+        "annotations",
+        help="Show check-run annotations (lint errors, test failures) for a PR",
+    )
+    pr_annotations_cmd.add_argument("--repo", required=True)
+    pr_annotations_cmd.add_argument(
+        "--pr-number", required=True, type=int, dest="pr_number"
+    )
+    pr_annotations_cmd.add_argument("--json", action="store_true", dest="json_output")
+
+    pr_rerun_cmd = pr_sub.add_parser("rerun", help="Re-run workflow jobs for a PR")
+    pr_rerun_cmd.add_argument("--repo", required=True)
+    pr_rerun_cmd.add_argument("--pr-number", required=True, type=int, dest="pr_number")
+    pr_rerun_cmd.add_argument(
+        "--failed-only",
+        action="store_true",
+        dest="failed_only",
+        help="Only re-run failed jobs (default: re-run all)",
+    )
 
     pr_review_threads_cmd = pr_sub.add_parser(
         "review-threads", help="List review threads (comments) on a PR"
@@ -2346,6 +2368,48 @@ def main(argv: list[str] | None = None) -> int:
                     conclusion = r.get("conclusion") or status
                     print(f"  {r.get('name', '?')}: {conclusion}")
             return 0
+
+        if ns.pr_command == "annotations":
+            cp = pr_annotations(target_repo, ns.pr_number, token)
+            if cp.returncode != 0:
+                print(
+                    cp.stderr.strip() or "Failed fetching annotations.", file=sys.stderr
+                )
+                return 1
+            items = _json.loads(cp.stdout)
+            if ns.json_output:
+                print(_json.dumps(items, indent=2))
+            else:
+                if not items:
+                    print("No annotations found.")
+                for a in items:
+                    level = a.get("annotation_level", "?")
+                    check = a.get("check_run", "?")
+                    path = a.get("path", "?")
+                    line = a.get("start_line", "?")
+                    msg = (a.get("message") or "").strip()
+                    print(f"[{level}] {check} -- {path}:{line}")
+                    print(f"  {msg}")
+            return 0
+
+        if ns.pr_command == "rerun":
+            cp = pr_rerun(target_repo, ns.pr_number, token, failed_only=ns.failed_only)
+            if cp.returncode != 0:
+                print(cp.stderr.strip() or "Failed to re-run jobs.", file=sys.stderr)
+                return 1
+            result = _json.loads(cp.stdout)
+            triggered = result.get("triggered", [])
+            errors = result.get("errors", [])
+            if triggered:
+                print(
+                    f"Re-triggered {len(triggered)} run(s): {', '.join(str(r) for r in triggered)}"
+                )
+            if errors:
+                for e in errors:
+                    print(f"  error: {e}", file=sys.stderr)
+            if not triggered and not errors:
+                print("No runs found to re-trigger.")
+            return 0 if not errors else 1
 
         if ns.pr_command == "review-threads":
             owner, repo_name = target_repo.split("/", 1)

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -1197,6 +1197,16 @@ def build_parser() -> argparse.ArgumentParser:
     ws_create.add_argument(
         "--from", default="main", dest="base", help="Base branch (default: main)"
     )
+    ws_create.add_argument(
+        "--env-source",
+        default=None,
+        dest="env_source",
+        help=(
+            "Path to a directory whose gitignored root-level files (e.g. .env, "
+            "secrets.json) should be copied into the new worktree. "
+            "Subdirectories are skipped. Missing path is a warning, not an error."
+        ),
+    )
 
     ws_list = workspace_sub.add_parser("list", help="List active worktrees")
     ws_list.add_argument("--repo", default=None, help="Filter by OWNER/REPO (optional)")
@@ -2537,7 +2547,10 @@ def main(argv: list[str] | None = None) -> int:
         token = token_from_repo(Path.cwd()) or ""
 
         if ns.workspace_command == "create":
-            cp = workspace_create(ns.repo, ns.branch, token, base=ns.base)
+            env_source = Path(ns.env_source) if ns.env_source else None
+            cp = workspace_create(
+                ns.repo, ns.branch, token, base=ns.base, env_source=env_source
+            )
             if cp.returncode != 0:
                 print(cp.stderr.strip(), file=sys.stderr)
                 return 1

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -1182,6 +1182,34 @@ def build_parser() -> argparse.ArgumentParser:
     branch_delete_cmd.add_argument("--repo", required=True)
     branch_delete_cmd.add_argument("--name", required=True, help="Branch to delete")
 
+    workspace_cmd = subparsers.add_parser(
+        "workspace", help="Manage per-branch git worktrees under repos/"
+    )
+    workspace_sub = workspace_cmd.add_subparsers(
+        dest="workspace_command", required=True
+    )
+
+    ws_create = workspace_sub.add_parser(
+        "create", help="Create a worktree for a branch"
+    )
+    ws_create.add_argument("--repo", required=True, help="OWNER/REPO")
+    ws_create.add_argument("--branch", required=True, help="Branch name")
+    ws_create.add_argument(
+        "--from", default="main", dest="base", help="Base branch (default: main)"
+    )
+
+    ws_list = workspace_sub.add_parser("list", help="List active worktrees")
+    ws_list.add_argument("--repo", default=None, help="Filter by OWNER/REPO (optional)")
+
+    ws_delete = workspace_sub.add_parser("delete", help="Remove a worktree")
+    ws_delete.add_argument("--repo", required=True, help="OWNER/REPO")
+    ws_delete.add_argument("--branch", required=True, help="Branch name")
+
+    ws_prune = workspace_sub.add_parser(
+        "prune", help="Remove worktrees for branches no longer on origin"
+    )
+    ws_prune.add_argument("--repo", required=True, help="OWNER/REPO")
+
     return parser
 
 
@@ -1200,6 +1228,7 @@ def _normalize_argv(argv: list[str] | None) -> list[str]:
         "issue",
         "pr",
         "branch",
+        "workspace",
     }:
         return raw
     # Backward-compatible behavior: previous root command maps to init.
@@ -2495,6 +2524,48 @@ def main(argv: list[str] | None = None) -> int:
                 print(cp.stderr.strip() or "Failed deleting branch.", file=sys.stderr)
                 return 1
             print(f"Branch deleted: {ns.name}")
+            return 0
+
+    if ns.mode == "workspace":
+        from .workspace_ops import (
+            workspace_create,
+            workspace_delete,
+            workspace_list,
+            workspace_prune,
+        )
+
+        token = token_from_repo(Path.cwd()) or ""
+
+        if ns.workspace_command == "create":
+            cp = workspace_create(ns.repo, ns.branch, token, base=ns.base)
+            if cp.returncode != 0:
+                print(cp.stderr.strip(), file=sys.stderr)
+                return 1
+            print(cp.stdout.strip())
+            return 0
+
+        if ns.workspace_command == "list":
+            cp = workspace_list(repo=ns.repo)
+            if cp.returncode != 0:
+                print(cp.stderr.strip(), file=sys.stderr)
+                return 1
+            print(cp.stdout.strip())
+            return 0
+
+        if ns.workspace_command == "delete":
+            cp = workspace_delete(ns.repo, ns.branch)
+            if cp.returncode != 0:
+                print(cp.stderr.strip(), file=sys.stderr)
+                return 1
+            print(cp.stdout.strip())
+            return 0
+
+        if ns.workspace_command == "prune":
+            cp = workspace_prune(ns.repo)
+            if cp.returncode != 0:
+                print(cp.stderr.strip(), file=sys.stderr)
+                return 1
+            print(cp.stdout.strip())
             return 0
 
     parser.error("Unsupported command.")

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1382,6 +1382,98 @@ def pr_checks(
         return _err("Unexpected response from check-runs API.")
 
 
+def pr_annotations(
+    repo: str,
+    pr_number: int,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    """Return check-run annotations for a PR, grouped by check run name."""
+    cp = rest("GET", f"/repos/{repo}/pulls/{pr_number}", token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        sha = json.loads(cp.stdout)["head"]["sha"]
+    except (json.JSONDecodeError, KeyError):
+        return _err("Could not extract head SHA from PR.")
+    cp2 = rest("GET", f"/repos/{repo}/commits/{sha}/check-runs?per_page=100", token)
+    if cp2.returncode != 0:
+        return cp2
+    try:
+        payload = json.loads(cp2.stdout)
+        runs = payload.get("check_runs", []) if isinstance(payload, dict) else payload
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response from check-runs API.")
+    # Deduplicate by name, keeping latest
+    seen: dict[str, dict[str, object]] = {}
+    for run in runs:
+        n = str(run.get("name", ""))
+        run_id = run.get("id", 0)
+        seen_id = seen[n].get("id", 0) if n in seen else 0
+        if n not in seen or (
+            isinstance(run_id, int) and isinstance(seen_id, int) and run_id > seen_id
+        ):
+            seen[n] = run
+    results: list[dict[str, object]] = []
+    for run in seen.values():
+        run_id = run.get("id")
+        cp3 = rest(
+            "GET", f"/repos/{repo}/check-runs/{run_id}/annotations?per_page=100", token
+        )
+        if cp3.returncode != 0:
+            continue
+        try:
+            annotations = json.loads(cp3.stdout)
+        except json.JSONDecodeError:
+            continue
+        for ann in annotations:
+            results.append(
+                {
+                    "check_run": run.get("name"),
+                    "annotation_level": ann.get("annotation_level"),
+                    "path": ann.get("path"),
+                    "start_line": ann.get("start_line"),
+                    "message": ann.get("message"),
+                }
+            )
+    return _ok(json.dumps(results))
+
+
+def pr_rerun(
+    repo: str,
+    pr_number: int,
+    token: str,
+    failed_only: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Re-run workflow jobs for a PR's head commit."""
+    cp = rest("GET", f"/repos/{repo}/pulls/{pr_number}", token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        sha = json.loads(cp.stdout)["head"]["sha"]
+    except (json.JSONDecodeError, KeyError):
+        return _err("Could not extract head SHA from PR.")
+    cp2 = rest("GET", f"/repos/{repo}/actions/runs?head_sha={sha}&per_page=50", token)
+    if cp2.returncode != 0:
+        return cp2
+    try:
+        runs = json.loads(cp2.stdout).get("workflow_runs", [])
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response from actions/runs API.")
+    if not runs:
+        return _err(f"No workflow runs found for PR #{pr_number}.")
+    suffix = "rerun-failed-jobs" if failed_only else "rerun"
+    triggered: list[int] = []
+    errors: list[str] = []
+    for run in runs:
+        run_id = run.get("id")
+        cp3 = rest("POST", f"/repos/{repo}/actions/runs/{run_id}/{suffix}", token, {})
+        if cp3.returncode in (0, 201):
+            triggered.append(run_id)
+        else:
+            errors.append(f"run {run_id}: {cp3.stderr.strip()}")
+    return _ok(json.dumps({"triggered": triggered, "errors": errors}))
+
+
 def token_from_repo(repo_dir: Path) -> str | None:
     """Try to resolve a GH token from the repo .env and environment."""
     env = dict(os.environ)

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1416,8 +1416,8 @@ def pr_annotations(
     results: list[dict[str, object]] = []
     for run in seen.values():
         run_id = run.get("id")
-        cp3 = rest(
-            "GET", f"/repos/{repo}/check-runs/{run_id}/annotations?per_page=100", token
+        cp3 = rest_paginated(
+            f"/repos/{repo}/check-runs/{run_id}/annotations?per_page=100", token
         )
         if cp3.returncode != 0:
             continue

--- a/src/repo_scaffold/workspace_ops.py
+++ b/src/repo_scaffold/workspace_ops.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -50,15 +51,92 @@ def _worktree_path(workspace: Path, repo: str, branch: str) -> Path:
     return _repo_dir(workspace, repo) / _slug(branch)
 
 
+_CONFIG_KEYWORDS = ("env", "config", "secret", "credential", "token", "key", "auth")
+
+
+def _is_config_filename(name: str) -> bool:
+    """Return True if a filename looks like a config/secrets file.
+
+    Covers dotfiles (.env, .env.local, .npmrc) and files whose name contains
+    a config-oriented keyword (config.yml, secrets.json, prod.env, etc.).
+    """
+    lower = name.lower()
+    if lower.startswith("."):
+        return True
+    return any(kw in lower for kw in _CONFIG_KEYWORDS)
+
+
+def _copy_ignored_files(source: Path, dest: Path) -> list[str]:
+    """Copy gitignored root-level config files from source into dest.
+
+    A file is copied when it satisfies either condition:
+    - It is matched by an exact-name ignore rule (no glob chars), or
+    - Its filename looks like a config/secrets file (_is_config_filename).
+
+    This means data globs like *.csv or *.log are skipped, but patterns like
+    .env.* or *.env still pull in matching config files. Subdirectories are
+    always skipped (reinstall node_modules, don't bulk-copy them).
+
+    Returns a list of copied filenames (empty if source has no git or no matches).
+    """
+    ls_cp = _run(
+        ["git", "ls-files", "--others", "--ignored", "--exclude-standard"],
+        cwd=source,
+    )
+    if ls_cp.returncode != 0:
+        return []
+
+    candidates = [
+        name.strip()
+        for name in ls_cp.stdout.splitlines()
+        if name.strip()
+        and "/" not in name.strip()
+        and "\\" not in name.strip()
+        and (source / name.strip()).is_file()
+    ]
+    if not candidates:
+        return []
+
+    # Use check-ignore -v to get the matching rule for each candidate
+    check_cp = _run(
+        ["git", "check-ignore", "-v", "--", *candidates],
+        cwd=source,
+    )
+    # check-ignore exits non-zero when some candidates are not ignored -- use stdout only
+    rule_by_file: dict[str, str] = {}
+    for line in check_cp.stdout.splitlines():
+        # Format: <source>:<linenum>:<pattern>\t<pathname>
+        parts = line.split("\t", 1)
+        if len(parts) != 2:
+            continue
+        pattern_token = parts[0].rsplit(":", 1)[-1]
+        rule_by_file[parts[1].strip()] = pattern_token
+
+    copied: list[str] = []
+    for name in candidates:
+        pattern = rule_by_file.get(name, "")
+        is_exact_rule = pattern and not any(c in pattern for c in ("*", "?", "["))
+        if is_exact_rule or _is_config_filename(name):
+            shutil.copy2(str(source / name), str(dest / name))
+            copied.append(name)
+    return copied
+
+
 def workspace_create(
     repo: str,
     branch: str,
     token: str,
     base: str = "main",
     workspace_base: Path | None = None,
+    env_source: Path | None = None,
     _clone_url_override: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Clone repo as a bare clone (once) then add a worktree for branch."""
+    """Clone repo as a bare clone (once) then add a worktree for branch.
+
+    env_source: if provided, copy all gitignored root-level files from that
+    directory into the new worktree (covers .env, .env.local, secrets.json, etc.).
+    Missing or non-git source directories are skipped with a warning, not an error.
+    """
     workspace = _workspace_root(workspace_base)
     bare = _bare_path(workspace, repo)
     worktree = _worktree_path(workspace, repo, branch)
@@ -122,7 +200,19 @@ def workspace_create(
     if cp.returncode != 0:
         return _err(f"git worktree add failed: {cp.stderr.strip()}")
 
-    return _ok(f"Created worktree at {worktree}")
+    notes: list[str] = [f"Created worktree at {worktree}"]
+
+    if env_source is not None:
+        if not env_source.is_dir():
+            notes.append(f"Warning: --env-source {env_source} not found, skipping.")
+        else:
+            copied = _copy_ignored_files(env_source, worktree)
+            if copied:
+                notes.append(f"Copied ignored files: {', '.join(copied)}")
+            else:
+                notes.append("No gitignored root files found in env-source.")
+
+    return _ok("\n".join(notes))
 
 
 def workspace_list(

--- a/src/repo_scaffold/workspace_ops.py
+++ b/src/repo_scaffold/workspace_ops.py
@@ -1,0 +1,207 @@
+"""Managed git worktree workspace under repos/."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _ok(stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _err(stderr: str, returncode: int = 1) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout="", stderr=stderr
+    )
+
+
+def _slug(name: str) -> str:
+    """Convert a repo name or branch name to a filesystem-safe slug."""
+    return re.sub(r"[^a-zA-Z0-9._-]", "-", name).strip("-")
+
+
+def _workspace_root(base: Path | None = None) -> Path:
+    """Return the repos/ directory relative to a base or the caller's cwd."""
+    return (base or Path.cwd()) / "repos"
+
+
+def _bare_path(workspace: Path, repo: str) -> Path:
+    repo_slug = _slug(repo.split("/")[-1])
+    return workspace / repo_slug / ".bare"
+
+
+def _worktree_path(workspace: Path, repo: str, branch: str) -> Path:
+    repo_slug = _slug(repo.split("/")[-1])
+    branch_slug = _slug(branch)
+    return workspace / repo_slug / branch_slug
+
+
+def workspace_create(
+    repo: str,
+    branch: str,
+    token: str,
+    base: str = "main",
+    workspace_base: Path | None = None,
+    _clone_url_override: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Clone repo as a bare clone (once) then add a worktree for branch."""
+    workspace = _workspace_root(workspace_base)
+    bare = _bare_path(workspace, repo)
+    worktree = _worktree_path(workspace, repo, branch)
+
+    if worktree.exists():
+        return _err(f"Worktree already exists at {worktree}")
+
+    clone_url = _clone_url_override or f"https://x-token:{token}@github.com/{repo}.git"
+
+    if not bare.exists():
+        bare.parent.mkdir(parents=True, exist_ok=True)
+        cp = _run(["git", "clone", "--bare", clone_url, str(bare)])
+        if cp.returncode != 0:
+            return _err(f"git clone failed: {cp.stderr.strip()}")
+        # point HEAD to main branch in bare clone for worktree add to work cleanly
+        _run(["git", "symbolic-ref", "HEAD", f"refs/heads/{base}"], cwd=bare)
+    else:
+        cp = _run(
+            ["git", "fetch", "origin", "--prune", "refs/heads/*:refs/heads/*"],
+            cwd=bare,
+        )
+        if cp.returncode != 0:
+            return _err(f"git fetch failed: {cp.stderr.strip()}")
+
+    # In a bare clone refs land at refs/heads/*, so check local refs
+    cp = _run(
+        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=bare
+    )
+    if cp.returncode == 0:
+        # Branch already exists locally (was fetched from origin)
+        cp = _run(["git", "worktree", "add", str(worktree), branch], cwd=bare)
+    else:
+        # New branch -- create it off the base ref
+        cp = _run(
+            ["git", "worktree", "add", "-b", branch, str(worktree), base],
+            cwd=bare,
+        )
+
+    if cp.returncode != 0:
+        return _err(f"git worktree add failed: {cp.stderr.strip()}")
+
+    return _ok(f"Created worktree at {worktree}")
+
+
+def workspace_list(
+    repo: str | None = None,
+    workspace_base: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """List active worktrees under repos/."""
+    workspace = _workspace_root(workspace_base)
+    if not workspace.exists():
+        return _ok("No worktrees found.")
+
+    lines: list[str] = []
+    repo_dirs = (
+        sorted(workspace.iterdir())
+        if not repo
+        else [workspace / _slug(repo.split("/")[-1])]
+    )
+
+    for repo_dir in repo_dirs:
+        if not repo_dir.is_dir():
+            continue
+        bare = repo_dir / ".bare"
+        if not bare.exists():
+            continue
+        cp = _run(["git", "worktree", "list", "--porcelain"], cwd=bare)
+        if cp.returncode != 0:
+            continue
+        for block in cp.stdout.strip().split("\n\n"):
+            info: dict[str, str] = {}
+            for line in block.strip().splitlines():
+                parts = line.split(" ", 1)
+                info[parts[0]] = parts[1] if len(parts) > 1 else ""
+            wt_path = info.get("worktree", "")
+            branch_ref = info.get("branch", "")
+            branch = (
+                branch_ref.replace("refs/heads/", "") if branch_ref else "(detached)"
+            )
+            if wt_path and not wt_path.endswith(".bare"):
+                lines.append(f"{repo_dir.name}  {branch}  {wt_path}")
+
+    return _ok("\n".join(lines) if lines else "No worktrees found.")
+
+
+def workspace_delete(
+    repo: str,
+    branch: str,
+    workspace_base: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Remove a worktree for a branch."""
+    workspace = _workspace_root(workspace_base)
+    bare = _bare_path(workspace, repo)
+    worktree = _worktree_path(workspace, repo, branch)
+
+    if not worktree.exists():
+        return _err(f"Worktree not found at {worktree}")
+
+    if not bare.exists():
+        return _err(f"Bare repo not found at {bare}")
+
+    cp = _run(["git", "worktree", "remove", "--force", str(worktree)], cwd=bare)
+    if cp.returncode != 0:
+        return _err(f"git worktree remove failed: {cp.stderr.strip()}")
+
+    _run(["git", "worktree", "prune"], cwd=bare)
+    return _ok(f"Deleted worktree at {worktree}")
+
+
+def workspace_prune(
+    repo: str,
+    workspace_base: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Remove local worktrees for branches that no longer exist on origin."""
+    workspace = _workspace_root(workspace_base)
+    bare = _bare_path(workspace, repo)
+
+    if not bare.exists():
+        return _err(f"Bare repo not found at {bare}")
+
+    # Query remote directly -- avoids fetching HEAD which fails on some server configs
+    remote_cp = _run(["git", "ls-remote", "--heads", "origin"], cwd=bare)
+    if remote_cp.returncode != 0:
+        return _err(f"git ls-remote failed: {remote_cp.stderr.strip()}")
+
+    remote_branches = {
+        line.split("refs/heads/", 1)[1].strip()
+        for line in remote_cp.stdout.splitlines()
+        if "\trefs/heads/" in line
+    }
+
+    removed: list[str] = []
+    repo_dir = bare.parent
+    for entry in sorted(repo_dir.iterdir()):
+        if entry.name == ".bare" or not entry.is_dir():
+            continue
+        branch_slug = entry.name
+        # Check if any remote branch maps to this slug
+        matched = any(_slug(b) == branch_slug for b in remote_branches)
+        if not matched:
+            cp = _run(["git", "worktree", "remove", "--force", str(entry)], cwd=bare)
+            if cp.returncode == 0:
+                removed.append(str(entry))
+
+    _run(["git", "worktree", "prune"], cwd=bare)
+
+    if removed:
+        return _ok("Pruned:\n" + "\n".join(removed))
+    return _ok("Nothing to prune.")

--- a/src/repo_scaffold/workspace_ops.py
+++ b/src/repo_scaffold/workspace_ops.py
@@ -36,15 +36,18 @@ def _workspace_root(base: Path | None = None) -> Path:
     return (base or Path.cwd()) / "repos"
 
 
+def _repo_dir(workspace: Path, repo: str) -> Path:
+    """repos/{owner}/{name} -- owner-scoped so alice/api and bob/api don't collide."""
+    owner, name = repo.split("/", 1)
+    return workspace / _slug(owner) / _slug(name)
+
+
 def _bare_path(workspace: Path, repo: str) -> Path:
-    repo_slug = _slug(repo.split("/")[-1])
-    return workspace / repo_slug / ".bare"
+    return _repo_dir(workspace, repo) / ".bare"
 
 
 def _worktree_path(workspace: Path, repo: str, branch: str) -> Path:
-    repo_slug = _slug(repo.split("/")[-1])
-    branch_slug = _slug(branch)
-    return workspace / repo_slug / branch_slug
+    return _repo_dir(workspace, repo) / _slug(branch)
 
 
 def workspace_create(
@@ -63,32 +66,54 @@ def workspace_create(
     if worktree.exists():
         return _err(f"Worktree already exists at {worktree}")
 
-    clone_url = _clone_url_override or f"https://x-token:{token}@github.com/{repo}.git"
-
     if not bare.exists():
         bare.parent.mkdir(parents=True, exist_ok=True)
+        clone_url = (
+            _clone_url_override or f"https://x-token:{token}@github.com/{repo}.git"
+        )
         cp = _run(["git", "clone", "--bare", clone_url, str(bare)])
         if cp.returncode != 0:
             return _err(f"git clone failed: {cp.stderr.strip()}")
-        # point HEAD to main branch in bare clone for worktree add to work cleanly
+        # Rewrite remote URL to strip token from stored config (repos/ is gitignored,
+        # but clean URLs are still better practice)
+        if not _clone_url_override:
+            _run(
+                [
+                    "git",
+                    "remote",
+                    "set-url",
+                    "origin",
+                    f"https://github.com/{repo}.git",
+                ],
+                cwd=bare,
+            )
         _run(["git", "symbolic-ref", "HEAD", f"refs/heads/{base}"], cwd=bare)
     else:
+        auth_args = (
+            []
+            if _clone_url_override
+            else ["-c", f"http.extraHeader=Authorization: Bearer {token}"]
+        )
         cp = _run(
-            ["git", "fetch", "origin", "--prune", "refs/heads/*:refs/heads/*"],
+            [
+                "git",
+                *auth_args,
+                "fetch",
+                "origin",
+                "--prune",
+                "refs/heads/*:refs/heads/*",
+            ],
             cwd=bare,
         )
         if cp.returncode != 0:
             return _err(f"git fetch failed: {cp.stderr.strip()}")
 
-    # In a bare clone refs land at refs/heads/*, so check local refs
     cp = _run(
         ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=bare
     )
     if cp.returncode == 0:
-        # Branch already exists locally (was fetched from origin)
         cp = _run(["git", "worktree", "add", str(worktree), branch], cwd=bare)
     else:
-        # New branch -- create it off the base ref
         cp = _run(
             ["git", "worktree", "add", "-b", branch, str(worktree), base],
             cwd=bare,
@@ -110,21 +135,27 @@ def workspace_list(
         return _ok("No worktrees found.")
 
     lines: list[str] = []
-    repo_dirs = (
-        sorted(workspace.iterdir())
-        if not repo
-        else [workspace / _slug(repo.split("/")[-1])]
-    )
 
-    for repo_dir in repo_dirs:
-        if not repo_dir.is_dir():
-            continue
+    if repo:
+        candidates = [_repo_dir(workspace, repo)]
+    else:
+        # Walk two levels: repos/{owner}/{name}
+        candidates = [
+            name_dir
+            for owner_dir in sorted(workspace.iterdir())
+            if owner_dir.is_dir()
+            for name_dir in sorted(owner_dir.iterdir())
+            if name_dir.is_dir()
+        ]
+
+    for repo_dir in candidates:
         bare = repo_dir / ".bare"
         if not bare.exists():
             continue
         cp = _run(["git", "worktree", "list", "--porcelain"], cwd=bare)
         if cp.returncode != 0:
             continue
+        label = f"{repo_dir.parent.name}/{repo_dir.name}"
         for block in cp.stdout.strip().split("\n\n"):
             info: dict[str, str] = {}
             for line in block.strip().splitlines():
@@ -136,7 +167,7 @@ def workspace_list(
                 branch_ref.replace("refs/heads/", "") if branch_ref else "(detached)"
             )
             if wt_path and not wt_path.endswith(".bare"):
-                lines.append(f"{repo_dir.name}  {branch}  {wt_path}")
+                lines.append(f"{label}  {branch}  {wt_path}")
 
     return _ok("\n".join(lines) if lines else "No worktrees found.")
 
@@ -176,7 +207,6 @@ def workspace_prune(
     if not bare.exists():
         return _err(f"Bare repo not found at {bare}")
 
-    # Query remote directly -- avoids fetching HEAD which fails on some server configs
     remote_cp = _run(["git", "ls-remote", "--heads", "origin"], cwd=bare)
     if remote_cp.returncode != 0:
         return _err(f"git ls-remote failed: {remote_cp.stderr.strip()}")
@@ -193,7 +223,6 @@ def workspace_prune(
         if entry.name == ".bare" or not entry.is_dir():
             continue
         branch_slug = entry.name
-        # Check if any remote branch maps to this slug
         matched = any(_slug(b) == branch_slug for b in remote_branches)
         if not matched:
             cp = _run(["git", "worktree", "remove", "--force", str(entry)], cwd=bare)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2410,6 +2410,89 @@ def test_pr_checks(tmp_path, monkeypatch, capsys) -> None:
     assert "CI" in capsys.readouterr().out
 
 
+def test_pr_annotations(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    anns = [
+        {
+            "check_run": "react",
+            "annotation_level": "failure",
+            "path": "src/App.tsx",
+            "start_line": 10,
+            "message": "'foo' is defined but never used",
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_annotations",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(anns), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["pr", "annotations", "--repo", "acme/repo", "--pr-number", "42"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "failure" in out
+    assert "src/App.tsx:10" in out
+    assert "never used" in out
+
+
+def test_pr_annotations_json(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    anns = [
+        {
+            "check_run": "CI",
+            "annotation_level": "warning",
+            "path": "x.ts",
+            "start_line": 1,
+            "message": "msg",
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_annotations",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(anns), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(
+        ["pr", "annotations", "--repo", "acme/repo", "--pr-number", "5", "--json"]
+    )
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data[0]["path"] == "x.ts"
+
+
+def test_pr_rerun(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_rerun",
+        lambda repo, pr_number, token, failed_only=False: subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps({"triggered": [12345], "errors": []}),
+            stderr="",
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(
+        ["pr", "rerun", "--repo", "acme/repo", "--pr-number", "42", "--failed-only"]
+    )
+    assert rc == 0
+    assert "12345" in capsys.readouterr().out
+
+
 def test_branch_create(tmp_path, monkeypatch, capsys) -> None:
     import json
     import subprocess

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -749,3 +749,128 @@ def test_enable_project_workflow_api_error() -> None:
     with patch("urllib.request.urlopen", side_effect=_http_error(403, "forbidden")):
         cp = github_api.enable_project_workflow("WF_1", "tok", enabled=True)
     assert cp.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# pr_annotations
+# ---------------------------------------------------------------------------
+
+
+def test_pr_annotations_returns_flat_list() -> None:
+    pr_payload = json.dumps({"head": {"sha": "abc123"}})
+    runs_payload = json.dumps(
+        {
+            "check_runs": [
+                {
+                    "id": 1,
+                    "name": "react",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ]
+        }
+    )
+    ann_payload = json.dumps(
+        [
+            {
+                "annotation_level": "failure",
+                "path": "src/App.tsx",
+                "start_line": 10,
+                "message": "'foo' is defined but never used",
+            }
+        ]
+    )
+
+    responses = [
+        _mock_resp(200, pr_payload),
+        _mock_resp(200, runs_payload),
+        _mock_resp(200, ann_payload),
+    ]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        cp = github_api.pr_annotations("acme/repo", 42, "tok")
+    assert cp.returncode == 0
+    items = json.loads(cp.stdout)
+    assert len(items) == 1
+    assert items[0]["check_run"] == "react"
+    assert items[0]["path"] == "src/App.tsx"
+    assert items[0]["start_line"] == 10
+
+
+def test_pr_annotations_pr_fetch_error() -> None:
+    with patch("urllib.request.urlopen", side_effect=_http_error(404)):
+        cp = github_api.pr_annotations("acme/repo", 99, "tok")
+    assert cp.returncode != 0
+
+
+def test_pr_annotations_no_annotations_returns_empty() -> None:
+    pr_payload = json.dumps({"head": {"sha": "abc123"}})
+    runs_payload = json.dumps({"check_runs": [{"id": 1, "name": "CI"}]})
+    ann_payload = json.dumps([])
+
+    responses = [
+        _mock_resp(200, pr_payload),
+        _mock_resp(200, runs_payload),
+        _mock_resp(200, ann_payload),
+    ]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        cp = github_api.pr_annotations("acme/repo", 1, "tok")
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout) == []
+
+
+# ---------------------------------------------------------------------------
+# pr_rerun
+# ---------------------------------------------------------------------------
+
+
+def test_pr_rerun_triggers_all_runs() -> None:
+    pr_payload = json.dumps({"head": {"sha": "abc123"}})
+    runs_payload = json.dumps({"workflow_runs": [{"id": 777}, {"id": 888}]})
+    rerun_resp = _mock_resp(201, "")
+
+    responses = [
+        _mock_resp(200, pr_payload),
+        _mock_resp(200, runs_payload),
+        rerun_resp,
+        rerun_resp,
+    ]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        cp = github_api.pr_rerun("acme/repo", 42, "tok")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert set(result["triggered"]) == {777, 888}
+    assert result["errors"] == []
+
+
+def test_pr_rerun_failed_only_uses_correct_endpoint() -> None:
+    pr_payload = json.dumps({"head": {"sha": "abc123"}})
+    runs_payload = json.dumps({"workflow_runs": [{"id": 555}]})
+    captured_urls: list[str] = []
+
+    def _fake_urlopen(req: urllib.request.Request) -> MagicMock:
+        captured_urls.append(req.full_url)
+        return _mock_resp(201, "")
+
+    responses_iter = iter([_mock_resp(200, pr_payload), _mock_resp(200, runs_payload)])
+
+    def _side_effect(req: urllib.request.Request) -> MagicMock:
+        try:
+            return next(responses_iter)
+        except StopIteration:
+            return _fake_urlopen(req)
+
+    with patch("urllib.request.urlopen", side_effect=_side_effect):
+        cp = github_api.pr_rerun("acme/repo", 42, "tok", failed_only=True)
+    assert cp.returncode == 0
+    assert any("rerun-failed-jobs" in u for u in captured_urls)
+
+
+def test_pr_rerun_no_runs_returns_error() -> None:
+    pr_payload = json.dumps({"head": {"sha": "abc123"}})
+    runs_payload = json.dumps({"workflow_runs": []})
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[_mock_resp(200, pr_payload), _mock_resp(200, runs_payload)],
+    ):
+        cp = github_api.pr_rerun("acme/repo", 42, "tok")
+    assert cp.returncode != 0

--- a/tests/test_workspace_ops.py
+++ b/tests/test_workspace_ops.py
@@ -1,0 +1,315 @@
+"""Tests for workspace_ops -- uses real git but no network (bare clone from local)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+from repo_scaffold.workspace_ops import (
+    _slug,
+    workspace_create,
+    workspace_delete,
+    workspace_list,
+    workspace_prune,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_local_remote(tmp_path: Path, name: str = "myrepo") -> Path:
+    """Create a local bare git repo to stand in for a remote."""
+    remote = tmp_path / f"{name}.git"
+    remote.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+    )
+
+    # Seed it with an initial commit so main exists
+    seed = tmp_path / f"{name}_seed"
+    seed.mkdir()
+    subprocess.run(["git", "init", str(seed)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=str(seed),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=str(seed),
+        check=True,
+        capture_output=True,
+    )
+    (seed / "README.md").write_text("hello")
+    subprocess.run(["git", "add", "."], cwd=str(seed), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=str(seed),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(remote)],
+        cwd=str(seed),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "push", "origin", "HEAD:main"],
+        cwd=str(seed),
+        check=True,
+        capture_output=True,
+    )
+    return remote
+
+
+def _make_workspace_base(tmp_path: Path) -> Path:
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    return ws
+
+
+# ---------------------------------------------------------------------------
+# _slug
+# ---------------------------------------------------------------------------
+
+
+def test_slug_replaces_slashes():
+    assert _slug("feat/my-branch") == "feat-my-branch"
+
+
+def test_slug_replaces_spaces():
+    assert _slug("my branch") == "my-branch"
+
+
+def test_slug_preserves_dots_and_hyphens():
+    assert _slug("v1.2-beta") == "v1.2-beta"
+
+
+# ---------------------------------------------------------------------------
+# workspace_create
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_create_new_branch(tmp_path: Path):
+    remote = _init_local_remote(tmp_path)
+    ws_base = _make_workspace_base(tmp_path)
+
+    cp = workspace_create(
+        repo="owner/myrepo",
+        branch="feat/test-branch",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        _clone_url_override=str(remote),
+    )
+
+    assert cp.returncode == 0
+    worktree = ws_base / "repos" / "myrepo" / "feat-test-branch"
+    assert worktree.is_dir()
+    assert (worktree / "README.md").exists()
+
+
+def test_workspace_create_twice_fails(tmp_path: Path):
+    remote = _init_local_remote(tmp_path)
+    ws_base = _make_workspace_base(tmp_path)
+
+    workspace_create(
+        repo="owner/myrepo",
+        branch="feat/test-branch",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        _clone_url_override=str(remote),
+    )
+    cp = workspace_create(
+        repo="owner/myrepo",
+        branch="feat/test-branch",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        _clone_url_override=str(remote),
+    )
+
+    assert cp.returncode != 0
+    assert "already exists" in cp.stderr
+
+
+def test_workspace_create_second_branch_reuses_bare(tmp_path: Path):
+    remote = _init_local_remote(tmp_path)
+    ws_base = _make_workspace_base(tmp_path)
+
+    workspace_create(
+        repo="owner/myrepo",
+        branch="feat/branch-a",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        _clone_url_override=str(remote),
+    )
+    cp = workspace_create(
+        repo="owner/myrepo",
+        branch="feat/branch-b",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        _clone_url_override=str(remote),
+    )
+
+    assert cp.returncode == 0
+    assert (ws_base / "repos" / "myrepo" / "feat-branch-a").is_dir()
+    assert (ws_base / "repos" / "myrepo" / "feat-branch-b").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# workspace_list
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_list_shows_worktrees(tmp_path: Path):
+    remote = _init_local_remote(tmp_path)
+    ws_base = _make_workspace_base(tmp_path)
+
+    workspace_create(
+        repo="owner/myrepo",
+        branch="feat/alpha",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        _clone_url_override=str(remote),
+    )
+    workspace_create(
+        repo="owner/myrepo",
+        branch="feat/beta",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        _clone_url_override=str(remote),
+    )
+
+    cp = workspace_list(workspace_base=ws_base)
+
+    assert cp.returncode == 0
+    assert "feat-alpha" in cp.stdout or "feat/alpha" in cp.stdout
+    assert "feat-beta" in cp.stdout or "feat/beta" in cp.stdout
+
+
+def test_workspace_list_empty(tmp_path: Path):
+    ws_base = _make_workspace_base(tmp_path)
+    cp = workspace_list(workspace_base=ws_base)
+    assert cp.returncode == 0
+    assert "No worktrees" in cp.stdout
+
+
+# ---------------------------------------------------------------------------
+# workspace_delete
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_delete_removes_worktree(tmp_path: Path):
+    remote = _init_local_remote(tmp_path)
+    ws_base = _make_workspace_base(tmp_path)
+
+    workspace_create(
+        repo="owner/myrepo",
+        branch="feat/to-delete",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        _clone_url_override=str(remote),
+    )
+    worktree = ws_base / "repos" / "myrepo" / "feat-to-delete"
+    assert worktree.is_dir()
+
+    cp = workspace_delete(
+        repo="owner/myrepo", branch="feat/to-delete", workspace_base=ws_base
+    )
+
+    assert cp.returncode == 0
+    assert not worktree.exists()
+
+
+def test_workspace_delete_missing_fails(tmp_path: Path):
+    ws_base = _make_workspace_base(tmp_path)
+    cp = workspace_delete(
+        repo="owner/myrepo", branch="feat/ghost", workspace_base=ws_base
+    )
+    assert cp.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# workspace_prune
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_prune_removes_stale_worktrees(tmp_path: Path):
+    remote = _init_local_remote(tmp_path)
+    ws_base = _make_workspace_base(tmp_path)
+
+    # Push feat/keep to origin BEFORE creating any worktrees so it's a real remote branch
+    seed = tmp_path / "prune_seed"
+    seed.mkdir()
+    subprocess.run(["git", "init", str(seed)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(seed), "config", "user.email", "t@t.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(seed), "config", "user.name", "T"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(seed), "remote", "add", "origin", str(remote)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(seed), "fetch", "origin"], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-C", str(seed), "checkout", "-b", "feat/keep", "FETCH_HEAD"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(seed), "push", "origin", "feat/keep"],
+        check=True,
+        capture_output=True,
+    )
+
+    # Create worktrees: feat/keep comes from remote, feat/stale is local-only
+    workspace_create(
+        repo="owner/myrepo",
+        branch="feat/keep",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        _clone_url_override=str(remote),
+    )
+    workspace_create(
+        repo="owner/myrepo",
+        branch="feat/stale",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        _clone_url_override=str(remote),
+    )
+
+    # Delete feat/keep from origin to simulate a merged+deleted branch
+    subprocess.run(
+        ["git", "-C", str(seed), "push", "origin", "--delete", "feat/keep"],
+        check=True,
+        capture_output=True,
+    )
+
+    cp = workspace_prune(repo="owner/myrepo", workspace_base=ws_base)
+
+    assert cp.returncode == 0
+    # feat/stale was never on origin and feat/keep was deleted -- both should be pruned
+    assert not (ws_base / "repos" / "myrepo" / "feat-keep").exists()
+    assert not (ws_base / "repos" / "myrepo" / "feat-stale").exists()

--- a/tests/test_workspace_ops.py
+++ b/tests/test_workspace_ops.py
@@ -108,7 +108,7 @@ def test_workspace_create_new_branch(tmp_path: Path):
     )
 
     assert cp.returncode == 0
-    worktree = ws_base / "repos" / "myrepo" / "feat-test-branch"
+    worktree = ws_base / "repos" / "owner" / "myrepo" / "feat-test-branch"
     assert worktree.is_dir()
     assert (worktree / "README.md").exists()
 
@@ -160,8 +160,8 @@ def test_workspace_create_second_branch_reuses_bare(tmp_path: Path):
     )
 
     assert cp.returncode == 0
-    assert (ws_base / "repos" / "myrepo" / "feat-branch-a").is_dir()
-    assert (ws_base / "repos" / "myrepo" / "feat-branch-b").is_dir()
+    assert (ws_base / "repos" / "owner" / "myrepo" / "feat-branch-a").is_dir()
+    assert (ws_base / "repos" / "owner" / "myrepo" / "feat-branch-b").is_dir()
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@ def test_workspace_delete_removes_worktree(tmp_path: Path):
         workspace_base=ws_base,
         _clone_url_override=str(remote),
     )
-    worktree = ws_base / "repos" / "myrepo" / "feat-to-delete"
+    worktree = ws_base / "repos" / "owner" / "myrepo" / "feat-to-delete"
     assert worktree.is_dir()
 
     cp = workspace_delete(
@@ -311,5 +311,5 @@ def test_workspace_prune_removes_stale_worktrees(tmp_path: Path):
 
     assert cp.returncode == 0
     # feat/stale was never on origin and feat/keep was deleted -- both should be pruned
-    assert not (ws_base / "repos" / "myrepo" / "feat-keep").exists()
-    assert not (ws_base / "repos" / "myrepo" / "feat-stale").exists()
+    assert not (ws_base / "repos" / "owner" / "myrepo" / "feat-keep").exists()
+    assert not (ws_base / "repos" / "owner" / "myrepo" / "feat-stale").exists()

--- a/tests/test_workspace_ops.py
+++ b/tests/test_workspace_ops.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 
 from repo_scaffold.workspace_ops import (
+    _copy_ignored_files,
     _slug,
     workspace_create,
     workspace_delete,
@@ -313,3 +314,138 @@ def test_workspace_prune_removes_stale_worktrees(tmp_path: Path):
     # feat/stale was never on origin and feat/keep was deleted -- both should be pruned
     assert not (ws_base / "repos" / "owner" / "myrepo" / "feat-keep").exists()
     assert not (ws_base / "repos" / "owner" / "myrepo" / "feat-stale").exists()
+
+
+# ---------------------------------------------------------------------------
+# _copy_ignored_files / --env-source
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo_with_ignored_files(tmp_path: Path) -> Path:
+    """Create a plain git repo with a mix of gitignored files to test copy filtering."""
+    repo = tmp_path / "source_repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.com"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "T"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+
+    # .gitignore with a mix of exact-name rules and glob patterns
+    (repo / ".gitignore").write_text(
+        ".env\n"
+        ".env.*\n"
+        "*.env\n"
+        "config.yml\n"
+        "*.csv\n"
+        "*.log\n"
+        "secrets.json\n"
+    )
+
+    # Exact-name ignored files -- should be copied
+    (repo / ".env").write_text("SECRET=abc")
+    (repo / "config.yml").write_text("db: localhost")
+    (repo / "secrets.json").write_text('{"key": "val"}')
+
+    # Glob-matched config files -- should be copied (.env.* and *.env are config globs)
+    (repo / ".env.local").write_text("LOCAL=1")
+    (repo / "production.env").write_text("PROD=1")
+
+    # Glob-matched data/log files -- should NOT be copied
+    (repo / "data.csv").write_text("a,b,c")
+    (repo / "output.log").write_text("log line")
+
+    # Tracked file -- not ignored, should not be copied
+    (repo / "README.md").write_text("hello")
+    subprocess.run(
+        ["git", "add", ".gitignore", "README.md"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=str(repo), check=True, capture_output=True
+    )
+
+    return repo
+
+
+def test_copy_ignored_files_copies_exact_name_rules(tmp_path: Path):
+    source = _init_git_repo_with_ignored_files(tmp_path)
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    copied = _copy_ignored_files(source, dest)
+
+    # Exact-name rules and glob-matched config files all copied
+    assert {
+        ".env",
+        "config.yml",
+        "secrets.json",
+        ".env.local",
+        "production.env",
+    }.issubset(set(copied))
+    assert (dest / ".env").read_text() == "SECRET=abc"
+    assert (dest / "config.yml").read_text() == "db: localhost"
+    assert (dest / "secrets.json").read_text() == '{"key": "val"}'
+    assert (dest / ".env.local").read_text() == "LOCAL=1"
+    assert (dest / "production.env").read_text() == "PROD=1"
+
+
+def test_copy_ignored_files_skips_glob_matched_data(tmp_path: Path):
+    source = _init_git_repo_with_ignored_files(tmp_path)
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    _copy_ignored_files(source, dest)
+
+    # Data/log globs must not be copied
+    assert not (dest / "data.csv").exists()
+    assert not (dest / "output.log").exists()
+
+
+def test_workspace_create_copies_env_source(tmp_path: Path):
+    remote = _init_local_remote(tmp_path)
+    ws_base = _make_workspace_base(tmp_path)
+    source = _init_git_repo_with_ignored_files(tmp_path)
+
+    cp = workspace_create(
+        repo="owner/myrepo",
+        branch="feat/with-env",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        env_source=source,
+        _clone_url_override=str(remote),
+    )
+
+    assert cp.returncode == 0
+    worktree = ws_base / "repos" / "owner" / "myrepo" / "feat-with-env"
+    assert (worktree / ".env").exists()
+    assert not (worktree / "data.csv").exists()
+
+
+def test_workspace_create_missing_env_source_warns_not_errors(tmp_path: Path):
+    remote = _init_local_remote(tmp_path)
+    ws_base = _make_workspace_base(tmp_path)
+
+    cp = workspace_create(
+        repo="owner/myrepo",
+        branch="feat/no-env",
+        token="unused",
+        base="main",
+        workspace_base=ws_base,
+        env_source=tmp_path / "nonexistent",
+        _clone_url_override=str(remote),
+    )
+
+    assert cp.returncode == 0
+    assert "Warning" in cp.stdout


### PR DESCRIPTION
## 🧾 Title

feat(workspace): add workspace command for managed per-branch git worktrees

## 🧠 Description

This PR introduces a managed git worktree workspace under repos/ (gitignored) so that all branch work happens at stable, predictable paths instead of arbitrary OS temp folders.

Layout: repos/{repo-slug}/.bare (shared object store) + repos/{repo-slug}/{branch-slug}/ (worktree)

## 🧩 Changes Included

- [x] Implemented new feature: workspace_ops.py with create/list/delete/prune
- [x] Added workspace command group to cli.py with four subcommands
- [x] Added repos/ to .gitignore
- [x] Updated CLAUDE.md with workspace workflow section and agent autonomy rules
- [x] Updated .claude/prompt.md boot file with workspace-based workflow

## 🎯 Purpose

Eliminates the temp-folder worktree pattern that caused fragile paths, WSL incompatibility, and abandoned directories. Gives every branch a named, stable home inside the repo-scaffold workspace with a clear lifecycle (create on branch start, delete after PR merges).

Also encodes the agent workflow rule: work autonomously inside worktrees, push PRs as the gate, do not ask for approval for file edits or git ops inside a worktree.

## 🔗 Related Issues / Epics

- **Closes:** #148

## 🧪 Testing

1. Run `poetry run pytest tests/test_workspace_ops.py -v` -- all 11 tests should pass
2. Run `poetry run repo-scaffold workspace --help` -- shows create/list/delete/prune subcommands
3. Run `poetry run tox -e precommit` -- full gate passes

## 🧰 Developer Notes

- workspace_create uses git clone --bare on first call, then git fetch origin --prune refs/heads/*:refs/heads/* on subsequent calls to reuse the same object store
- workspace_prune uses git ls-remote --heads instead of git fetch --all to avoid HEAD fetch failures on some server configs
- _clone_url_override param in workspace_create is for tests only (points to local bare repo instead of GitHub)