### PR TITLE
feat(pr): add pr request-reviewer subcommand (#162)

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -38,6 +38,7 @@ from .github_api import (
     pr_rerun,
     pr_resolve_thread,
     pr_review_threads,
+    pr_request_reviewer,
     pr_reviews,
     pr_update,
     pr_view,
@@ -1183,6 +1184,22 @@ def build_parser() -> argparse.ArgumentParser:
         "--pr-number", required=True, type=int, dest="pr_number"
     )
     pr_list_comments_cmd.add_argument("--json", action="store_true", dest="json_output")
+
+    pr_request_reviewer_cmd = pr_sub.add_parser(
+        "request-reviewer", help="Request one or more reviewers on a PR"
+    )
+    pr_request_reviewer_cmd.add_argument("--repo", required=True)
+    pr_request_reviewer_cmd.add_argument(
+        "--pr-number", required=True, type=int, dest="pr_number"
+    )
+    pr_request_reviewer_cmd.add_argument(
+        "--reviewer",
+        action="append",
+        dest="reviewers",
+        required=True,
+        metavar="USER",
+        help="GitHub username to request (repeatable)",
+    )
 
     branch_cmd = subparsers.add_parser("branch", help="Manage GitHub branches")
     branch_sub = branch_cmd.add_subparsers(dest="branch_command", required=True)
@@ -2546,6 +2563,19 @@ def main(argv: list[str] | None = None) -> int:
                     body = (c.get("body") or "").strip()
                     print(f"{author} on {path}:{line}")
                     print(f"  {body[:200]}")
+            return 0
+
+        if ns.pr_command == "request-reviewer":
+            cp = pr_request_reviewer(target_repo, ns.pr_number, token, ns.reviewers)
+            if cp.returncode not in (0, 201):
+                print(
+                    cp.stderr.strip() or "Failed requesting reviewer.",
+                    file=sys.stderr,
+                )
+                return 1
+            data = _json.loads(cp.stdout)
+            requested = [r.get("login", "") for r in data.get("requested_reviewers", [])]
+            print(f"Reviewers requested on PR #{ns.pr_number}: {', '.join(requested)}")
             return 0
 
     if ns.mode == "branch":

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -2574,7 +2574,9 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 return 1
             data = _json.loads(cp.stdout)
-            requested = [r.get("login", "") for r in data.get("requested_reviewers", [])]
+            requested = [
+                r.get("login", "") for r in data.get("requested_reviewers", [])
+            ]
             print(f"Reviewers requested on PR #{ns.pr_number}: {', '.join(requested)}")
             return 0
 

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1504,6 +1504,21 @@ def pr_reviews(
     return _ok(json.dumps(items))
 
 
+def pr_request_reviewer(
+    repo: str,
+    pr_number: int,
+    token: str,
+    reviewers: list[str],
+) -> subprocess.CompletedProcess[str]:
+    """Request one or more reviewers on an open pull request."""
+    return rest(
+        "POST",
+        f"/repos/{repo}/pulls/{pr_number}/requested_reviewers",
+        token,
+        {"reviewers": reviewers},
+    )
+
+
 def token_from_repo(repo_dir: Path) -> str | None:
     """Try to resolve a GH token from the repo .env and environment."""
     env = dict(os.environ)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2753,3 +2753,38 @@ def test_body_file_non_utf8_exits_cleanly(
             ]
         )
     assert "UTF-8" in str(exc.value)
+
+
+def test_pr_request_reviewer(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    payload = {
+        "number": 42,
+        "requested_reviewers": [{"login": "blairg23"}],
+    }
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_request_reviewer",
+        lambda repo, pr_number, token, reviewers: subprocess.CompletedProcess(
+            args=[], returncode=201, stdout=json.dumps(payload), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(
+        [
+            "pr",
+            "request-reviewer",
+            "--repo",
+            "acme/repo",
+            "--pr-number",
+            "42",
+            "--reviewer",
+            "blairg23",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "blairg23" in out
+    assert "42" in out


### PR DESCRIPTION
﻿## 🧾 Title
feat(pr): add pr request-reviewer subcommand (#162)

## 🧠 Description
There was no way to request a reviewer on an open PR via repo-scaffold. This adds a `pr request-reviewer` subcommand backed by the GitHub REST API.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement

## 🎯 Purpose
Allows agents and users to formally request PR reviewers without leaving repo-scaffold or calling `gh` CLI.

## 🔗 Related Issues / Epics
- **Issue:** #162
- Closes #162

## 🧪 Testing
1. Run `poetry run repo-scaffold pr request-reviewer --repo OWNER/REPO --pr-number N --reviewer USER`
2. Verify USER appears as a requested reviewer on the PR
3. Run `poetry run pytest tests/test_cli.py -k test_pr_request_reviewer -q` -- passes

## 🧰 Developer Notes
- New `pr_request_reviewer(repo, pr_number, token, reviewers)` in github_api.py calls POST /repos/{owner}/{repo}/pulls/{n}/requested_reviewers
- Accepts one or more `--reviewer USER` flags per invocation
- Unit test monkeypatches the API call and asserts the confirmed reviewer list is printed