### PR TITLE
feat(pr): add pr reviews subcommand (#147)

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -38,6 +38,7 @@ from .github_api import (
     pr_rerun,
     pr_resolve_thread,
     pr_review_threads,
+    pr_reviews,
     pr_update,
     pr_view,
     token_from_repo,
@@ -1158,6 +1159,15 @@ def build_parser() -> argparse.ArgumentParser:
     pr_review_threads_cmd.add_argument(
         "--json", action="store_true", dest="json_output"
     )
+
+    pr_reviews_cmd = pr_sub.add_parser(
+        "reviews", help="List submitted reviews for a PR"
+    )
+    pr_reviews_cmd.add_argument("--repo", required=True)
+    pr_reviews_cmd.add_argument(
+        "--pr-number", required=True, type=int, dest="pr_number"
+    )
+    pr_reviews_cmd.add_argument("--json", action="store_true", dest="json_output")
 
     pr_list_comments_cmd = pr_sub.add_parser(
         "list-comments", help="List all inline review comments on a PR"
@@ -2481,6 +2491,30 @@ def main(argv: list[str] | None = None) -> int:
                         line = c.get("line") or c.get("originalLine") or "?"
                         body = c.get("body", "").strip()
                         print(f"[{state}] {author} on {path}:{line}")
+                        print(f"  {body[:200]}")
+            return 0
+
+        if ns.pr_command == "reviews":
+            cp = pr_reviews(target_repo, ns.pr_number, token)
+            if cp.returncode != 0:
+                print(
+                    cp.stderr.strip() or "Failed fetching reviews.",
+                    file=sys.stderr,
+                )
+                return 1
+            reviews = _json.loads(cp.stdout)
+            if ns.json_output:
+                print(_json.dumps(reviews, indent=2))
+            else:
+                if not reviews:
+                    print("No reviews found.")
+                for r in reviews:
+                    state = r.get("state", "?")
+                    user = r.get("user", "?")
+                    submitted = r.get("submitted_at", "")[:10]
+                    body = (r.get("body") or "").strip()
+                    print(f"{user}  {state}  {submitted}")
+                    if body:
                         print(f"  {body[:200]}")
             return 0
 

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1474,6 +1474,33 @@ def pr_rerun(
     return _ok(json.dumps({"triggered": triggered, "errors": errors}))
 
 
+def pr_reviews(
+    repo: str,
+    pr_number: int,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    """Return submitted reviews for a PR (reviewer login, state, submitted_at, body)."""
+    cp = rest("GET", f"/repos/{repo}/pulls/{pr_number}/reviews?per_page=100", token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        reviews = json.loads(cp.stdout)
+    except json.JSONDecodeError:
+        return _err("Unexpected response from reviews API.")
+    items = [
+        {
+            "id": r.get("id"),
+            "user": r.get("user", {}).get("login", ""),
+            "state": r.get("state", ""),
+            "submitted_at": r.get("submitted_at", ""),
+            "body": r.get("body", ""),
+        }
+        for r in reviews
+        if isinstance(r, dict)
+    ]
+    return _ok(json.dumps(items))
+
+
 def token_from_repo(repo_dir: Path) -> str | None:
     """Try to resolve a GH token from the repo .env and environment."""
     env = dict(os.environ)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2493,6 +2493,67 @@ def test_pr_rerun(tmp_path, monkeypatch, capsys) -> None:
     assert "12345" in capsys.readouterr().out
 
 
+def test_pr_reviews_human_readable(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_reviews",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "id": 1,
+                        "user": "alice",
+                        "state": "APPROVED",
+                        "submitted_at": "2026-06-01T12:00:00Z",
+                        "body": "LGTM",
+                    }
+                ]
+            ),
+            stderr="",
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["pr", "reviews", "--repo", "acme/repo", "--pr-number", "5"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "alice" in out
+    assert "APPROVED" in out
+
+
+def test_pr_reviews_json(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    payload = [
+        {
+            "id": 2,
+            "user": "bob",
+            "state": "CHANGES_REQUESTED",
+            "submitted_at": "",
+            "body": "",
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_reviews",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(payload), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["pr", "reviews", "--repo", "acme/repo", "--pr-number", "5", "--json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert json.loads(out) == payload
+
+
 def test_branch_create(tmp_path, monkeypatch, capsys) -> None:
     import json
     import subprocess

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -874,3 +874,51 @@ def test_pr_rerun_no_runs_returns_error() -> None:
     ):
         cp = github_api.pr_rerun("acme/repo", 42, "tok")
     assert cp.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# pr_reviews
+# ---------------------------------------------------------------------------
+
+
+def test_pr_reviews_returns_reviewer_state() -> None:
+    payload = json.dumps(
+        [
+            {
+                "id": 1,
+                "user": {"login": "alice"},
+                "state": "APPROVED",
+                "submitted_at": "2026-06-01T12:00:00Z",
+                "body": "LGTM",
+            },
+            {
+                "id": 2,
+                "user": {"login": "bob"},
+                "state": "CHANGES_REQUESTED",
+                "submitted_at": "2026-06-02T08:00:00Z",
+                "body": "Please fix the types.",
+            },
+        ]
+    )
+    with patch("urllib.request.urlopen", return_value=_mock_resp(200, payload)):
+        cp = github_api.pr_reviews("acme/repo", 42, "tok")
+    assert cp.returncode == 0
+    reviews = json.loads(cp.stdout)
+    assert len(reviews) == 2
+    assert reviews[0]["user"] == "alice"
+    assert reviews[0]["state"] == "APPROVED"
+    assert reviews[1]["user"] == "bob"
+    assert reviews[1]["state"] == "CHANGES_REQUESTED"
+
+
+def test_pr_reviews_empty_returns_empty_list() -> None:
+    with patch("urllib.request.urlopen", return_value=_mock_resp(200, "[]")):
+        cp = github_api.pr_reviews("acme/repo", 99, "tok")
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout) == []
+
+
+def test_pr_reviews_api_error_propagates() -> None:
+    with patch("urllib.request.urlopen", side_effect=_http_error(404, "Not Found")):
+        cp = github_api.pr_reviews("acme/repo", 0, "tok")
+    assert cp.returncode != 0


### PR DESCRIPTION
﻿## Title
feat(pr): add pr reviews subcommand (#147)

## Description
This pull request adds a `pr reviews` subcommand that returns the review state for a pull request via the GitHub REST API. Resolves #147.

## Changes Included
- [x] Implemented new feature or enhancement
- [x] Added/updated documentation

## Purpose
Agents need to know the approval/request-changes state of a PR before deciding whether to push more commits or wait for merge. The new command surfaces per-reviewer decisions without requiring a browser.

## Related Issues / Epics
- **Issue:** #147
- Closes #147

## Testing
1. `poetry run repo-scaffold pr reviews --repo OWNER/REPO --pr-number N` returns a table of reviewer login, state, and submitted_at
2. `poetry run repo-scaffold pr reviews --repo OWNER/REPO --pr-number N --json` returns raw JSON array
3. `poetry run pytest tests/test_github_api.py tests/test_cli.py -q` passes (3 API tests + 2 CLI tests added)

## Developer Notes
- `github_api.pr_reviews()` calls `GET /repos/{repo}/pulls/{pr_number}/reviews?per_page=100`
- Output fields: id, user, state, submitted_at, body
- CLI dispatch added in `cli.py` under the `pr` subparser group