### PR TITLE
feat(label): add repo label management commands and standard preset (#166)

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -28,6 +28,10 @@ from .github_api import (
     issue_label,
     issue_list,
     issue_update,
+    label_apply_preset,
+    label_create,
+    label_delete,
+    label_list,
     pr_annotations,
     pr_checks,
     pr_comment,
@@ -1198,6 +1202,31 @@ def build_parser() -> argparse.ArgumentParser:
     branch_delete_cmd.add_argument("--repo", required=True)
     branch_delete_cmd.add_argument("--name", required=True, help="Branch to delete")
 
+    label_cmd = subparsers.add_parser("label", help="Manage repository labels")
+    label_sub = label_cmd.add_subparsers(dest="label_command", required=True)
+
+    label_list_cmd = label_sub.add_parser("list", help="List all labels in a repo")
+    label_list_cmd.add_argument("--repo", required=True)
+    label_list_cmd.add_argument("--json", action="store_true")
+
+    label_create_cmd = label_sub.add_parser("create", help="Create a label in a repo")
+    label_create_cmd.add_argument("--repo", required=True)
+    label_create_cmd.add_argument("--name", required=True, help="Label name")
+    label_create_cmd.add_argument(
+        "--color", required=True, help="6-char hex color (without #)"
+    )
+    label_create_cmd.add_argument("--description", default="", help="Label description")
+
+    label_delete_cmd = label_sub.add_parser("delete", help="Delete a label from a repo")
+    label_delete_cmd.add_argument("--repo", required=True)
+    label_delete_cmd.add_argument("--name", required=True, help="Label name to delete")
+
+    label_preset_cmd = label_sub.add_parser(
+        "apply-preset",
+        help="Idempotently create the standard label set on a repo",
+    )
+    label_preset_cmd.add_argument("--repo", required=True)
+
     workspace_cmd = subparsers.add_parser(
         "workspace", help="Manage per-branch git worktrees under repos/"
     )
@@ -1250,6 +1279,7 @@ def _normalize_argv(argv: list[str] | None) -> list[str]:
         "check",
         "delete",
         "import",
+        "label",
         "project",
         "issue",
         "pr",
@@ -2575,6 +2605,62 @@ def main(argv: list[str] | None = None) -> int:
                 print(cp.stderr.strip() or "Failed deleting branch.", file=sys.stderr)
                 return 1
             print(f"Branch deleted: {ns.name}")
+            return 0
+
+    if ns.mode == "label":
+        import json as _json
+
+        target_repo, repo_error = _resolve_repo_from_args_or_env(
+            repo=ns.repo, fallback_name=None
+        )
+        if repo_error:
+            print(repo_error, file=sys.stderr)
+            return 2
+        assert target_repo is not None
+        token = token_from_repo(Path.cwd()) or ""
+
+        if ns.label_command == "list":
+            cp = label_list(target_repo, token)
+            if cp.returncode not in (0, 200):
+                print(cp.stderr.strip() or "Failed listing labels.", file=sys.stderr)
+                return 1
+            labels = _json.loads(cp.stdout)
+            if getattr(ns, "json", False):
+                print(cp.stdout)
+                return 0
+            for lbl in labels:
+                desc = f" -- {lbl['description']}" if lbl.get("description") else ""
+                print(f"  #{lbl['color']}  {lbl['name']}{desc}")
+            print(f"\nTotal: {len(labels)}")
+            return 0
+
+        if ns.label_command == "create":
+            cp = label_create(target_repo, ns.name, ns.color, token, ns.description)
+            if cp.returncode not in (0, 200, 201):
+                print(cp.stderr.strip() or "Failed creating label.", file=sys.stderr)
+                return 1
+            print(f"Label created: {ns.name}")
+            return 0
+
+        if ns.label_command == "delete":
+            cp = label_delete(target_repo, ns.name, token)
+            if cp.returncode not in (0, 200, 204):
+                print(cp.stderr.strip() or "Failed deleting label.", file=sys.stderr)
+                return 1
+            print(f"Label deleted: {ns.name}")
+            return 0
+
+        if ns.label_command == "apply-preset":
+            cp = label_apply_preset(target_repo, token)
+            if cp.returncode not in (0, 200):
+                print(cp.stderr.strip() or "Failed applying preset.", file=sys.stderr)
+                return 1
+            result = _json.loads(cp.stdout)
+            created = result.get("created", [])
+            skipped = result.get("skipped", 0)
+            if created:
+                print(f"Created: {', '.join(created)}")
+            print(f"Skipped (already exist): {skipped}")
             return 0
 
     if ns.mode == "workspace":

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1183,10 +1183,22 @@ def issue_add_sub_issue(
 # ---------------------------------------------------------------------------
 
 STANDARD_LABELS: list[dict[str, str]] = [
-    {"name": "needs-triage", "color": "e4e669", "description": "New issue awaiting review"},
-    {"name": "good first issue", "color": "7057ff", "description": "Good for newcomers"},
+    {
+        "name": "needs-triage",
+        "color": "e4e669",
+        "description": "New issue awaiting review",
+    },
+    {
+        "name": "good first issue",
+        "color": "7057ff",
+        "description": "Good for newcomers",
+    },
     {"name": "help wanted", "color": "008672", "description": "Extra attention needed"},
-    {"name": "breaking change", "color": "e98014", "description": "Breaking API or behavior change"},
+    {
+        "name": "breaking change",
+        "color": "e98014",
+        "description": "Breaking API or behavior change",
+    },
     {"name": "documentation", "color": "0075ca", "description": "Documentation only"},
 ]
 
@@ -1231,7 +1243,9 @@ def label_apply_preset(repo: str, token: str) -> subprocess.CompletedProcess[str
         if cp2.returncode not in (0, 200, 201):
             return cp2
         created.append(lbl["name"])
-    return _ok(json.dumps({"created": created, "skipped": len(STANDARD_LABELS) - len(created)}))
+    return _ok(
+        json.dumps({"created": created, "skipped": len(STANDARD_LABELS) - len(created)})
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1179,6 +1179,62 @@ def issue_add_sub_issue(
 
 
 # ---------------------------------------------------------------------------
+# Repo labels
+# ---------------------------------------------------------------------------
+
+STANDARD_LABELS: list[dict[str, str]] = [
+    {"name": "needs-triage", "color": "e4e669", "description": "New issue awaiting review"},
+    {"name": "good first issue", "color": "7057ff", "description": "Good for newcomers"},
+    {"name": "help wanted", "color": "008672", "description": "Extra attention needed"},
+    {"name": "breaking change", "color": "e98014", "description": "Breaking API or behavior change"},
+    {"name": "documentation", "color": "0075ca", "description": "Documentation only"},
+]
+
+
+def label_list(repo: str, token: str) -> subprocess.CompletedProcess[str]:
+    return rest("GET", f"/repos/{repo}/labels?per_page=100", token)
+
+
+def label_create(
+    repo: str,
+    name: str,
+    color: str,
+    token: str,
+    description: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return rest(
+        "POST",
+        f"/repos/{repo}/labels",
+        token,
+        {"name": name, "color": color.lstrip("#"), "description": description},
+    )
+
+
+def label_delete(repo: str, name: str, token: str) -> subprocess.CompletedProcess[str]:
+    encoded = urllib.parse.quote(name, safe="")
+    return rest("DELETE", f"/repos/{repo}/labels/{encoded}", token)
+
+
+def label_apply_preset(repo: str, token: str) -> subprocess.CompletedProcess[str]:
+    cp = label_list(repo, token)
+    if cp.returncode not in (0, 200):
+        return cp
+    try:
+        existing = {lbl["name"] for lbl in json.loads(cp.stdout)}
+    except (json.JSONDecodeError, KeyError):
+        return _err("Failed to parse existing labels.")
+    created = []
+    for lbl in STANDARD_LABELS:
+        if lbl["name"] in existing:
+            continue
+        cp2 = label_create(repo, lbl["name"], lbl["color"], token, lbl["description"])
+        if cp2.returncode not in (0, 200, 201):
+            return cp2
+        created.append(lbl["name"])
+    return _ok(json.dumps({"created": created, "skipped": len(STANDARD_LABELS) - len(created)}))
+
+
+# ---------------------------------------------------------------------------
 # Pull requests
 # ---------------------------------------------------------------------------
 

--- a/src/repo_scaffold/workspace_ops.py
+++ b/src/repo_scaffold/workspace_ops.py
@@ -10,9 +10,14 @@ import urllib.request
 from pathlib import Path
 
 
-def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+def _run(
+    args: list[str], cwd: Path | None = None, bare: bool = False
+) -> subprocess.CompletedProcess[str]:
+    git_args = args
+    if bare and args and args[0] == "git":
+        git_args = ["git", "-c", "safe.bareRepository=all"] + args[1:]
     return subprocess.run(
-        args,
+        git_args,
         cwd=str(cwd) if cwd else None,
         capture_output=True,
         text=True,
@@ -158,7 +163,7 @@ def _setup_bare_auth(bare: Path, token: str) -> None:
 
     creds_posix = creds_file.as_posix()
     # Empty string resets the credential helper list, overriding the system GCM
-    _run(["git", "config", "credential.helper", ""], cwd=bare)
+    _run(["git", "config", "credential.helper", ""], cwd=bare, bare=True)
     _run(
         [
             "git",
@@ -168,6 +173,7 @@ def _setup_bare_auth(bare: Path, token: str) -> None:
             f'store --file "{creds_posix}"',
         ],
         cwd=bare,
+        bare=True,
     )
 
 
@@ -214,34 +220,49 @@ def workspace_create(
                     f"https://github.com/{repo}.git",
                 ],
                 cwd=bare,
+                bare=True,
             )
             _setup_bare_auth(bare, token)
-        _run(["git", "symbolic-ref", "HEAD", f"refs/heads/{base}"], cwd=bare)
+        _run(["git", "symbolic-ref", "HEAD", f"refs/heads/{base}"], cwd=bare, bare=True)
     else:
         if not _clone_url_override:
             _setup_bare_auth(bare, token)
+        # Fetch to remote-tracking refs so we never touch branches checked out
+        # in existing worktrees (git refuses to update those via local ref mapping).
         cp = _run(
             [
                 "git",
                 "fetch",
                 "origin",
                 "--prune",
-                "refs/heads/*:refs/heads/*",
+                "+refs/heads/*:refs/remotes/origin/*",
             ],
             cwd=bare,
+            bare=True,
         )
         if cp.returncode != 0:
             return _err(f"git fetch failed: {cp.stderr.strip()}")
+        # Sync just the base branch local ref so worktree add can use it by name.
+        _run(
+            ["git", "fetch", "origin", f"+refs/heads/{base}:refs/heads/{base}"],
+            cwd=bare,
+            bare=True,
+        )
 
     cp = _run(
-        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=bare
+        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        cwd=bare,
+        bare=True,
     )
     if cp.returncode == 0:
-        cp = _run(["git", "worktree", "add", str(worktree), branch], cwd=bare)
+        cp = _run(
+            ["git", "worktree", "add", str(worktree), branch], cwd=bare, bare=True
+        )
     else:
         cp = _run(
             ["git", "worktree", "add", "-b", branch, str(worktree), base],
             cwd=bare,
+            bare=True,
         )
 
     if cp.returncode != 0:
@@ -289,7 +310,7 @@ def workspace_list(
         bare = repo_dir / ".bare"
         if not bare.exists():
             continue
-        cp = _run(["git", "worktree", "list", "--porcelain"], cwd=bare)
+        cp = _run(["git", "worktree", "list", "--porcelain"], cwd=bare, bare=True)
         if cp.returncode != 0:
             continue
         label = f"{repo_dir.parent.name}/{repo_dir.name}"
@@ -325,11 +346,13 @@ def workspace_delete(
     if not bare.exists():
         return _err(f"Bare repo not found at {bare}")
 
-    cp = _run(["git", "worktree", "remove", "--force", str(worktree)], cwd=bare)
+    cp = _run(
+        ["git", "worktree", "remove", "--force", str(worktree)], cwd=bare, bare=True
+    )
     if cp.returncode != 0:
         return _err(f"git worktree remove failed: {cp.stderr.strip()}")
 
-    _run(["git", "worktree", "prune"], cwd=bare)
+    _run(["git", "worktree", "prune"], cwd=bare, bare=True)
     return _ok(f"Deleted worktree at {worktree}")
 
 
@@ -344,7 +367,7 @@ def workspace_prune(
     if not bare.exists():
         return _err(f"Bare repo not found at {bare}")
 
-    remote_cp = _run(["git", "ls-remote", "--heads", "origin"], cwd=bare)
+    remote_cp = _run(["git", "ls-remote", "--heads", "origin"], cwd=bare, bare=True)
     if remote_cp.returncode != 0:
         return _err(f"git ls-remote failed: {remote_cp.stderr.strip()}")
 
@@ -362,11 +385,15 @@ def workspace_prune(
         branch_slug = entry.name
         matched = any(_slug(b) == branch_slug for b in remote_branches)
         if not matched:
-            cp = _run(["git", "worktree", "remove", "--force", str(entry)], cwd=bare)
+            cp = _run(
+                ["git", "worktree", "remove", "--force", str(entry)],
+                cwd=bare,
+                bare=True,
+            )
             if cp.returncode == 0:
                 removed.append(str(entry))
 
-    _run(["git", "worktree", "prune"], cwd=bare)
+    _run(["git", "worktree", "prune"], cwd=bare, bare=True)
 
     if removed:
         return _ok("Pruned:\n" + "\n".join(removed))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2629,7 +2629,16 @@ def test_label_create(tmp_path, monkeypatch, capsys) -> None:
     from repo_scaffold.cli import main
 
     rc = main(
-        ["label", "create", "--repo", "acme/repo", "--name", "needs-triage", "--color", "e4e669"]
+        [
+            "label",
+            "create",
+            "--repo",
+            "acme/repo",
+            "--name",
+            "needs-triage",
+            "--color",
+            "e4e669",
+        ]
     )
     assert rc == 0
     assert "needs-triage" in capsys.readouterr().out
@@ -2662,7 +2671,9 @@ def test_label_apply_preset(tmp_path, monkeypatch, capsys) -> None:
         lambda repo, token: subprocess.CompletedProcess(
             args=[],
             returncode=200,
-            stdout=json.dumps({"created": ["needs-triage", "good first issue"], "skipped": 3}),
+            stdout=json.dumps(
+                {"created": ["needs-triage", "good first issue"], "skipped": 3}
+            ),
             stderr="",
         ),
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2591,6 +2591,90 @@ def test_branch_delete(tmp_path, monkeypatch, capsys) -> None:
     assert rc == 0
 
 
+def test_label_list(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.label_list",
+        lambda repo, token: subprocess.CompletedProcess(
+            args=[],
+            returncode=200,
+            stdout=json.dumps(
+                [{"name": "bug", "color": "d73a4a", "description": "Something broken"}]
+            ),
+            stderr="",
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["label", "list", "--repo", "acme/repo"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "bug" in out
+    assert "Total: 1" in out
+
+
+def test_label_create(tmp_path, monkeypatch, capsys) -> None:
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.label_create",
+        lambda repo, name, color, token, description="": subprocess.CompletedProcess(
+            args=[], returncode=201, stdout="{}", stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(
+        ["label", "create", "--repo", "acme/repo", "--name", "needs-triage", "--color", "e4e669"]
+    )
+    assert rc == 0
+    assert "needs-triage" in capsys.readouterr().out
+
+
+def test_label_delete(tmp_path, monkeypatch, capsys) -> None:
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.label_delete",
+        lambda repo, name, token: subprocess.CompletedProcess(
+            args=[], returncode=204, stdout="", stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["label", "delete", "--repo", "acme/repo", "--name", "needs-triage"])
+    assert rc == 0
+    assert "needs-triage" in capsys.readouterr().out
+
+
+def test_label_apply_preset(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.label_apply_preset",
+        lambda repo, token: subprocess.CompletedProcess(
+            args=[],
+            returncode=200,
+            stdout=json.dumps({"created": ["needs-triage", "good first issue"], "skipped": 3}),
+            stderr="",
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["label", "apply-preset", "--repo", "acme/repo"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "needs-triage" in out
+    assert "Skipped (already exist): 3" in out
+
+
 def test_issue_comment_body_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -922,3 +922,91 @@ def test_pr_reviews_api_error_propagates() -> None:
     with patch("urllib.request.urlopen", side_effect=_http_error(404, "Not Found")):
         cp = github_api.pr_reviews("acme/repo", 0, "tok")
     assert cp.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Repo labels
+# ---------------------------------------------------------------------------
+
+
+def test_label_list_success() -> None:
+    payload = json.dumps([{"name": "bug", "color": "ee0701"}])
+    with patch("urllib.request.urlopen", return_value=_mock_resp(200, payload)):
+        cp = github_api.label_list("acme/repo", "tok")
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout)[0]["name"] == "bug"
+
+
+def test_label_list_api_error_propagates() -> None:
+    with patch("urllib.request.urlopen", side_effect=_http_error(404, "Not Found")):
+        cp = github_api.label_list("acme/repo", "tok")
+    assert cp.returncode != 0
+
+
+def test_label_create_success() -> None:
+    payload = json.dumps({"name": "bug", "color": "ee0701"})
+    with patch("urllib.request.urlopen", return_value=_mock_resp(201, payload)) as m:
+        cp = github_api.label_create(
+            "acme/repo", "bug", "#ee0701", "tok", "Bug reports"
+        )
+    assert cp.returncode == 0
+    sent_body = json.loads(m.call_args[0][0].data)
+    assert sent_body == {"name": "bug", "color": "ee0701", "description": "Bug reports"}
+
+
+def test_label_create_api_error_propagates() -> None:
+    with patch(
+        "urllib.request.urlopen", side_effect=_http_error(422, "already_exists")
+    ):
+        cp = github_api.label_create("acme/repo", "bug", "ee0701", "tok")
+    assert cp.returncode != 0
+
+
+def test_label_delete_success() -> None:
+    with patch("urllib.request.urlopen", return_value=_mock_resp(204, "")):
+        cp = github_api.label_delete("acme/repo", "good first issue", "tok")
+    assert cp.returncode == 0
+
+
+def test_label_delete_api_error_propagates() -> None:
+    with patch("urllib.request.urlopen", side_effect=_http_error(404, "Not Found")):
+        cp = github_api.label_delete("acme/repo", "bug", "tok")
+    assert cp.returncode != 0
+
+
+def test_label_apply_preset_creates_missing_labels() -> None:
+    existing = json.dumps([{"name": "needs-triage"}])
+    created_payload = json.dumps({"name": "x"})
+    responses = [_mock_resp(200, existing)] + [
+        _mock_resp(201, created_payload) for _ in github_api.STANDARD_LABELS[1:]
+    ]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        cp = github_api.label_apply_preset("acme/repo", "tok")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert "needs-triage" not in result["created"]
+    assert len(result["created"]) == len(github_api.STANDARD_LABELS) - 1
+    assert result["skipped"] == 1
+
+
+def test_label_apply_preset_list_error_propagates() -> None:
+    with patch("urllib.request.urlopen", side_effect=_http_error(500, "boom")):
+        cp = github_api.label_apply_preset("acme/repo", "tok")
+    assert cp.returncode != 0
+
+
+def test_label_apply_preset_unparseable_labels_returns_err() -> None:
+    with patch("urllib.request.urlopen", return_value=_mock_resp(200, "not json")):
+        cp = github_api.label_apply_preset("acme/repo", "tok")
+    assert cp.returncode != 0
+    assert "Failed to parse" in cp.stderr
+
+
+def test_label_apply_preset_create_error_propagates() -> None:
+    existing = json.dumps([])
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[_mock_resp(200, existing), _http_error(422, "boom")],
+    ):
+        cp = github_api.label_apply_preset("acme/repo", "tok")
+    assert cp.returncode != 0


### PR DESCRIPTION
﻿## 🧾 Title
Add repo label management commands and standard preset

## 🧠 Description
This pull request adds `label list`, `label create`, `label delete`, and `label apply-preset` commands backed by the GitHub REST API (`/repos/{owner}/{repo}/labels`).

The standard preset replaces the ad-hoc `epic`, `ticket`, and `epic:X` labels that were workarounds before native sub-issues and issue types were available. New preset: `needs-triage`, `good first issue`, `help wanted`, `breaking change`, `documentation`.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [x] Added/updated documentation

## 🎯 Purpose
This PR aims to give repo-scaffold native label management so generated repos can be bootstrapped with a consistent label set instead of relying on manual GitHub UI setup or ad-hoc labels.

## 🔗 Related Issues / Epics
- **Issue:** #166
- Closes #166

## 🧪 Testing
1. Run `poetry run pytest tests/test_cli.py tests/test_github_api.py -k label`
2. Confirm all label subcommand tests pass
3. Manual: run `label apply-preset --repo blairg23/repo-scaffold` after merge and confirm the standard labels are created

## 🧰 Developer Notes
- [x] Ensure code runs under both local and CI/CD environments
