### PR TITLE
feat(agents): add branch naming and PR title standards to AGENTS.md and generator (#154)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,35 +131,58 @@ poetry run repo-scaffold check rules --repo OWNER/REPO
 
 ---
 
+## Branch naming
+
+Format: `type/NNN-short-description`
+
+- `type`: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
+- `NNN`: the GitHub issue number -- create the issue first if one does not exist
+- `short-description`: kebab-case, 3-4 words max
+
+Examples: `feat/153-pr-update-state`, `fix/148-workspace-gcm`, `docs/161-pillar-crt-spec`
+
+`main` is the only long-lived branch. Never reuse a branch after its PR has merged.
+
+---
+
+## PR titles
+
+Format: `type(scope): description (#NNN)`
+
+Example: `feat(pr): add --state flag to pr update (#153)`
+
+The issue number at the end is required so the PR is immediately traceable to its ticket.
+
+---
+
 ## How to contribute
 
-1. Pick an open issue from the [repo-scaffold Roadmap](https://github.com/users/blairg23/projects/6).
-2. Branch off `main`:
+1. Create or pick an issue from the [repo-scaffold Roadmap](https://github.com/users/blairg23/projects/6). Note the issue number (`NNN`).
+2. Branch off `main` using the `type/NNN-short-description` format:
    ```bash
    git checkout main && git pull
-   git checkout -b feat/your-feature
+   git checkout -b feat/NNN-short-description
    ```
 3. Make changes. Run the gate before committing:
    ```bash
-   python -m pre_commit run --all-files
+   poetry run tox -e precommit
    ```
    If Black reformats files, re-stage them and re-run.
-4. Commit with a subject + blank line + body (see recent commits for style).
-5. Open a draft PR using the PR template and link it to the issue:
+4. Commit with a subject + blank line + body (see recent commits for style). No one-liners.
+5. Open a PR using the PR template. Title must follow `type(scope): description (#NNN)`:
    ```bash
    poetry run repo-scaffold pr create \
      --repo blairg23/repo-scaffold \
-     --title "feat: your change" \
-     --head feat/your-feature \
-     --draft \
+     --title "feat(scope): your change (#NNN)" \
+     --head feat/NNN-short-description \
      --body "..."
    ```
-6. Add the PR to the project board:
+6. Add the issue to the project board (issues only -- not PRs):
    ```bash
    poetry run repo-scaffold project item-add \
      --project-title "repo-scaffold Roadmap" \
      --repo blairg23/repo-scaffold \
-     --issue-number <PR number>
+     --issue-number NNN
    ```
 
 ---
@@ -180,9 +203,11 @@ Coverage must stay at or above 70%.
 
 - Never use `gh` CLI -- use repo-scaffold commands or `github_api.py` directly.
 - Never merge or close PRs -- only CODEOWNERS may do that.
-- Always add issues and PRs to the project board after creating them.
+- Never push to a branch whose PR is already merged -- cut a fresh branch from main.
 - Always use issue and PR templates -- no freeform bodies.
+- Always add issues to the project board after creating them (issues only, not PRs).
 - Commit messages: subject + blank line + body. No one-liners.
+- Git identity: confirm `user.name` and `user.email` are real values before the first commit.
 
 See [CLAUDE.md](CLAUDE.md) for the full portability and agnosticism requirements.
 See [examples/README.md](examples/README.md) for backlog and ticket format examples.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,8 @@ poetry run repo-scaffold project sync-metadata --project-owner OWNER --project-t
 # Compile individual .md tickets into issues.json
 poetry run repo-scaffold import backlog --repo OWNER/REPO
 
-# Push issues.json to GitHub (creates issues + project board items)
-poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
+# Push issues.json to GitHub (creates issues; add --with-project for project board items)
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --path . --with-project
 ```
 
 ### Scaffold Generation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,8 @@ poetry run repo-scaffold project sync-metadata --project-owner OWNER --project-t
 # Compile individual .md tickets into issues.json
 poetry run repo-scaffold import backlog --repo OWNER/REPO
 
-# Push issues.json to GitHub (creates issues; add --with-project for project board items)
-poetry run repo-scaffold apply backlog --repo OWNER/REPO --path . --with-project
+# Push issues.json to GitHub (creates issues + project board items)
+poetry run repo-scaffold apply backlog --repo OWNER/REPO --path .
 ```
 
 ### Scaffold Generation

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -900,6 +900,19 @@ Format: subject line (imperative mood) + blank line + body.
 - If `.repo-scaffold/project.json` exists, it is the canonical GitHub Project metadata for this repo.
 - Planning markdown lives in `artifacts/tickets/`.
 - Imported backlog JSON lives in `artifacts/backlog/issues.json`.
+- `GH_REPO` (set in `.env`) is the canonical repo identity for this workspace (e.g. `owner/repo`).
+
+---
+
+## GitHub Projects v2 auth
+
+For GitHub Projects v2 commands, use the `ghp` shell alias or the explicit form:
+
+```bash
+GH_TOKEN=$GH_PROJECT_TOKEN gh ...
+```
+
+`GH_PROJECT_TOKEN` is a classic PAT with `project` scope. Set it in `.env`.
 """
 
 

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -836,24 +836,70 @@ def _render_claude_settings_local() -> str:
 
 
 def _render_agents_md(config: ScaffoldConfig) -> str:
-    return f"""# AGENTS
+    return f"""# AGENTS.md -- {config.name}
 
-Repo-scaffold conventions for local agents:
+Agent workflow guide. Read this before touching anything.
 
-- Treat `GH_REPO` (or `GITHUB_ORG` + `GITHUB_REPO`) as the canonical GitHub repo identity for this workspace.
-- Do not mutate other repositories unless the user explicitly asks.
-- If `.repo-scaffold/project.json` exists, it is the canonical GitHub Project metadata for this repo. Read it before doing project or ticket work.
-- Prefer repo issues and the repo-linked roadmap project for planning context.
+---
+
+## Branch naming
+
+Format: `type/NNN-short-description`
+
+- `type`: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
+- `NNN`: the GitHub issue number -- create the issue first if one does not exist
+- `short-description`: kebab-case, 3-4 words max
+
+Examples: `feat/42-user-auth`, `fix/88-crash-on-load`, `docs/17-api-reference`
+
+`main` is the only long-lived branch. Never reuse a branch after its PR has merged.
+
+---
+
+## PR titles
+
+Format: `type(scope): description (#NNN)`
+
+Example: `feat(auth): add OAuth login flow (#42)`
+
+The issue number at the end is required so the PR is immediately traceable to its ticket.
+
+---
+
+## Workflow rules
+
+- Create a GitHub issue before starting work so you have the `NNN` for the branch name.
+- Always use the PR template (`.github/pull_request_template.md`) -- no freeform bodies.
+- Always use the issue templates (`.github/ISSUE_TEMPLATE/ticket.md` or `epic.md`).
+- After creating an issue, add it to the `{config.name} Roadmap` project board.
+- Never merge or close PRs -- push the branch, open the PR, stop there.
+- Never push new commits to a branch whose PR is already merged -- cut a fresh branch from main.
+
+---
+
+## Git identity
+
+Before your first commit, confirm `git config user.name` and `git config user.email` are
+set to real values (not `Your Name` / `you@example.com`). If they are placeholders, stop
+and ask the user to configure them before continuing.
+
+---
+
+## Commit messages
+
+Format: subject line (imperative mood) + blank line + body.
+
+- Subject: 50 chars max, no trailing period
+- Body: explain WHY the change is needed, not what it does (the diff shows what)
+- No one-liner commits for non-trivial changes
+
+---
+
+## Project context
+
+- If `.repo-scaffold/project.json` exists, it is the canonical GitHub Project metadata for this repo.
 - Planning markdown lives in `artifacts/tickets/`.
 - Imported backlog JSON lives in `artifacts/backlog/issues.json`.
-- For local GitHub auth, prefer `gh auth login` or an OS credential manager. Use `.env` tokens only when the user intentionally wants repo-local token-based scripting.
-- For GitHub Projects v2 commands in WSL / Claude Code, prefer the `ghp` shell alias or `GH_TOKEN=<classic-PAT> gh ...`.
-- Do not rely on `GH_TOKEN=$GH_PROJECT_TOKEN gh ...` for project board commands in this environment.
-- `.claude/settings.local.json` is local-only and should carry `GH_PROJECT_TOKEN` for Claude Code sessions.
-
-Expected default project title:
-
-- `{config.name} Roadmap`
 """
 
 


### PR DESCRIPTION
﻿## 🧾 Title
<!-- Example: Improve backlog bootstrap issue creation flow -->
feat(agents): add branch naming and PR title standards to AGENTS.md and generator (#154)

## 🧠 Description
<!-- Briefly explain what this PR accomplishes and why it's needed. -->
This pull request adds the canonical branch naming and PR title conventions to repo-scaffold's own AGENTS.md and rewrites the generated-repo template so every scaffolded repo starts with the same standards baked in.

## 🧩 Changes Included
<!-- List the key modifications made in this PR. -->
- [x] Added/updated documentation
- [x] Implemented new feature or enhancement

Specifically:
- AGENTS.md: new Branch naming and PR titles sections; contribute example updated to feat/NNN-short-description; standing rules expanded with branch-reuse and git identity checks
- generator._render_agents_md: full structured guide replacing the old short bullet list; includes branch naming, PR titles, workflow rules, git identity, commit message format, and project context

## 🎯 Purpose
<!-- What problem does this PR solve or what value does it add? -->
This PR aims to ensure every agent (and contributor) working in repo-scaffold or any repo it generates starts with unambiguous written conventions, eliminating the branch-reuse and freeform-PR-body violations we saw in practice.

## 🔗 Related Issues / Epics
<!-- Link GitHub issues/epics for traceability. -->
- Closes #154

## 🧪 Testing
<!-- Describe how reviewers can verify this PR works as intended. -->
1. Read AGENTS.md and confirm Branch naming and PR titles sections are present
2. `poetry run repo-scaffold init --name test-repo --owner test --out /tmp/test-scaffold --yes`
3. Open /tmp/test-scaffold/AGENTS.md and confirm it contains the full structured guide

## 🧰 Developer Notes
<!-- Optional: Add any additional notes, caveats, or follow-ups here. -->
- The generator template uses f-string interpolation for config.name and the project title; all other content is static