### PR TITLE
fix(workspace): pass safe.bareRepository=all and fix fetch refspec (#171)

### DIFF
--- a/src/repo_scaffold/workspace_ops.py
+++ b/src/repo_scaffold/workspace_ops.py
@@ -10,9 +10,14 @@ import urllib.request
 from pathlib import Path
 
 
-def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+def _run(
+    args: list[str], cwd: Path | None = None, bare: bool = False
+) -> subprocess.CompletedProcess[str]:
+    git_args = args
+    if bare and args and args[0] == "git":
+        git_args = ["git", "-c", "safe.bareRepository=all"] + args[1:]
     return subprocess.run(
-        args,
+        git_args,
         cwd=str(cwd) if cwd else None,
         capture_output=True,
         text=True,
@@ -158,7 +163,7 @@ def _setup_bare_auth(bare: Path, token: str) -> None:
 
     creds_posix = creds_file.as_posix()
     # Empty string resets the credential helper list, overriding the system GCM
-    _run(["git", "config", "credential.helper", ""], cwd=bare)
+    _run(["git", "config", "credential.helper", ""], cwd=bare, bare=True)
     _run(
         [
             "git",
@@ -168,6 +173,7 @@ def _setup_bare_auth(bare: Path, token: str) -> None:
             f'store --file "{creds_posix}"',
         ],
         cwd=bare,
+        bare=True,
     )
 
 
@@ -214,9 +220,10 @@ def workspace_create(
                     f"https://github.com/{repo}.git",
                 ],
                 cwd=bare,
+                bare=True,
             )
             _setup_bare_auth(bare, token)
-        _run(["git", "symbolic-ref", "HEAD", f"refs/heads/{base}"], cwd=bare)
+        _run(["git", "symbolic-ref", "HEAD", f"refs/heads/{base}"], cwd=bare, bare=True)
     else:
         if not _clone_url_override:
             _setup_bare_auth(bare, token)
@@ -226,22 +233,33 @@ def workspace_create(
                 "fetch",
                 "origin",
                 "--prune",
-                "refs/heads/*:refs/heads/*",
+                "+refs/heads/*:refs/remotes/origin/*",
             ],
             cwd=bare,
+            bare=True,
         )
         if cp.returncode != 0:
             return _err(f"git fetch failed: {cp.stderr.strip()}")
+        _run(
+            ["git", "fetch", "origin", f"+refs/heads/{base}:refs/heads/{base}"],
+            cwd=bare,
+            bare=True,
+        )
 
     cp = _run(
-        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=bare
+        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        cwd=bare,
+        bare=True,
     )
     if cp.returncode == 0:
-        cp = _run(["git", "worktree", "add", str(worktree), branch], cwd=bare)
+        cp = _run(
+            ["git", "worktree", "add", str(worktree), branch], cwd=bare, bare=True
+        )
     else:
         cp = _run(
             ["git", "worktree", "add", "-b", branch, str(worktree), base],
             cwd=bare,
+            bare=True,
         )
 
     if cp.returncode != 0:
@@ -289,7 +307,7 @@ def workspace_list(
         bare = repo_dir / ".bare"
         if not bare.exists():
             continue
-        cp = _run(["git", "worktree", "list", "--porcelain"], cwd=bare)
+        cp = _run(["git", "worktree", "list", "--porcelain"], cwd=bare, bare=True)
         if cp.returncode != 0:
             continue
         label = f"{repo_dir.parent.name}/{repo_dir.name}"
@@ -325,11 +343,13 @@ def workspace_delete(
     if not bare.exists():
         return _err(f"Bare repo not found at {bare}")
 
-    cp = _run(["git", "worktree", "remove", "--force", str(worktree)], cwd=bare)
+    cp = _run(
+        ["git", "worktree", "remove", "--force", str(worktree)], cwd=bare, bare=True
+    )
     if cp.returncode != 0:
         return _err(f"git worktree remove failed: {cp.stderr.strip()}")
 
-    _run(["git", "worktree", "prune"], cwd=bare)
+    _run(["git", "worktree", "prune"], cwd=bare, bare=True)
     return _ok(f"Deleted worktree at {worktree}")
 
 
@@ -344,7 +364,7 @@ def workspace_prune(
     if not bare.exists():
         return _err(f"Bare repo not found at {bare}")
 
-    remote_cp = _run(["git", "ls-remote", "--heads", "origin"], cwd=bare)
+    remote_cp = _run(["git", "ls-remote", "--heads", "origin"], cwd=bare, bare=True)
     if remote_cp.returncode != 0:
         return _err(f"git ls-remote failed: {remote_cp.stderr.strip()}")
 
@@ -362,11 +382,15 @@ def workspace_prune(
         branch_slug = entry.name
         matched = any(_slug(b) == branch_slug for b in remote_branches)
         if not matched:
-            cp = _run(["git", "worktree", "remove", "--force", str(entry)], cwd=bare)
+            cp = _run(
+                ["git", "worktree", "remove", "--force", str(entry)],
+                cwd=bare,
+                bare=True,
+            )
             if cp.returncode == 0:
                 removed.append(str(entry))
 
-    _run(["git", "worktree", "prune"], cwd=bare)
+    _run(["git", "worktree", "prune"], cwd=bare, bare=True)
 
     if removed:
         return _ok("Pruned:\n" + "\n".join(removed))


### PR DESCRIPTION
﻿## 🧾 Title
fix(workspace): pass safe.bareRepository=all and fix fetch refspec (#171)

## 🧠 Description
Two bugs in workspace_ops.py break `workspace create` whenever the bare repo already exists on disk. Python subprocesses don't inherit the global git config, so every git command with `cwd=bare` fails with "cannot use bare repository (safe.bareRepository is 'explicit')". A second bug caused fetch to fail when any branch was already checked out in an active worktree.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [x] Improved error handling or logging

## 🎯 Purpose
Unblocks `workspace create` on any repo where the bare clone already exists locally, and prevents fetch failures when other worktrees are active.

## 🔗 Related Issues / Epics
- **Issue:** #171
- Closes #171

## 🧪 Testing
1. Run `workspace create` on a repo with an existing bare clone -- should succeed
2. Run `workspace create` when another branch is checked out in a worktree -- should succeed
3. Run `poetry run pytest tests/ -q` -- all tests pass

## 🧰 Developer Notes
- `_run()` gains `bare=True`; when set, prepends `-c safe.bareRepository=all` to git invocations
- Fetch refspec changed to `+refs/heads/*:refs/remotes/origin/*` (remote-tracking refs only, never touches checked-out branches)
- Separate targeted fetch syncs the base branch local ref after the main fetch