### PR TITLE
chore(readme): add CI badge, MIT license, and license badge (#160)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Blair Gemmer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # repo-scaffold
 
+[![CI](https://github.com/blairg23/repo-scaffold/actions/workflows/ci.yml/badge.svg)](https://github.com/blairg23/repo-scaffold/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/blairg23/repo-scaffold/graph/badge.svg)](https://codecov.io/gh/blairg23/repo-scaffold)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 `repo-scaffold` is a repo operations toolkit with seven modes:
 


### PR DESCRIPTION
﻿## 🧾 Title
chore(readme): add CI badge, MIT license, and license badge (#160)

## 🧠 Description
Repo hygiene pass: wires up the missing CI status badge, adds the MIT LICENSE file, and adds a license badge to the README. The CODECOV_TOKEN secret was already added to GitHub repo settings separately.

## 🧩 Changes Included
- [x] Added/updated documentation

Specifically:
- Added GitHub Actions CI status badge (live build pass/fail)
- Added MIT LICENSE file (Copyright 2026 Blair Gemmer)
- Added License badge linking to LICENSE file

## 🎯 Purpose
This PR aims to make the repo look complete and professional with standard open-source hygiene markers.

## 🔗 Related Issues / Epics
- Closes #160

## 🧪 Testing
1. Confirm CI badge renders green after merge
2. Confirm codecov badge populates after next CI run (CODECOV_TOKEN already set)
3. Confirm License badge links to LICENSE file

## 🧰 Developer Notes
- CI badge URL: `https://github.com/blairg23/repo-scaffold/actions/workflows/ci.yml/badge.svg`
- No workflow changes needed