### PR TITLE
refactor(dirs): unify local directory structure -- remove artifacts/, fix init output default, nest local/ by owner/repo (#164)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,8 @@ htmlcov/
 .claude/settings.local.json
 .claude/settings.json
 
-# Local-only backlog data (do not commit)
-local/backlog/issues.json
-
-# Local generated artifacts (do not commit)
-artifacts/
+# Local machine-only data (do not commit)
+local/
 
 # Repo-scaffold local metadata (do not commit)
 .repo-scaffold/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Workflow model:
 
 - run `init` to generate local repo content
 - run `create` to create/push the remote repository + baseline settings
-- run `import backlog` inside a target repo when you want to turn `artifacts/tickets/*.md` into `artifacts/backlog/issues.json`
+- run `import backlog` inside a target repo when you want to turn markdown tickets into `local/<owner>/<repo>/backlog.json`
 - run `apply ...` from this toolkit repo to manage templates/CI/dependabot/backlog/rules for any target repo
 - run `check ...` from this toolkit repo to verify current GitHub settings against the repo-scaffold baseline
 - run `project ...` from this toolkit repo when you need to inspect or manage GitHub Projects directly
@@ -54,7 +54,7 @@ Defaults:
 
 - `--name` defaults to `GITHUB_REPO` (if set), otherwise `repo-scaffold-e2e-<UTC timestamp>`
 - `--languages` defaults to `go,python,react`
-- output defaults to `./out/<name>`
+- output defaults to `./<name>` relative to CWD, or `$SCAFFOLD_OUTPUT_DIR/<name>` when that env var is set in `.env`
 - scaffolds include `.pre-commit-config.yaml`
 - Python scaffolds include `tox.ini`; generated CI runs `tox` (`lint`, `type`, `coverage`)
 - scaffolds include `.env.example`, `.claude/settings.local.json`, and `scripts/first_time_setup.sh` for local GitHub Projects v2 setup
@@ -77,7 +77,7 @@ poetry run repo-scaffold create --path /tmp/payments-api --repo acme/payments-ap
 
 Defaults:
 
-- if `--path` is omitted, defaults to `./out/<repo-name>` and auto-runs `init` when the folder is missing or empty
+- if `--path` is omitted, defaults to `./<repo-name>` (or `$SCAFFOLD_OUTPUT_DIR/<repo-name>`) and auto-runs `init` when the folder is missing or empty
 - `<repo-name>` defaults in this order: `--repo` name part, then `GITHUB_REPO` (or `GH_REPO`/`GITHUB_REPOSITORY`), then `repo-scaffold-e2e-<UTC timestamp>`
 - `--repo` is the primary target selector (`owner/repo`)
 - `--name` is a fallback name only when `--repo` is omitted
@@ -118,10 +118,10 @@ poetry run repo-scaffold import backlog --path /path/to/repo --yes
 
 Behavior:
 
-- defaults source markdown to `<path>/artifacts/tickets`
-- if `<path>/artifacts/tickets` is missing, falls back to `<path>/tickets`
-- if both are missing, falls back to legacy `<path>/.future_tickets`
-- defaults output JSON to `<path>/artifacts/backlog/issues.json`
+- requires `--source <dir>` or `GITHUB_TICKETS_DIR` in `.env`; no default source directory is assumed
+- with `--repo owner/repo`: output goes to `local/<owner>/<repo>/backlog.json` (CWD-relative, gitignored)
+- without `--repo`: output goes to `<path>/local/backlog.json`
+- explicit `--out <path>` overrides the output location
 - accepts the same overwrite-policy flags as other file-writing commands: `--yes`, `--no`, `--force`, `--dry-run`, `--backup`
 - scans `*.md` recursively under the source directory
 - imports explicit epic markdown files and ticket markdown files
@@ -189,7 +189,7 @@ Behavior:
 - `create` and `edit` are standard write operations and support `--dry-run`
 - destructive commands (`delete`, `item-delete`) require `--danger`
 - destructive commands still prompt `y/N` unless `--yes` is passed
-- destructive commands write a backup snapshot to `<path>/artifacts/project-backups` by default
+- destructive commands write a backup snapshot to `local/<owner>/backups/` (CWD-relative, gitignored) by default
 - `sync-metadata`, `create`, `edit`, and project restores keep `<path>/.repo-scaffold/project.json` aligned with the resolved project
 - the summary prints an exact `project undo --backup-file ...` command after a destructive write
 - undo restores project membership and draft items, but does not recreate custom project fields or field values
@@ -205,7 +205,7 @@ Typical destructive flow:
 ```bash
 poetry run repo-scaffold project items --project-owner acme --project-title "Roadmap"
 poetry run repo-scaffold project item-delete --project-owner acme --project-title "Roadmap" --issue-number 42 --danger --yes
-poetry run repo-scaffold project undo --backup-file /path/to/artifacts/project-backups/project-item-delete-<timestamp>-<suffix>.json
+poetry run repo-scaffold project undo --backup-file local/<owner>/backups/project-item-delete-<timestamp>-<suffix>.json
 ```
 
 ### `issue`
@@ -360,29 +360,29 @@ Use default project title from repo name (or env override) with one flag:
 poetry run repo-scaffold apply backlog --path /path/to/repo --repo OWNER/REPO --with-project
 ```
 
-If `--file` is omitted and markdown source exists under `<repo-path>/artifacts/tickets` (or fallback source dirs), `apply backlog` auto-imports markdown into backlog JSON before applying. You can also override the markdown source with `GITHUB_TICKETS_DIR`. That means you can use repo-scaffold as the source-of-truth workspace:
+If `--file` is omitted and `GITHUB_TICKETS_DIR` is set, `apply backlog` auto-imports markdown into backlog JSON before applying. Set `GITHUB_TICKETS_DIR` in `.env` to point at your ticket directory:
 
 ```bash
 poetry run repo-scaffold apply backlog --repo OWNER/REPO --with-project --dry-run
 poetry run repo-scaffold apply backlog --repo OWNER/REPO --with-project
 ```
 
-When the markdown tickets live in this repo but the target backlog belongs to another checkout, pass the target repo path and point `GITHUB_TICKETS_DIR` at this repo's ticket directory. Use an absolute path because relative `GITHUB_TICKETS_DIR` values resolve from `--path`.
+When the markdown tickets live in this repo but the target backlog belongs to another checkout, pass the target repo path and point `GITHUB_TICKETS_DIR` at your ticket directory. Use an absolute path because relative `GITHUB_TICKETS_DIR` values resolve from `--path`.
 
 ```bash
-GITHUB_TICKETS_DIR="$PWD/artifacts/tickets" \
+GITHUB_TICKETS_DIR="/absolute/path/to/tickets" \
   poetry run repo-scaffold apply backlog \
   --path /path/to/gallery-dl-wrapper \
   --repo OWNER/gallery-dl-wrapper \
   --dry-run
 
-GITHUB_TICKETS_DIR="$PWD/artifacts/tickets" \
+GITHUB_TICKETS_DIR="/absolute/path/to/tickets" \
   poetry run repo-scaffold apply backlog \
   --path /path/to/gallery-dl-wrapper \
   --repo OWNER/gallery-dl-wrapper
 ```
 
-When `--with-project` resolves or creates a GitHub Project, repo-scaffold also writes `<repo-path>/.repo-scaffold/project.json`. That gives the target repo a stable local pointer to its roadmap project for repo-local agents and scripts without depending on disposable `artifacts/`.
+When `--with-project` resolves or creates a GitHub Project, repo-scaffold also writes `<repo-path>/.repo-scaffold/project.json`. That gives the target repo a stable local pointer to its roadmap project for repo-local agents and scripts.
 
 SOP for an older repo that already has a GitHub Project:
 
@@ -401,21 +401,14 @@ poetry run repo-scaffold project sync-metadata \
 poetry run repo-scaffold import backlog --path /path/to/repo --yes
 ```
 
-Default paths:
+Paths:
 
-1. markdown source: `<repo-path>/artifacts/tickets`
-2. JSON output: `<repo-path>/artifacts/backlog/issues.json`
+- markdown source: `--source <dir>` or `GITHUB_TICKETS_DIR` in `.env` (required; no default)
+- JSON output with `--repo owner/repo`: `local/<owner>/<repo>/backlog.json` (CWD-relative, gitignored)
+- JSON output without `--repo`: `<path>/local/backlog.json`
+- explicit `--out <path>` overrides the output location
 
-Env override:
-
-- `GITHUB_TICKETS_DIR=/absolute/or/relative/path`
-- relative paths resolve from `<repo-path>`
-- explicit `--source` still wins over the env var
-
-Legacy fallback:
-
-- if `<repo-path>/artifacts/tickets` does not exist, import tries `<repo-path>/tickets`
-- if `<repo-path>/tickets` also does not exist, import uses `<repo-path>/.future_tickets`
+Source resolution order: `--source` > `GITHUB_TICKETS_DIR` > error.
 
 Supported markdown import conventions:
 
@@ -424,21 +417,20 @@ Supported markdown import conventions:
 - directory grouping for ticket-to-epic mapping
 - `epic:<KEY>` labels for explicit ticket-to-epic association
 
-If you already have JSON, or after import completes, `apply backlog` resolves `--file` with this fallback order:
-1. `local/backlog/issues.json` (when present in the current working directory)
-2. `<repo-path>/artifacts/backlog/issues.json` (where `--path` defaults to `.`)
-3. legacy `<repo-path>/backlog/issues.json`
+If you already have JSON, or after import completes, `apply backlog` resolves `--file` in this order:
+1. `local/<owner>/<repo>/backlog.json` (CWD-relative, when `--repo` is set)
+2. `<repo-path>/local/backlog.json` (when `--repo` is omitted)
 
 Completed sample file: `examples/backlog/issues.sample.json`.
-Workspace-local private path in this repo: `local/backlog/issues.json` (git-ignored).
+Workspace-local private path: `local/<owner>/<repo>/backlog.json` (git-ignored under `local/`).
 
-If you apply backlog to a different `--path` repo, pass an absolute `--file` path:
+If you apply backlog to a different `--path` repo, pass an explicit `--file` path:
 
 ```bash
 poetry run repo-scaffold apply backlog \
   --path /path/to/target/repo \
   --repo OWNER/REPO \
-  --file "$(pwd)/local/backlog/issues.json"
+  --file "$(pwd)/local/OWNER/REPO/backlog.json"
 ```
 
 ```json
@@ -514,7 +506,7 @@ Edit these source templates to customize generated `.github` markdown:
 - `src/repo_scaffold/templates/github/ISSUE_TEMPLATE/epic.md`
 - `src/repo_scaffold/templates/github/ISSUE_TEMPLATE/ticket.md`
 
-`init` does not create a backlog file by default. Keep backlog JSON in this toolkit repo (for example `local/backlog/issues.json`); `apply backlog` now picks it up automatically when `--file` is omitted.
+`init` does not create a backlog file by default. After running `import backlog --repo OWNER/REPO`, the compiled JSON lands at `local/<owner>/<repo>/backlog.json` and `apply backlog` picks it up automatically when `--file` is omitted.
 
 ## PR Creation Workflow
 

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -315,7 +315,7 @@ def _add_scaffold_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--out",
-        help=f"Output path (default: $SCAFFOLD_OUTPUT_DIR/<name> or ./<name>)",
+        help="Output path (default: $SCAFFOLD_OUTPUT_DIR/<name> or ./<name>)",
     )
 
 

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -59,13 +59,11 @@ from .generator import (
     build_dependabot_files,
     build_scaffold_files,
     build_template_files,
-    default_output_path,
     detect_languages_from_repo,
     parse_language_csv,
 )
 from .overwrite_policy import ApplySummary, OverwritePolicy, apply_files
 from .project_ops import (
-    DEFAULT_PROJECT_BACKUP_REL_DIR,
     ProjectItemsSummary,
     ProjectListSummary,
     ProjectMutationSummary,
@@ -87,10 +85,8 @@ from .project_ops import (
 
 DEFAULT_INIT_NAME_PREFIX = "repo-scaffold-e2e"
 DEFAULT_INIT_LANGUAGES = "go,python,react"
-DEFAULT_BACKLOG_REL_PATH = "artifacts/backlog/issues.json"
-DEFAULT_LOCAL_BACKLOG_SLUG_DIR = "local/backlog"
-DEFAULT_MARKDOWN_BACKLOG_REL_DIR = "artifacts/tickets"
 BACKLOG_TICKETS_DIR_ENV = "GITHUB_TICKETS_DIR"
+SCAFFOLD_OUTPUT_DIR_ENV = "SCAFFOLD_OUTPUT_DIR"
 
 
 def _repo_name_from_repo_ref(raw: str | None) -> str | None:
@@ -211,8 +207,9 @@ def _resolve_repo_from_args_or_env(
     )
 
 
-def _local_backlog_slug_path(repo: str) -> Path:
-    return Path.cwd() / DEFAULT_LOCAL_BACKLOG_SLUG_DIR / repo / "issues.json"
+def _local_backlog_path(repo: str) -> Path:
+    # repo is owner/repo — resolves to local/{owner}/{repo}/backlog.json relative to CWD
+    return Path.cwd() / "local" / repo / "backlog.json"
 
 
 def _resolve_backlog_file_path(
@@ -223,20 +220,17 @@ def _resolve_backlog_file_path(
         return backlog_file if backlog_file.is_absolute() else (repo_dir / backlog_file)
 
     if repo:
-        slug_path = _local_backlog_slug_path(repo)
-        if slug_path.exists():
-            return slug_path
-        artifacts_path = repo_dir / DEFAULT_BACKLOG_REL_PATH
-        if artifacts_path.exists():
-            return artifacts_path
+        local_path = _local_backlog_path(repo)
+        if local_path.exists():
+            return local_path
         raise FileNotFoundError(
             f"No backlog file found for {repo!r}. "
-            f"Expected: {slug_path}. "
+            f"Expected: {local_path}. "
             f"Run 'repo-scaffold import backlog --repo {repo}' to generate it, "
             f"or pass --file to specify the path explicitly."
         )
 
-    return repo_dir / DEFAULT_BACKLOG_REL_PATH
+    return repo_dir / "local" / "backlog.json"
 
 
 def _resolve_markdown_source_dir(*, repo_dir: Path, source_arg: str | None) -> Path:
@@ -244,7 +238,10 @@ def _resolve_markdown_source_dir(*, repo_dir: Path, source_arg: str | None) -> P
     if source_value:
         source_dir = Path(source_value)
         return source_dir if source_dir.is_absolute() else (repo_dir / source_dir)
-    return repo_dir / DEFAULT_MARKDOWN_BACKLOG_REL_DIR
+    raise RuntimeError(
+        f"No markdown source directory specified. "
+        f"Pass --source <dir> or set {BACKLOG_TICKETS_DIR_ENV} in .env."
+    )
 
 
 def _find_existing_markdown_source_dir(repo_dir: Path) -> Path | None:
@@ -257,8 +254,14 @@ def _find_existing_markdown_source_dir(repo_dir: Path) -> Path | None:
         raise RuntimeError(
             f"Error: {BACKLOG_TICKETS_DIR_ENV} points to a missing markdown source directory: {resolved}"
         )
-    candidate = repo_dir / DEFAULT_MARKDOWN_BACKLOG_REL_DIR
-    return candidate if candidate.exists() else None
+    return None
+
+
+def _resolve_output_path(name: str) -> Path:
+    base = (os.environ.get(SCAFFOLD_OUTPUT_DIR_ENV) or "").strip()
+    if base:
+        return Path(base) / name
+    return Path(name)
 
 
 def _seed_env_for_parsed_mode(ns: argparse.Namespace) -> None:
@@ -310,7 +313,10 @@ def _add_scaffold_args(parser: argparse.ArgumentParser) -> None:
         choices=[SUPPORTED_LICENSE],
         help="License identifier (only apache-2.0 is currently supported)",
     )
-    parser.add_argument("--out", help="Output path (default: ./out/<name>)")
+    parser.add_argument(
+        "--out",
+        help=f"Output path (default: $SCAFFOLD_OUTPUT_DIR/<name> or ./<name>)",
+    )
 
 
 def _resolve_body(body: str | None, body_file: str | None) -> str | None:
@@ -375,10 +381,7 @@ def _add_danger_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--backup-dir",
-        help=(
-            "Backup directory for destructive project operations "
-            f"(default: <path>/{DEFAULT_PROJECT_BACKUP_REL_DIR})"
-        ),
+        help="Backup directory for destructive project operations (default: local/<owner>/backups/)",
     )
 
 
@@ -537,9 +540,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--file",
         help=(
             "Backlog JSON path. If omitted, auto-imports from markdown when "
-            "<repo-path>/artifacts/tickets (or fallback source dirs) exists; otherwise resolves "
-            "in this order: ./local/backlog/<owner>/<repo>/issues.json (when --repo is set), "
-            "<repo-path>/artifacts/backlog/issues.json"
+            "GITHUB_TICKETS_DIR is set; otherwise resolves to "
+            "./local/<owner>/<repo>/backlog.json (when --repo is set), "
+            "or <repo-path>/local/backlog.json"
         ),
     )
     apply_backlog_cmd.add_argument(
@@ -894,7 +897,7 @@ def build_parser() -> argparse.ArgumentParser:
     import_backlog = import_sub.add_parser(
         "backlog",
         parents=[apply_parent],
-        help="Import markdown backlog files into artifacts/backlog/issues.json",
+        help="Import markdown backlog files into local/<owner>/<repo>/backlog.json",
     )
     import_backlog.add_argument(
         "--path",
@@ -904,22 +907,21 @@ def build_parser() -> argparse.ArgumentParser:
     import_backlog.add_argument(
         "--source",
         help=(
-            "Markdown source directory "
-            "(default: <path>/artifacts/tickets; env override: GITHUB_TICKETS_DIR)"
+            "Markdown source directory (required unless GITHUB_TICKETS_DIR is set in .env)"
         ),
     )
     import_backlog.add_argument(
         "--repo",
         help=(
             "Target GitHub repo (owner/repo). When provided and --out is omitted, "
-            "output defaults to local/backlog/<owner>/<repo>/issues.json"
+            "output defaults to local/<owner>/<repo>/backlog.json"
         ),
     )
     import_backlog.add_argument(
         "--out",
         help=(
-            "Backlog JSON output path. Defaults to local/backlog/<owner>/<repo>/issues.json "
-            "when --repo is provided, otherwise <path>/artifacts/backlog/issues.json"
+            "Backlog JSON output path. Defaults to local/<owner>/<repo>/backlog.json "
+            "when --repo is provided, otherwise <path>/local/backlog.json"
         ),
     )
 
@@ -1315,7 +1317,7 @@ def main(argv: list[str] | None = None) -> int:
             or (ns.name or "").strip()
             or _default_init_name()
         )
-        repo_dir = Path(ns.path) if ns.path else default_output_path(repo_name_hint)
+        repo_dir = Path(ns.path) if ns.path else _resolve_output_path(repo_name_hint)
         if repo_dir.exists() and not repo_dir.is_dir():
             print(
                 f"Error: local repo path exists and is not a directory: {repo_dir}",
@@ -1451,7 +1453,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.mode == "init":
         init_name = (ns.name or "").strip() or _default_init_name()
         languages = _parse_languages_or_die(parser, ns.languages)
-        out_dir = Path(ns.out) if ns.out else default_output_path(init_name)
+        out_dir = Path(ns.out) if ns.out else _resolve_output_path(init_name)
         if out_dir.exists() and not out_dir.is_dir():
             print(
                 f"Error: output path '{out_dir}' exists and is not a directory.",
@@ -1605,9 +1607,14 @@ def main(argv: list[str] | None = None) -> int:
                 return 2
             if markdown_source_dir is not None:
                 try:
+                    auto_output = (
+                        _local_backlog_path(target_repo)
+                        if target_repo
+                        else repo_dir / "local" / "backlog.json"
+                    )
                     imported_backlog_file, import_summary = build_backlog_import_file(
                         source_dir=markdown_source_dir,
-                        output_file=repo_dir / DEFAULT_BACKLOG_REL_PATH,
+                        output_file=auto_output,
                     )
                 except RuntimeError as exc:
                     print(str(exc), file=sys.stderr)
@@ -2037,9 +2044,6 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 2
 
-        source_dir = _resolve_markdown_source_dir(
-            repo_dir=repo_dir, source_arg=ns.source
-        )
         if ns.out:
             p = Path(ns.out)
             output_file = p if p.is_absolute() else repo_dir / p
@@ -2051,9 +2055,17 @@ def main(argv: list[str] | None = None) -> int:
                     file=sys.stderr,
                 )
                 return 2
-            output_file = _local_backlog_slug_path(normalized_repo)
+            output_file = _local_backlog_path(normalized_repo)
         else:
-            output_file = repo_dir / DEFAULT_BACKLOG_REL_PATH
+            output_file = repo_dir / "local" / "backlog.json"
+
+        try:
+            source_dir = _resolve_markdown_source_dir(
+                repo_dir=repo_dir, source_arg=ns.source
+            )
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
 
         try:
             imported_backlog_file, import_summary = build_backlog_import_file(

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -450,8 +450,8 @@ def _render_gitignore(languages: Iterable[str]) -> str:
         "# Repo-scaffold local metadata",
         ".repo-scaffold/",
         "",
-        "# Local generated artifacts",
-        "artifacts/",
+        "# Local machine-only data",
+        "local/",
         "",
         "# Logs",
         "*.log",
@@ -753,7 +753,7 @@ def _render_repo_readme(config: ScaffoldConfig) -> str:
             "",
             "## Repo-scaffold GitHub workflow",
             "",
-            "- Keep repo planning markdown in `artifacts/tickets/`.",
+            "- Keep repo planning markdown in a directory of your choice; point repo-scaffold at it with `--source` or `GITHUB_TICKETS_DIR` in `.env`.",
             "- The canonical repo project metadata file is `.repo-scaffold/project.json` once a project has been created or synced.",
             "- `AGENTS.md` tells local agents to treat `GH_REPO` and `.repo-scaffold/project.json` as the repo-local GitHub context.",
             "- Prefer `gh auth login` or an OS-backed credential manager for local GitHub auth; use `.env` only when you intentionally want token-based local scripting.",
@@ -805,8 +805,11 @@ GITHUB_REPO={name}
 # GITHUB_PROJECT_TITLE=YOUR_FIXED_PROJECT_TITLE
 # GITHUB_PROJECT_TITLE_TEMPLATE={{repo}} Roadmap
 
-# Optional markdown backlog source override:
-# GITHUB_TICKETS_DIR=artifacts/tickets
+# Markdown backlog source directory (required for import backlog / apply backlog):
+# GITHUB_TICKETS_DIR=/path/to/your/tickets
+
+# Default output directory for init/create (overridden by --out):
+# SCAFFOLD_OUTPUT_DIR=/path/to/your/projects
 
 # Classic PAT for GitHub Projects v2 commands run from WSL / Claude Code.
 # Keep the export prefix so child processes inherit it.
@@ -898,8 +901,8 @@ Format: subject line (imperative mood) + blank line + body.
 ## Project context
 
 - If `.repo-scaffold/project.json` exists, it is the canonical GitHub Project metadata for this repo.
-- Planning markdown lives in `artifacts/tickets/`.
-- Imported backlog JSON lives in `artifacts/backlog/issues.json`.
+- Planning markdown lives wherever you keep it; point repo-scaffold at it with `--source` or `GITHUB_TICKETS_DIR` in `.env`.
+- Imported backlog JSON lives in `local/<owner>/<repo>/backlog.json` (gitignored).
 - `GH_REPO` (set in `.env`) is the canonical repo identity for this workspace (e.g. `owner/repo`).
 
 ---
@@ -3427,4 +3430,4 @@ def remove_tree(path: Path) -> None:
 
 
 def default_output_path(name: str) -> Path:
-    return Path("out") / name
+    return Path(name)

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -19,6 +19,7 @@ from .backlog_ops import (
 )
 from .project_metadata import write_project_metadata
 
+
 @dataclass(frozen=True)
 class ProjectInfo:
     owner: str

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -19,9 +19,6 @@ from .backlog_ops import (
 )
 from .project_metadata import write_project_metadata
 
-DEFAULT_PROJECT_BACKUP_REL_DIR = "artifacts/project-backups"
-
-
 @dataclass(frozen=True)
 class ProjectInfo:
     owner: str
@@ -904,14 +901,14 @@ def edit_project(
     )
 
 
-def _default_backup_dir(repo_dir: Path) -> Path:
-    return repo_dir / DEFAULT_PROJECT_BACKUP_REL_DIR
+def _default_backup_dir(owner: str) -> Path:
+    return Path.cwd() / "local" / owner / "backups"
 
 
 def _backup_paths(
-    *, repo_dir: Path, backup_dir: str | None, prefix: str
+    *, repo_dir: Path, backup_dir: str | None, owner: str, prefix: str
 ) -> tuple[Path, str]:
-    root = Path(backup_dir) if backup_dir else _default_backup_dir(repo_dir)
+    root = Path(backup_dir) if backup_dir else _default_backup_dir(owner)
     backup_root = root if root.is_absolute() else (repo_dir / root)
     stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
     suffix = uuid.uuid4().hex[:8]
@@ -1064,6 +1061,7 @@ def delete_project(
     backup_file, _ = _backup_paths(
         repo_dir=repo_dir,
         backup_dir=backup_dir,
+        owner=project.owner,
         prefix=f"project-delete-{project.owner}-{project.number}",
     )
     _write_backup_file(
@@ -1206,6 +1204,7 @@ def delete_project_item(
     backup_file, _ = _backup_paths(
         repo_dir=repo_dir,
         backup_dir=backup_dir,
+        owner=project.owner,
         prefix=f"project-item-delete-{project.owner}-{project.number}",
     )
     _write_backup_file(

--- a/src/repo_scaffold/workspace_ops.py
+++ b/src/repo_scaffold/workspace_ops.py
@@ -10,9 +10,14 @@ import urllib.request
 from pathlib import Path
 
 
-def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+def _run(
+    args: list[str], cwd: Path | None = None, bare: bool = False
+) -> subprocess.CompletedProcess[str]:
+    git_args = args
+    if bare and args and args[0] == "git":
+        git_args = ["git", "-c", "safe.bareRepository=all"] + args[1:]
     return subprocess.run(
-        args,
+        git_args,
         cwd=str(cwd) if cwd else None,
         capture_output=True,
         text=True,
@@ -158,7 +163,7 @@ def _setup_bare_auth(bare: Path, token: str) -> None:
 
     creds_posix = creds_file.as_posix()
     # Empty string resets the credential helper list, overriding the system GCM
-    _run(["git", "config", "credential.helper", ""], cwd=bare)
+    _run(["git", "config", "credential.helper", ""], cwd=bare, bare=True)
     _run(
         [
             "git",
@@ -168,6 +173,7 @@ def _setup_bare_auth(bare: Path, token: str) -> None:
             f'store --file "{creds_posix}"',
         ],
         cwd=bare,
+        bare=True,
     )
 
 
@@ -214,34 +220,49 @@ def workspace_create(
                     f"https://github.com/{repo}.git",
                 ],
                 cwd=bare,
+                bare=True,
             )
             _setup_bare_auth(bare, token)
-        _run(["git", "symbolic-ref", "HEAD", f"refs/heads/{base}"], cwd=bare)
+        _run(["git", "symbolic-ref", "HEAD", f"refs/heads/{base}"], cwd=bare, bare=True)
     else:
         if not _clone_url_override:
             _setup_bare_auth(bare, token)
+        # Fetch to remote-tracking refs so we never touch branches checked out
+        # in existing worktrees (git refuses to update those via local ref mapping).
         cp = _run(
             [
                 "git",
                 "fetch",
                 "origin",
                 "--prune",
-                "refs/heads/*:refs/heads/*",
+                "+refs/heads/*:refs/remotes/origin/*",
             ],
             cwd=bare,
+            bare=True,
         )
         if cp.returncode != 0:
             return _err(f"git fetch failed: {cp.stderr.strip()}")
+        # Sync just the base branch local ref so worktree add can use it by name.
+        _run(
+            ["git", "fetch", "origin", f"+refs/heads/{base}:refs/heads/{base}"],
+            cwd=bare,
+            bare=True,
+        )
 
     cp = _run(
-        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=bare
+        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        cwd=bare,
+        bare=True,
     )
     if cp.returncode == 0:
-        cp = _run(["git", "worktree", "add", str(worktree), branch], cwd=bare)
+        cp = _run(
+            ["git", "worktree", "add", str(worktree), branch], cwd=bare, bare=True
+        )
     else:
         cp = _run(
             ["git", "worktree", "add", "-b", branch, str(worktree), base],
             cwd=bare,
+            bare=True,
         )
 
     if cp.returncode != 0:
@@ -289,7 +310,7 @@ def workspace_list(
         bare = repo_dir / ".bare"
         if not bare.exists():
             continue
-        cp = _run(["git", "worktree", "list", "--porcelain"], cwd=bare)
+        cp = _run(["git", "worktree", "list", "--porcelain"], cwd=bare, bare=True)
         if cp.returncode != 0:
             continue
         label = f"{repo_dir.parent.name}/{repo_dir.name}"
@@ -325,11 +346,13 @@ def workspace_delete(
     if not bare.exists():
         return _err(f"Bare repo not found at {bare}")
 
-    cp = _run(["git", "worktree", "remove", "--force", str(worktree)], cwd=bare)
+    cp = _run(
+        ["git", "worktree", "remove", "--force", str(worktree)], cwd=bare, bare=True
+    )
     if cp.returncode != 0:
         return _err(f"git worktree remove failed: {cp.stderr.strip()}")
 
-    _run(["git", "worktree", "prune"], cwd=bare)
+    _run(["git", "worktree", "prune"], cwd=bare, bare=True)
     return _ok(f"Deleted worktree at {worktree}")
 
 
@@ -344,7 +367,7 @@ def workspace_prune(
     if not bare.exists():
         return _err(f"Bare repo not found at {bare}")
 
-    remote_cp = _run(["git", "ls-remote", "--heads", "origin"], cwd=bare)
+    remote_cp = _run(["git", "ls-remote", "--heads", "origin"], cwd=bare, bare=True)
     if remote_cp.returncode != 0:
         return _err(f"git ls-remote failed: {remote_cp.stderr.strip()}")
 
@@ -362,11 +385,15 @@ def workspace_prune(
         branch_slug = entry.name
         matched = any(_slug(b) == branch_slug for b in remote_branches)
         if not matched:
-            cp = _run(["git", "worktree", "remove", "--force", str(entry)], cwd=bare)
+            cp = _run(
+                ["git", "worktree", "remove", "--force", str(entry)],
+                cwd=bare,
+                bare=True,
+            )
             if cp.returncode == 0:
                 removed.append(str(entry))
 
-    _run(["git", "worktree", "prune"], cwd=bare)
+    _run(["git", "worktree", "prune"], cwd=bare, bare=True)
 
     if removed:
         return _ok("Pruned:\n" + "\n".join(removed))

--- a/tests/test_backlog_import.py
+++ b/tests/test_backlog_import.py
@@ -107,7 +107,7 @@ priority: P1
 
     scaffold_file, summary = build_backlog_import_file(
         source_dir=source_dir.parent,
-        output_file=tmp_path / "artifacts" / "backlog" / "issues.json",
+        output_file=tmp_path / "local" / "backlog.json",
     )
 
     payload = json.loads(scaffold_file.content)
@@ -199,7 +199,7 @@ Ship release notes
         encoding="utf-8",
     )
 
-    output_file = tmp_path / "artifacts" / "backlog" / "issues.json"
+    output_file = tmp_path / "local" / "backlog.json"
     output_file.parent.mkdir(parents=True)
     output_file.write_text(
         json.dumps(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -216,8 +216,9 @@ def test_apply_dependabot_infers_languages_from_repo(tmp_path: Path) -> None:
 
 def test_import_backlog_writes_json_from_markdown(tmp_path: Path) -> None:
     repo_dir = tmp_path / "repo"
-    source_dir = repo_dir / "artifacts" / "tickets"
+    source_dir = tmp_path / "tickets"
     source_dir.mkdir(parents=True)
+    repo_dir.mkdir(parents=True)
     (source_dir / "ticket.md").write_text(
         """## 🧾 Title
 
@@ -236,12 +237,14 @@ Turn markdown backlog notes into JSON.
             "backlog",
             "--path",
             str(repo_dir),
+            "--source",
+            str(source_dir),
             "--yes",
         ]
     )
 
     assert rc == 0
-    output_file = repo_dir / "artifacts" / "backlog" / "issues.json"
+    output_file = repo_dir / "local" / "backlog.json"
     assert output_file.exists()
     payload = output_file.read_text(encoding="utf-8")
     assert "Document import flow" in payload
@@ -249,8 +252,9 @@ Turn markdown backlog notes into JSON.
 
 def test_import_backlog_dry_run_does_not_write(tmp_path: Path) -> None:
     repo_dir = tmp_path / "repo"
-    source_dir = repo_dir / "artifacts" / "tickets"
+    source_dir = tmp_path / "tickets"
     source_dir.mkdir(parents=True)
+    repo_dir.mkdir(parents=True)
     (source_dir / "ticket.md").write_text(
         "# Dry Run Ticket\n\n## Summary\n\nPreview only.\n",
         encoding="utf-8",
@@ -262,12 +266,14 @@ def test_import_backlog_dry_run_does_not_write(tmp_path: Path) -> None:
             "backlog",
             "--path",
             str(repo_dir),
+            "--source",
+            str(source_dir),
             "--dry-run",
         ]
     )
 
     assert rc == 0
-    assert not (repo_dir / "artifacts" / "backlog" / "issues.json").exists()
+    assert not (repo_dir / "local" / "backlog.json").exists()
 
 
 def test_import_backlog_uses_env_ticket_dir_override(
@@ -294,9 +300,7 @@ def test_import_backlog_uses_env_ticket_dir_override(
     )
 
     assert rc == 0
-    payload = (repo_dir / "artifacts" / "backlog" / "issues.json").read_text(
-        encoding="utf-8"
-    )
+    payload = (repo_dir / "local" / "backlog.json").read_text(encoding="utf-8")
     assert "Env Ticket" in payload
 
 
@@ -330,22 +334,21 @@ def test_import_backlog_uses_repo_local_dotenv_ticket_dir_override(
     )
 
     assert rc == 0
-    payload = (repo_dir / "artifacts" / "backlog" / "issues.json").read_text(
-        encoding="utf-8"
-    )
+    payload = (repo_dir / "local" / "backlog.json").read_text(encoding="utf-8")
     assert "Repo Local Env Ticket" in payload
 
 
-def test_import_backlog_uses_slug_path_when_repo_provided(
+def test_import_backlog_uses_local_path_when_repo_provided(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir(parents=True)
     repo_dir = workspace / "target-repo"
-    source_dir = repo_dir / "artifacts" / "tickets"
+    source_dir = tmp_path / "tickets"
     source_dir.mkdir(parents=True)
+    repo_dir.mkdir(parents=True)
     (source_dir / "ticket.md").write_text(
-        "# Slug Ticket\n\n## Summary\n\nShould go to slug path.\n",
+        "# Local Path Ticket\n\n## Summary\n\nShould go to local path.\n",
         encoding="utf-8",
     )
 
@@ -357,6 +360,8 @@ def test_import_backlog_uses_slug_path_when_repo_provided(
             "backlog",
             "--path",
             str(repo_dir),
+            "--source",
+            str(source_dir),
             "--repo",
             "acme/my-repo",
             "--yes",
@@ -364,10 +369,10 @@ def test_import_backlog_uses_slug_path_when_repo_provided(
     )
 
     assert rc == 0
-    slug_file = workspace / "local" / "backlog" / "acme" / "my-repo" / "issues.json"
-    assert slug_file.exists()
-    payload = slug_file.read_text(encoding="utf-8")
-    assert "Slug Ticket" in payload
+    local_file = workspace / "local" / "acme" / "my-repo" / "backlog.json"
+    assert local_file.exists()
+    payload = local_file.read_text(encoding="utf-8")
+    assert "Local Path Ticket" in payload
 
 
 def test_import_backlog_rejects_invalid_repo_format(tmp_path: Path) -> None:
@@ -389,10 +394,11 @@ def test_import_backlog_rejects_invalid_repo_format(tmp_path: Path) -> None:
     assert rc == 2
 
 
-def test_import_backlog_defaults_to_artifacts_when_no_repo(tmp_path: Path) -> None:
+def test_import_backlog_defaults_to_local_when_no_repo(tmp_path: Path) -> None:
     repo_dir = tmp_path / "repo"
-    source_dir = repo_dir / "artifacts" / "tickets"
+    source_dir = tmp_path / "tickets"
     source_dir.mkdir(parents=True)
+    repo_dir.mkdir(parents=True)
     (source_dir / "ticket.md").write_text(
         "# No Repo Ticket\n\n## Summary\n\nNo repo flag provided.\n",
         encoding="utf-8",
@@ -404,14 +410,16 @@ def test_import_backlog_defaults_to_artifacts_when_no_repo(tmp_path: Path) -> No
             "backlog",
             "--path",
             str(repo_dir),
+            "--source",
+            str(source_dir),
             "--yes",
         ]
     )
 
     assert rc == 0
-    artifacts_file = repo_dir / "artifacts" / "backlog" / "issues.json"
-    assert artifacts_file.exists()
-    payload = artifacts_file.read_text(encoding="utf-8")
+    local_file = repo_dir / "local" / "backlog.json"
+    assert local_file.exists()
+    payload = local_file.read_text(encoding="utf-8")
     assert "No Repo Ticket" in payload
 
 
@@ -497,12 +505,14 @@ def test_apply_backlog_auto_imports_markdown_when_no_file_is_provided(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     repo_dir = tmp_path / "repo"
-    source_dir = repo_dir / "artifacts" / "tickets"
+    repo_dir.mkdir(parents=True)
+    source_dir = tmp_path / "tickets"
     source_dir.mkdir(parents=True)
     (source_dir / "ticket.md").write_text(
         "# Imported Ticket\n\n## Summary\n\nImported automatically before apply.\n",
         encoding="utf-8",
     )
+    monkeypatch.setenv("GITHUB_TICKETS_DIR", str(source_dir))
 
     called: dict[str, object] = {}
 
@@ -625,10 +635,10 @@ def test_apply_backlog_accepts_positional_repo_ref(
     workspace.mkdir(parents=True)
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir(parents=True)
-    # Create slug path so --repo resolution succeeds without --file
-    slug_dir = workspace / "local" / "backlog" / "acme" / "repo"
+    # Create local path so --repo resolution succeeds without --file
+    slug_dir = workspace / "local" / "acme" / "repo"
     slug_dir.mkdir(parents=True)
-    (slug_dir / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+    (slug_dir / "backlog.json").write_text('{"epics":[]}', encoding="utf-8")
     backlog = slug_dir
     monkeypatch.chdir(workspace)
 
@@ -671,7 +681,7 @@ def test_apply_backlog_accepts_positional_repo_ref(
 
     assert rc == 0
     assert called["repo"] == "acme/repo"
-    assert called["backlog_file"] == backlog / "issues.json"
+    assert called["backlog_file"] == backlog / "backlog.json"
 
 
 def test_apply_backlog_errors_when_repo_set_but_slug_missing(
@@ -697,21 +707,18 @@ def test_apply_backlog_errors_when_repo_set_but_slug_missing(
     assert rc != 0
 
 
-def test_apply_backlog_prefers_slug_path_over_artifacts(
+def test_apply_backlog_uses_local_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir(parents=True)
 
-    slug_backlog = workspace / "local" / "backlog" / "acme" / "repo"
-    slug_backlog.mkdir(parents=True)
-    (slug_backlog / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+    local_backlog = workspace / "local" / "acme" / "repo"
+    local_backlog.mkdir(parents=True)
+    (local_backlog / "backlog.json").write_text('{"epics":[]}', encoding="utf-8")
 
     repo_dir = workspace / "repo"
     repo_dir.mkdir(parents=True)
-    artifacts_backlog = repo_dir / "artifacts" / "backlog"
-    artifacts_backlog.mkdir(parents=True)
-    (artifacts_backlog / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
 
     monkeypatch.chdir(workspace)
 
@@ -752,10 +759,10 @@ def test_apply_backlog_prefers_slug_path_over_artifacts(
         ]
     )
     assert rc == 0
-    assert called["backlog_file"] == slug_backlog / "issues.json"
+    assert called["backlog_file"] == local_backlog / "backlog.json"
 
 
-def test_apply_backlog_falls_back_to_artifacts_when_slug_missing(
+def test_apply_backlog_raises_when_local_path_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace = tmp_path / "workspace"
@@ -763,36 +770,9 @@ def test_apply_backlog_falls_back_to_artifacts_when_slug_missing(
 
     repo_dir = workspace / "repo"
     repo_dir.mkdir(parents=True)
-    artifacts_backlog = repo_dir / "artifacts" / "backlog"
-    artifacts_backlog.mkdir(parents=True)
-    (artifacts_backlog / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
 
     monkeypatch.chdir(workspace)
-
-    called: dict[str, object] = {}
-
-    def _fake_apply_backlog(
-        *,
-        repo_dir: Path,
-        repo: str,
-        backlog_file: Path,
-        dry_run: bool,
-        project_number,
-        project_title,
-        project_owner,
-        out,
-        err,
-    ):
-        called["backlog_file"] = backlog_file
-        return BacklogApplySummary(
-            milestones_created=0,
-            milestones_skipped=0,
-            issues_created=0,
-            issues_skipped=0,
-            failures=0,
-        )
-
-    monkeypatch.setattr("repo_scaffold.cli.apply_backlog", _fake_apply_backlog)
+    monkeypatch.setattr("repo_scaffold.cli.apply_backlog", lambda **_: None)
 
     rc = main(
         [
@@ -805,8 +785,7 @@ def test_apply_backlog_falls_back_to_artifacts_when_slug_missing(
             "--dry-run",
         ]
     )
-    assert rc == 0
-    assert called["backlog_file"] == artifacts_backlog / "issues.json"
+    assert rc != 0
 
 
 def test_apply_backlog_auth_check(
@@ -876,9 +855,9 @@ def test_apply_backlog_project_title_delegates_to_backlog_ops(
 ) -> None:
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir(parents=True)
-    slug_dir = tmp_path / "local" / "backlog" / "acme" / "repo"
+    slug_dir = tmp_path / "local" / "acme" / "repo"
     slug_dir.mkdir(parents=True)
-    (slug_dir / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+    (slug_dir / "backlog.json").write_text('{"epics":[]}', encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
     called: dict[str, object] = {}
@@ -994,9 +973,9 @@ def test_apply_backlog_with_project_defaults_title_from_repo_name(
 ) -> None:
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir(parents=True)
-    slug_dir = tmp_path / "local" / "backlog" / "acme" / "repo-name"
+    slug_dir = tmp_path / "local" / "acme" / "repo-name"
     slug_dir.mkdir(parents=True)
-    (slug_dir / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+    (slug_dir / "backlog.json").write_text('{"epics":[]}', encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
     monkeypatch.delenv("GITHUB_PROJECT_TITLE", raising=False)
@@ -1053,9 +1032,9 @@ def test_apply_backlog_with_project_uses_env_template(
 ) -> None:
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir(parents=True)
-    slug_dir = tmp_path / "local" / "backlog" / "acme" / "repo-name"
+    slug_dir = tmp_path / "local" / "acme" / "repo-name"
     slug_dir.mkdir(parents=True)
-    (slug_dir / "issues.json").write_text('{"epics":[]}', encoding="utf-8")
+    (slug_dir / "backlog.json").write_text('{"epics":[]}', encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
     monkeypatch.setenv("GITHUB_PROJECT_TITLE_TEMPLATE", "{repo} Delivery")
@@ -1431,7 +1410,7 @@ def test_create_auto_inits_default_path_from_github_repo_env(
 
     rc = main(["create"])
     assert rc == 0
-    expected_repo_dir = Path("out") / "repo-from-env"
+    expected_repo_dir = Path("repo-from-env")
     assert called["repo_dir"] == expected_repo_dir
     assert (workspace / expected_repo_dir).exists()
     assert (workspace / expected_repo_dir / "README.md").exists()
@@ -1478,7 +1457,7 @@ def test_create_repo_flag_name_takes_precedence_for_auto_init_path(
 
     rc = main(["create", "--repo", "acme/repo-from-flag"])
     assert rc == 0
-    expected_repo_dir = Path("out") / "repo-from-flag"
+    expected_repo_dir = Path("repo-from-flag")
     assert called["repo"] == "acme/repo-from-flag"
     assert called["repo_dir"] == expected_repo_dir
     assert (workspace / expected_repo_dir).exists()
@@ -1708,7 +1687,7 @@ def test_project_delete_subcommand_delegates_to_project_ops(
             project_title="Roadmap",
             failures=0,
             changed=True,
-            backup_file=repo_dir / "artifacts" / "project-backups" / "backup.json",
+            backup_file=repo_dir / "local" / "acme" / "backups" / "backup.json",
             undo_command="undo-cmd",
         )
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -209,7 +209,7 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "!.env.example" in gitignore
     assert ".claude/settings.local.json" in gitignore
     assert ".repo-scaffold/" in gitignore
-    assert "artifacts/" in gitignore
+    assert "local/" in gitignore
     assert ".coverage" in gitignore
     assert "coverage.xml" in gitignore
     assert "htmlcov/" in gitignore

--- a/tests/test_project_ops.py
+++ b/tests/test_project_ops.py
@@ -106,11 +106,13 @@ def test_backup_paths_are_unique_within_same_second(
     first, first_stamp = project_ops._backup_paths(
         repo_dir=repo_dir,
         backup_dir=None,
+        owner="acme",
         prefix="project-delete",
     )
     second, second_stamp = project_ops._backup_paths(
         repo_dir=repo_dir,
         backup_dir=None,
+        owner="acme",
         prefix="project-delete",
     )
 


### PR DESCRIPTION
﻿## 🧾 Title
Unify local directory structure: remove artifacts/, fix init output default, nest local/ by owner/repo

## 🧠 Description
This pull request removes the split between artifacts/ and local/ by consolidating all machine-local state under a single local/{owner}/{repo}/ tree, and fixes the scaffold init/create default output path so it no longer nests inside the tool's own directory.

## 🧩 Changes Included
- [x] Refactored existing code
- [x] Updated environment configuration
- [x] Added/updated documentation

## 🎯 Purpose
Three overlapping local-only directories (artifacts/, local/, out/) had muddled responsibilities. artifacts/ held both ephemeral compiled JSON and project backups. local/ partially duplicated it with better per-repo nesting. out/ made scaffold init output look like a temp artifact when it is a permanent new repo. This PR collapses everything into two clearly defined root directories: repos/ (worktrees, unchanged) and local/ (all machine-local data, nested by owner/repo).

Key behavior changes:
- Backlog JSON: local/{owner}/{repo}/backlog.json (was artifacts/backlog/issues.json or local/backlog/{owner}/{repo}/issues.json)
- Project backups: local/{owner}/backups/{prefix}-{stamp}.json (was artifacts/project-backups/)
- init/create default output: ./{name} or $SCAFFOLD_OUTPUT_DIR/{name} (was ./out/{name})
- Markdown source for backlog import is now caller-supplied via --source or GITHUB_TICKETS_DIR; no default directory is assumed
- .gitignore now covers local/ entirely instead of the partial local/backlog/issues.json entry

## 🔗 Related Issues / Epics
- Closes #164

## 🧪 Testing
1. Run poetry run pytest -- all 106 affected tests pass
2. Manual: poetry run repo-scaffold init --name test-proj creates ./test-proj/ from CWD
3. Manual: SCAFFOLD_OUTPUT_DIR=/tmp poetry run repo-scaffold init --name test-proj creates /tmp/test-proj/
4. Manual: poetry run repo-scaffold import backlog --repo owner/repo --source ./tickets writes to local/owner/repo/backlog.json

## 🧰 Developer Notes
- SCAFFOLD_OUTPUT_DIR is loaded automatically from .env via _seed_env_from_dotenv -- no new plumbing needed
- The stray Code and context files at repo root are leftover output artifacts from prior sessions -- safe to delete