### PR TITLE
feat(agents): add branch naming and PR title standards to AGENTS.md and generator (#154)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,35 +131,58 @@ poetry run repo-scaffold check rules --repo OWNER/REPO
 
 ---
 
+## Branch naming
+
+Format: `type/NNN-short-description`
+
+- `type`: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
+- `NNN`: the GitHub issue number -- create the issue first if one does not exist
+- `short-description`: kebab-case, 3-4 words max
+
+Examples: `feat/153-pr-update-state`, `fix/148-workspace-gcm`, `docs/161-pillar-crt-spec`
+
+`main` is the only long-lived branch. Never reuse a branch after its PR has merged.
+
+---
+
+## PR titles
+
+Format: `type(scope): description (#NNN)`
+
+Example: `feat(pr): add --state flag to pr update (#153)`
+
+The issue number at the end is required so the PR is immediately traceable to its ticket.
+
+---
+
 ## How to contribute
 
-1. Pick an open issue from the [repo-scaffold Roadmap](https://github.com/users/blairg23/projects/6).
-2. Branch off `main`:
+1. Create or pick an issue from the [repo-scaffold Roadmap](https://github.com/users/blairg23/projects/6). Note the issue number (`NNN`).
+2. Branch off `main` using the `type/NNN-short-description` format:
    ```bash
    git checkout main && git pull
-   git checkout -b feat/your-feature
+   git checkout -b feat/NNN-short-description
    ```
 3. Make changes. Run the gate before committing:
    ```bash
-   python -m pre_commit run --all-files
+   poetry run tox -e precommit
    ```
    If Black reformats files, re-stage them and re-run.
-4. Commit with a subject + blank line + body (see recent commits for style).
-5. Open a draft PR using the PR template and link it to the issue:
+4. Commit with a subject + blank line + body (see recent commits for style). No one-liners.
+5. Open a PR using the PR template. Title must follow `type(scope): description (#NNN)`:
    ```bash
    poetry run repo-scaffold pr create \
      --repo blairg23/repo-scaffold \
-     --title "feat: your change" \
-     --head feat/your-feature \
-     --draft \
+     --title "feat(scope): your change (#NNN)" \
+     --head feat/NNN-short-description \
      --body "..."
    ```
-6. Add the PR to the project board:
+6. Add the issue to the project board (issues only -- not PRs):
    ```bash
    poetry run repo-scaffold project item-add \
      --project-title "repo-scaffold Roadmap" \
      --repo blairg23/repo-scaffold \
-     --issue-number <PR number>
+     --issue-number NNN
    ```
 
 ---
@@ -180,9 +203,11 @@ Coverage must stay at or above 70%.
 
 - Never use `gh` CLI -- use repo-scaffold commands or `github_api.py` directly.
 - Never merge or close PRs -- only CODEOWNERS may do that.
-- Always add issues and PRs to the project board after creating them.
+- Never push to a branch whose PR is already merged -- cut a fresh branch from main.
 - Always use issue and PR templates -- no freeform bodies.
+- Always add issues to the project board after creating them (issues only, not PRs).
 - Commit messages: subject + blank line + body. No one-liners.
+- Git identity: confirm `user.name` and `user.email` are real values before the first commit.
 
 See [CLAUDE.md](CLAUDE.md) for the full portability and agnosticism requirements.
 See [examples/README.md](examples/README.md) for backlog and ticket format examples.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,87 +1,188 @@
-# Pre-Implementation Requirements
+# AGENTS.md -- repo-scaffold
 
-Before writing any code, verify every item below. These are non-negotiable and apply to every agent working in every repo.
-
-## Portability
-- [ ] No OS-specific tools or CLIs (no `gh`, no `brew`, no `apt`, no bash-only commands)
-- [ ] No assumptions about shell availability
-- [ ] Works on Windows, Linux, and Mac equally
-- [ ] Works in headless and agent environments
-
-## Agnosticism
-- [ ] No LLM-specific code, prompts, or dependencies
-- [ ] No assumptions about which AI tool is running
-- [ ] No CLI wrappers around HTTP APIs — use HTTP directly
-- [ ] HTTP/REST preferred over SDK when SDK adds OS assumptions
-
-## Execution Layer
-- [ ] Agents decide WHAT to do, never HOW it executes
-- [ ] All execution goes through CueQueue jobs
-- [ ] CueQueue is the only layer that touches the OS
-- [ ] Acceptable CueQueue job types: HTTP calls, file sync, local git, build tools, agent chains, any shell command routed through CueQueue
-
-## Dependencies
-- [ ] Every external dependency is explicitly justified
-- [ ] HTTP APIs preferred over installed CLIs
-- [ ] If a CLI wraps an HTTP API, the API is used directly
-- [ ] Each dependency's purpose is documented
-
-## Standing Rules (non-negotiable)
-- [ ] Never use `gh` CLI — use GitHub REST API directly
-- [ ] Never assume a shell exists — queue a CueQueue job instead
-- [ ] Never write LLM-specific code — stay model-agnostic
-- [ ] Never write OS-specific code — HTTP works everywhere
-- [ ] CueQueue is the universal executor for all shell operations
+Operational guide for agents working in this repo. Read this before touching anything.
 
 ---
 
-# repo-scaffold Agent Context
-
 ## What this repo does
 
-`repo-scaffold` is a CLI toolkit for creating, scaffolding, and managing GitHub repositories. It generates project structure, applies settings, manages backlogs, and interacts with GitHub Projects — all via the GitHub REST and GraphQL APIs. No `gh` CLI required.
+`repo-scaffold` is a CLI for creating, scaffolding, and managing GitHub repositories.
+It generates project structure (CI, templates, CODEOWNERS, AGENTS.md, SPEC.md),
+applies settings, manages issue backlogs, and interacts with GitHub Projects v2 --
+all via the GitHub REST and GraphQL APIs. No `gh` CLI required.
 
-## Key commands
-
-```bash
-poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N [--json]
-poetry run repo-scaffold issue list --repo OWNER/REPO [--state open|closed|all] [--json]
-poetry run repo-scaffold issue create --repo OWNER/REPO --title "TITLE" [--body "TEXT"] [--label L] [--assignee U]
-poetry run repo-scaffold issue close --repo OWNER/REPO --issue-number N
-poetry run repo-scaffold issue comment --repo OWNER/REPO --issue-number N --body "TEXT"
-poetry run repo-scaffold issue label --repo OWNER/REPO --issue-number N [--add L] [--remove L]
-poetry run repo-scaffold issue assign --repo OWNER/REPO --issue-number N [--add USER] [--remove USER]
-poetry run repo-scaffold pr list --repo OWNER/REPO [--json]
-poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N [--json]
-poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
-poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
-poetry run repo-scaffold pr create --repo OWNER/REPO --title "TITLE" --head BRANCH [--base main] [--body "TEXT"] [--draft]
-poetry run repo-scaffold project items --project-title "TITLE" --limit 40
-poetry run repo-scaffold create --repo OWNER/REPO --visibility public --path /path/to/code
-poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
-poetry run repo-scaffold check rules --repo OWNER/REPO
-poetry run repo-scaffold init --name NAME --languages go,gin,python,react --owner OWNER --out /path --yes
-```
+---
 
 ## Auth
 
-`GH_TOKEN` in `.env`. Loaded automatically. Never requires `gh` on PATH.
+`GH_TOKEN` lives in `.env`. Commands load it automatically via `_seed_env_from_dotenv`.
+Copy `.env.example` to `.env` and fill in the token. It must be a classic PAT with
+`repo`, `workflow`, and `project` scopes.
+
+```bash
+cp .env.example .env
+# Edit .env and set GH_TOKEN=<your-token>
+```
+
+---
+
+## Commands
+
+### Issues
+
+```bash
+poetry run repo-scaffold issue view   --repo OWNER/REPO --issue-number N [--json]
+poetry run repo-scaffold issue list   --repo OWNER/REPO [--state open|closed|all] [--label LABEL] [--json]
+poetry run repo-scaffold issue create --repo OWNER/REPO --title "TITLE" [--body "TEXT"] [--label L] [--assignee U]
+poetry run repo-scaffold issue update --repo OWNER/REPO --issue-number N [--title "TITLE"] [--body "TEXT"] [--state open|closed]
+poetry run repo-scaffold issue close  --repo OWNER/REPO --issue-number N
+poetry run repo-scaffold issue comment --repo OWNER/REPO --issue-number N --body "TEXT"
+poetry run repo-scaffold issue label  --repo OWNER/REPO --issue-number N [--add L] [--remove L]
+poetry run repo-scaffold issue assign --repo OWNER/REPO --issue-number N [--add USER] [--remove USER]
+```
+
+### Pull Requests
+
+```bash
+poetry run repo-scaffold pr list    --repo OWNER/REPO [--json]
+poetry run repo-scaffold pr view    --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr create  --repo OWNER/REPO --title "TITLE" --head BRANCH [--base main] [--body "TEXT"] [--draft]
+poetry run repo-scaffold pr update  --repo OWNER/REPO --pr-number N [--title "TITLE"] [--body "TEXT"]
+poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N --body "TEXT" [--reply-to COMMENT_ID]
+poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
+poetry run repo-scaffold pr checks  --repo OWNER/REPO --pr-number N [--json]
+```
+
+> Never call `pr merge` -- only CODEOWNERS may merge. See CLAUDE.md.
+
+### Branches
+
+```bash
+poetry run repo-scaffold branch create --repo OWNER/REPO --name BRANCH [--from main]
+poetry run repo-scaffold branch delete --repo OWNER/REPO --name BRANCH
+```
+
+### Projects
+
+```bash
+poetry run repo-scaffold project list     --project-owner OWNER
+poetry run repo-scaffold project view     --project-title "TITLE"
+poetry run repo-scaffold project items    --project-title "TITLE" --limit 40
+poetry run repo-scaffold project create   --project-owner OWNER --project-title "TITLE" [--description "TEXT"]
+poetry run repo-scaffold project edit     --project-owner OWNER --project-title "TITLE" [--title "NEW"] [--description "TEXT"]
+poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N
+poetry run repo-scaffold project item-delete --project-title "TITLE" --issue-number N
+poetry run repo-scaffold project link-repo   --project-title "TITLE" --repo OWNER/REPO
+poetry run repo-scaffold project sync-metadata --project-owner OWNER --project-title "TITLE" --repo OWNER/REPO
+```
+
+### Backlog
+
+```bash
+# Compile individual .md tickets into issues.json
+poetry run repo-scaffold import backlog --repo OWNER/REPO
+
+# Push issues.json to GitHub (creates issues + project board items)
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
+```
+
+### Scaffold Generation
+
+```bash
+# New repo from scratch (git init + initial commit + GitHub create)
+poetry run repo-scaffold create --repo OWNER/REPO --visibility public --path /path/to/code
+
+# Init scaffold files into an existing local directory
+poetry run repo-scaffold init --name NAME --languages go,gin,python,react --owner OWNER --out /path --yes
+
+# Apply CI workflows to an existing repo
+poetry run repo-scaffold apply ci --path . --languages go,gin,python,react
+
+# Apply issue/PR templates to an existing repo
+poetry run repo-scaffold apply templates --path . --name NAME --owner OWNER
+
+# Check branch protection rules
+poetry run repo-scaffold check rules --repo OWNER/REPO
+```
+
+**Supported languages:** `go`, `gin`, `python`, `react`
+(`gin` and `go` are mutually exclusive -- both use go.mod)
+
+---
+
+## Key file locations
+
+| Path | What it is |
+|------|-----------|
+| `src/repo_scaffold/cli.py` | Argparse entry point -- all subcommands |
+| `src/repo_scaffold/generator.py` | Scaffold file generation (CI, templates, SPEC.md, etc.) |
+| `src/repo_scaffold/github_api.py` | All GitHub API calls (urllib, no CLI) |
+| `src/repo_scaffold/backlog_ops.py` | Issue, milestone, label, project operations |
+| `src/repo_scaffold/create_ops.py` | Repo creation, settings, git init |
+| `src/repo_scaffold/project_ops.py` | GitHub Projects v2 management |
+| `src/repo_scaffold/overwrite_policy.py` | File write/skip/overwrite logic |
+| `tests/` | pytest test suite |
+| `examples/` | Sample spec, backlog, and ticket files -- see `examples/README.md` |
+| `artifacts/` | Gitignored. Ephemeral backlog files live here -- import and discard. |
+| `.env.example` | Token and config template |
+| `.github/ISSUE_TEMPLATE/epic.md` | Epic issue template |
+| `.github/ISSUE_TEMPLATE/ticket.md` | Ticket issue template |
+| `.github/pull_request_template.md` | PR template |
+
+---
+
+## How to contribute
+
+1. Pick an open issue from the [repo-scaffold Roadmap](https://github.com/users/blairg23/projects/6).
+2. Branch off `main`:
+   ```bash
+   git checkout main && git pull
+   git checkout -b feat/your-feature
+   ```
+3. Make changes. Run the gate before committing:
+   ```bash
+   python -m pre_commit run --all-files
+   ```
+   If Black reformats files, re-stage them and re-run.
+4. Commit with a subject + blank line + body (see recent commits for style).
+5. Open a draft PR using the PR template and link it to the issue:
+   ```bash
+   poetry run repo-scaffold pr create \
+     --repo blairg23/repo-scaffold \
+     --title "feat: your change" \
+     --head feat/your-feature \
+     --draft \
+     --body "..."
+   ```
+6. Add the PR to the project board:
+   ```bash
+   poetry run repo-scaffold project item-add \
+     --project-title "repo-scaffold Roadmap" \
+     --repo blairg23/repo-scaffold \
+     --issue-number <PR number>
+   ```
+
+---
 
 ## Testing
 
 ```bash
-poetry run pytest
-poetry run tox -e precommit   # full gate: format + lint + type + coverage
+poetry run pytest                         # all tests
+poetry run pytest tests/test_cli.py -q   # CLI only
+poetry run tox -e precommit              # full gate: format + lint + type + coverage
 ```
 
-## Architecture notes
+Coverage must stay at or above 70%.
 
-- `github_api.py` — all GitHub API calls via `urllib` (stdlib only, no CLI)
-- `backlog_ops.py` — issue/milestone/label/project operations
-- `create_ops.py` — repo creation, settings, git init
-- `project_ops.py` — GitHub Projects v2 management
-- `generator.py` — scaffold file generation (go, gin, python, react)
-- `cli.py` — argparse entry point
+---
 
-## Full lifecycle coverage
-All GitHub operations are implemented via GH_TOKEN + urllib. No `gh` CLI required anywhere.
+## Standing rules
+
+- Never use `gh` CLI -- use repo-scaffold commands or `github_api.py` directly.
+- Never merge or close PRs -- only CODEOWNERS may do that.
+- Always add issues and PRs to the project board after creating them.
+- Always use issue and PR templates -- no freeform bodies.
+- Commit messages: subject + blank line + body. No one-liners.
+
+See [CLAUDE.md](CLAUDE.md) for the full portability and agnosticism requirements.
+See [examples/README.md](examples/README.md) for backlog and ticket format examples.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,8 @@ poetry run repo-scaffold project sync-metadata --project-owner OWNER --project-t
 # Compile individual .md tickets into issues.json
 poetry run repo-scaffold import backlog --repo OWNER/REPO
 
-# Push issues.json to GitHub (creates issues + project board items)
-poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
+# Push issues.json to GitHub (creates issues; add --with-project for project board items)
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --path . --with-project
 ```
 
 ### Scaffold Generation

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -823,24 +823,70 @@ def _render_claude_settings_local() -> str:
 
 
 def _render_agents_md(config: ScaffoldConfig) -> str:
-    return f"""# AGENTS
+    return f"""# AGENTS.md -- {config.name}
 
-Repo-scaffold conventions for local agents:
+Agent workflow guide. Read this before touching anything.
 
-- Treat `GH_REPO` (or `GITHUB_ORG` + `GITHUB_REPO`) as the canonical GitHub repo identity for this workspace.
-- Do not mutate other repositories unless the user explicitly asks.
-- If `.repo-scaffold/project.json` exists, it is the canonical GitHub Project metadata for this repo. Read it before doing project or ticket work.
-- Prefer repo issues and the repo-linked roadmap project for planning context.
+---
+
+## Branch naming
+
+Format: `type/NNN-short-description`
+
+- `type`: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
+- `NNN`: the GitHub issue number -- create the issue first if one does not exist
+- `short-description`: kebab-case, 3-4 words max
+
+Examples: `feat/42-user-auth`, `fix/88-crash-on-load`, `docs/17-api-reference`
+
+`main` is the only long-lived branch. Never reuse a branch after its PR has merged.
+
+---
+
+## PR titles
+
+Format: `type(scope): description (#NNN)`
+
+Example: `feat(auth): add OAuth login flow (#42)`
+
+The issue number at the end is required so the PR is immediately traceable to its ticket.
+
+---
+
+## Workflow rules
+
+- Create a GitHub issue before starting work so you have the `NNN` for the branch name.
+- Always use the PR template (`.github/pull_request_template.md`) -- no freeform bodies.
+- Always use the issue templates (`.github/ISSUE_TEMPLATE/ticket.md` or `epic.md`).
+- After creating an issue, add it to the `{config.name} Roadmap` project board.
+- Never merge or close PRs -- push the branch, open the PR, stop there.
+- Never push new commits to a branch whose PR is already merged -- cut a fresh branch from main.
+
+---
+
+## Git identity
+
+Before your first commit, confirm `git config user.name` and `git config user.email` are
+set to real values (not `Your Name` / `you@example.com`). If they are placeholders, stop
+and ask the user to configure them before continuing.
+
+---
+
+## Commit messages
+
+Format: subject line (imperative mood) + blank line + body.
+
+- Subject: 50 chars max, no trailing period
+- Body: explain WHY the change is needed, not what it does (the diff shows what)
+- No one-liner commits for non-trivial changes
+
+---
+
+## Project context
+
+- If `.repo-scaffold/project.json` exists, it is the canonical GitHub Project metadata for this repo.
 - Planning markdown lives in `artifacts/tickets/`.
 - Imported backlog JSON lives in `artifacts/backlog/issues.json`.
-- For local GitHub auth, prefer `gh auth login` or an OS credential manager. Use `.env` tokens only when the user intentionally wants repo-local token-based scripting.
-- For GitHub Projects v2 commands in WSL / Claude Code, prefer the `ghp` shell alias or `GH_TOKEN=<classic-PAT> gh ...`.
-- Do not rely on `GH_TOKEN=$GH_PROJECT_TOKEN gh ...` for project board commands in this environment.
-- `.claude/settings.local.json` is local-only and should carry `GH_PROJECT_TOKEN` for Claude Code sessions.
-
-Expected default project title:
-
-- `{config.name} Roadmap`
 """
 
 


### PR DESCRIPTION
﻿## Title

Add branch naming and PR title standards to AGENTS.md and generator (#154)

## Description

This PR adds the canonical branch naming and PR title conventions to repo-scaffold's own AGENTS.md and rewrites the generated-repo template so every scaffolded repo starts with the same standards baked in.

## Changes Included

- [x] Added/updated documentation
- [x] Implemented new feature or enhancement

Specifically:
- AGENTS.md: new Branch naming and PR titles sections; contribute example updated from feat/your-feature to feat/NNN-short-description; standing rules expanded with branch-reuse and git identity checks
- generator._render_agents_md: full structured guide replacing the old short bullet list; includes branch naming, PR titles, workflow rules, git identity, commit message format, and project context

## Purpose

This PR aims to ensure every agent (and contributor) working in repo-scaffold or any repo it generates starts with unambiguous written conventions, eliminating the branch-reuse and freeform-PR-body violations we saw in practice.

## Related Issues / Epics

- Closes #154

## Testing

1. Read AGENTS.md and confirm Branch naming and PR titles sections are present
2. Run poetry run repo-scaffold init --name test-repo --owner test --out /tmp/test-scaffold --yes
3. Open /tmp/test-scaffold/AGENTS.md and confirm it contains the full guide

## Developer Notes

- The generator template uses f-string interpolation for config.name and the project title; all other content is static