### PR TITLE
feat(pr): add --state flag to pr update for closing/reopening PRs

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -1106,6 +1106,12 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="Read body from a UTF-8 file (mutually exclusive with --body)",
     )
+    pr_update_cmd.add_argument(
+        "--state",
+        choices=["open", "closed"],
+        default=None,
+        help="Set PR state to open or closed",
+    )
 
     pr_resolve_cmd = pr_sub.add_parser(
         "resolve-thread", help="Resolve a PR review thread"
@@ -2361,9 +2367,9 @@ def main(argv: list[str] | None = None) -> int:
 
         if ns.pr_command == "update":
             resolved_body = _resolve_body(ns.body, ns.body_file)
-            if ns.title is None and resolved_body is None:
+            if ns.title is None and resolved_body is None and ns.state is None:
                 print(
-                    "Error: at least one of --title or --body is required.",
+                    "Error: at least one of --title, --body, or --state is required.",
                     file=sys.stderr,
                 )
                 return 2
@@ -2373,6 +2379,7 @@ def main(argv: list[str] | None = None) -> int:
                 token=token,
                 title=ns.title,
                 body=resolved_body,
+                state=ns.state,
             )
             if cp.returncode != 0:
                 print(cp.stderr.strip() or "Failed updating PR.", file=sys.stderr)

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1284,12 +1284,15 @@ def pr_update(
     token: str,
     title: str | None = None,
     body: str | None = None,
+    state: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     payload: dict[str, object] = {}
     if title is not None:
         payload["title"] = title
     if body is not None:
         payload["body"] = body
+    if state is not None:
+        payload["state"] = state
     return rest("PATCH", f"/repos/{repo}/pulls/{pr_number}", token, payload)
 
 


### PR DESCRIPTION
## Title

Add --state flag to pr update for closing/reopening PRs

## Description

This PR adds a --state {open,closed} argument to the pr update subcommand so PRs can be closed or reopened entirely within the repo-scaffold CLI, without reaching for gh or raw API calls.

## Changes Included

- [x] Implemented new feature or enhancement

## Purpose

This PR aims to expose the GitHub PATCH /pulls/{number} state field through the CLI. We hit this gap immediately when closing stale PRs created by agent workflow violations (branch reuse). Dogfooding the CLI meant implementing the missing command before using it.

## Related Issues / Epics

- **Issue:** #153

## Testing

1. Run: poetry run repo-scaffold pr update --repo OWNER/REPO --pr-number N --state closed
2. Verify the PR is now closed on GitHub.
3. Run with --state open to reopen it.
4. Confirm that omitting all three flags (--title, --body, --state) still returns an error.

## Developer Notes

- The --state and --title/--body flags are all optional and independent; any combination is valid as long as at least one is provided.