### PR TITLE
feat(repo): add local repo registry, multi-repo check/apply/sync, and declared languages config (#172)

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -65,6 +65,13 @@ from .generator import (
     parse_language_csv,
 )
 from .overwrite_policy import ApplySummary, OverwritePolicy, apply_files
+from .project_config import resolve_languages
+from .registry_ops import (
+    RegistryEntry,
+    forget_repo,
+    list_registry,
+    register_repo,
+)
 from .project_ops import (
     DEFAULT_PROJECT_BACKUP_REL_DIR,
     ProjectItemsSummary,
@@ -210,6 +217,58 @@ def _resolve_repo_from_args_or_env(
         None,
         "Error: could not resolve target repo. Pass --repo owner/repo or set GH_REPO (or GITHUB_ORG + GITHUB_REPO) in .env.",
     )
+
+
+def _resolve_repo_targets(
+    ns: argparse.Namespace,
+) -> tuple[list[tuple[str, Path]], str | None]:
+    """Resolve one or more (repo, repo_dir) targets from --repo/--repos/--all.
+
+    --repo uses the current working directory as repo_dir (existing single-repo
+    behavior). --repos/--all resolve repo_dir from the local registry, since
+    settings checks need a local git checkout to authenticate against.
+    """
+    selected = [
+        flag
+        for flag, value in (
+            ("--repo", getattr(ns, "repo", None)),
+            ("--repos", getattr(ns, "repos", None)),
+            ("--all", getattr(ns, "all_repos", False)),
+        )
+        if value
+    ]
+    if len(selected) > 1:
+        return [], f"Error: pass only one of {', '.join(selected)}."
+
+    if getattr(ns, "all_repos", False):
+        entries = list_registry()
+        if not entries:
+            return [], "Error: no repos registered. Run 'repo register' first."
+        return [(e.repo, Path(e.local_path)) for e in entries], None
+
+    if getattr(ns, "repos", None):
+        registry = {e.repo: e for e in list_registry()}
+        targets: list[tuple[str, Path]] = []
+        for raw in ns.repos.split(","):
+            repo = raw.strip()
+            if not repo:
+                continue
+            entry = registry.get(repo)
+            if entry is None:
+                return (
+                    [],
+                    f"Error: repo not registered: {repo}. Run 'repo register' first.",
+                )
+            targets.append((repo, Path(entry.local_path)))
+        return targets, None
+
+    target_repo, repo_error = _resolve_repo_from_args_or_env(
+        repo=getattr(ns, "repo", None), fallback_name=None
+    )
+    if repo_error:
+        return [], repo_error
+    assert target_repo is not None
+    return [(target_repo, Path.cwd())], None
 
 
 def _local_backlog_slug_path(repo: str) -> Path:
@@ -575,6 +634,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     apply_rules.add_argument("--repo", help="Target GitHub repo (owner/repo)")
     apply_rules.add_argument(
+        "--repos", help="Comma-separated registered repos (owner/repo,owner/repo)"
+    )
+    apply_rules.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_repos",
+        help="Target every repo in the local registry",
+    )
+    apply_rules.add_argument(
         "--apply",
         action="store_true",
         dest="do_apply",
@@ -607,6 +675,83 @@ def build_parser() -> argparse.ArgumentParser:
         help="Check merge settings, managed ruleset, and security defaults",
     )
     check_rules.add_argument("--repo", help="Target GitHub repo (owner/repo)")
+    check_rules.add_argument(
+        "--repos", help="Comma-separated registered repos (owner/repo,owner/repo)"
+    )
+    check_rules.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_repos",
+        help="Target every repo in the local registry",
+    )
+
+    check_settings_cmd = check_sub.add_parser(
+        "settings",
+        help="Check repository settings including required status checks",
+    )
+    check_settings_cmd.add_argument(
+        "--repo",
+        required=True,
+        help="Target GitHub repo (owner/repo)",
+    )
+    check_settings_cmd.add_argument(
+        "--languages",
+        default="",
+        help=(
+            "Comma-separated language list to require as status checks "
+            "(default: read from .repo-scaffold.yml, falling back to file detection)"
+        ),
+    )
+
+    repo_cmd = subparsers.add_parser(
+        "repo",
+        help="Manage the local registry of repos repo-scaffold knows about",
+    )
+    repo_sub = repo_cmd.add_subparsers(dest="repo_command", required=True)
+    repo_register_cmd = repo_sub.add_parser(
+        "register", help="Register a repo in the local registry"
+    )
+    repo_register_cmd.add_argument(
+        "--repo", required=True, help="GitHub repo (owner/repo)"
+    )
+    repo_register_cmd.add_argument(
+        "--path", required=True, help="Local path to the repo's checkout"
+    )
+    repo_register_cmd.add_argument(
+        "--notes", default="", help="Free-text notes about this repo"
+    )
+    repo_sub.add_parser("list", help="List registered repos")
+    repo_forget_cmd = repo_sub.add_parser(
+        "forget", help="Remove a repo from the local registry"
+    )
+    repo_forget_cmd.add_argument(
+        "--repo", required=True, help="GitHub repo (owner/repo)"
+    )
+
+    sync_cmd = subparsers.add_parser(
+        "sync",
+        help="Check then apply settings/rules across one or more repos",
+    )
+    sync_sub = sync_cmd.add_subparsers(dest="sync_command", required=True)
+    sync_rules_cmd = sync_sub.add_parser(
+        "rules",
+        help="Check merge settings/ruleset/security defaults, then apply per-repo on confirm",
+    )
+    sync_rules_cmd.add_argument("--repo", help="Target GitHub repo (owner/repo)")
+    sync_rules_cmd.add_argument(
+        "--repos", help="Comma-separated registered repos (owner/repo,owner/repo)"
+    )
+    sync_rules_cmd.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_repos",
+        help="Target every repo in the local registry",
+    )
+    sync_rules_cmd.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the per-repo confirmation prompt and apply all drifted repos",
+    )
 
     project_cmd = subparsers.add_parser(
         "project",
@@ -1272,6 +1417,8 @@ def _normalize_argv(argv: list[str] | None) -> list[str]:
         "pr",
         "branch",
         "workspace",
+        "repo",
+        "sync",
     }:
         return raw
     # Backward-compatible behavior: previous root command maps to init.
@@ -1733,48 +1880,77 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if ns.mode == "apply" and ns.apply_command == "rules":
-        target_repo, repo_error = _resolve_repo_from_args_or_env(
-            repo=ns.repo, fallback_name=None
-        )
-        if repo_error:
-            print(repo_error, file=sys.stderr)
+        targets, targets_error = _resolve_repo_targets(ns)
+        if targets_error:
+            print(targets_error, file=sys.stderr)
             return 2
-        assert target_repo is not None
         preview_only = not ns.do_apply or getattr(ns, "dry_run", False)
-        try:
-            apply_repository_settings(
-                repo_dir=Path.cwd(),
-                repo=target_repo,
-                dry_run=preview_only,
-                out=print,
-                warn=lambda line: print(line, file=sys.stderr),
-            )
-        except RuntimeError as exc:
-            print(str(exc), file=sys.stderr)
-            return 1
+        failures = 0
+        for target_repo, repo_dir in targets:
+            try:
+                apply_repository_settings(
+                    repo_dir=repo_dir,
+                    repo=target_repo,
+                    dry_run=preview_only,
+                    out=print,
+                    warn=lambda line: print(line, file=sys.stderr),
+                )
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+                failures += 1
 
         print("")
         print("Summary:")
+        if len(targets) > 1:
+            print(f"  repos: {len(targets)}")
+            print(f"  failures: {failures}")
         if preview_only:
             print("  mode: dry-run")
             print("  settings planned: True")
         else:
             print("  settings applied: True")
-        return 0
+        return 1 if failures else 0
 
     if ns.mode == "check" and ns.check_command == "rules":
-        target_repo, repo_error = _resolve_repo_from_args_or_env(
-            repo=ns.repo, fallback_name=None
-        )
-        if repo_error:
-            print(repo_error, file=sys.stderr)
+        targets, targets_error = _resolve_repo_targets(ns)
+        if targets_error:
+            print(targets_error, file=sys.stderr)
             return 2
-        assert target_repo is not None
+        total_failed = 0
+        for target_repo, repo_dir in targets:
+            try:
+                check_summary: SettingsCheckSummary = check_repository_settings(
+                    repo_dir=repo_dir,
+                    repo=target_repo,
+                    out=print,
+                )
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+                total_failed += 1
+                continue
+
+            print("")
+            print("Summary:")
+            print(f"  repo: {check_summary.repo}")
+            print(f"  checks passed: {check_summary.passed}")
+            print(f"  checks failed: {check_summary.failed}")
+            print(f"  checks skipped: {check_summary.skipped}")
+            print(f"  drift items: {len(check_summary.drifts)}")
+            total_failed += check_summary.failed
+        return 1 if total_failed > 0 else 0
+
+    if ns.mode == "check" and ns.check_command == "settings":
+        langs = (
+            _parse_languages_or_die(parser, ns.languages)
+            if ns.languages
+            else tuple(resolve_languages(Path.cwd()))
+        )
         try:
-            check_summary: SettingsCheckSummary = check_repository_settings(
+            settings_summary: SettingsCheckSummary = check_repository_settings(
                 repo_dir=Path.cwd(),
-                repo=target_repo,
+                repo=ns.repo,
                 out=print,
+                languages=list(langs) if langs else None,
             )
         except RuntimeError as exc:
             print(str(exc), file=sys.stderr)
@@ -1782,12 +1958,92 @@ def main(argv: list[str] | None = None) -> int:
 
         print("")
         print("Summary:")
-        print(f"  repo: {check_summary.repo}")
-        print(f"  checks passed: {check_summary.passed}")
-        print(f"  checks failed: {check_summary.failed}")
-        print(f"  checks skipped: {check_summary.skipped}")
-        print(f"  drift items: {len(check_summary.drifts)}")
-        return 1 if check_summary.failed > 0 else 0
+        print(f"  repo: {settings_summary.repo}")
+        if langs:
+            print(f"  languages: {', '.join(langs)}")
+        print(f"  checks passed: {settings_summary.passed}")
+        print(f"  checks failed: {settings_summary.failed}")
+        print(f"  checks skipped: {settings_summary.skipped}")
+        print(f"  drift items: {len(settings_summary.drifts)}")
+        return 1 if settings_summary.failed > 0 else 0
+
+    if ns.mode == "repo" and ns.repo_command == "register":
+        entry: RegistryEntry = register_repo(ns.repo, ns.path, ns.notes)
+        print(f"Registered {entry.repo} -> {entry.local_path}")
+        return 0
+
+    if ns.mode == "repo" and ns.repo_command == "list":
+        entries = list_registry()
+        if not entries:
+            print("No repos registered.")
+            return 0
+        for entry in entries:
+            suffix = f"  ({entry.notes})" if entry.notes else ""
+            print(f"{entry.repo} -> {entry.local_path}{suffix}")
+        return 0
+
+    if ns.mode == "repo" and ns.repo_command == "forget":
+        removed = forget_repo(ns.repo)
+        if not removed:
+            print(f"Error: repo not registered: {ns.repo}", file=sys.stderr)
+            return 2
+        print(f"Removed {ns.repo} from the registry.")
+        return 0
+
+    if ns.mode == "sync" and ns.sync_command == "rules":
+        targets, targets_error = _resolve_repo_targets(ns)
+        if targets_error:
+            print(targets_error, file=sys.stderr)
+            return 2
+
+        drifted: list[tuple[str, Path]] = []
+        for target_repo, repo_dir in targets:
+            try:
+                drift_summary: SettingsCheckSummary = check_repository_settings(
+                    repo_dir=repo_dir,
+                    repo=target_repo,
+                    out=print,
+                )
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+                continue
+            print(
+                f"  {target_repo}: {drift_summary.failed} drifted, {len(drift_summary.drifts)} drift items"
+            )
+            if drift_summary.failed > 0:
+                drifted.append((target_repo, repo_dir))
+
+        if not drifted:
+            print("")
+            print("No drift found. Nothing to apply.")
+            return 0
+
+        print("")
+        applied = 0
+        for target_repo, repo_dir in drifted:
+            if not ns.yes:
+                answer = input(f"Apply fixes for {target_repo}? [y/N] ").strip().lower()
+                if answer != "y":
+                    print(f"Skipped {target_repo}.")
+                    continue
+            try:
+                apply_repository_settings(
+                    repo_dir=repo_dir,
+                    repo=target_repo,
+                    dry_run=False,
+                    out=print,
+                    warn=lambda line: print(line, file=sys.stderr),
+                )
+                applied += 1
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+
+        print("")
+        print("Summary:")
+        print(f"  repos checked: {len(targets)}")
+        print(f"  repos drifted: {len(drifted)}")
+        print(f"  repos applied: {applied}")
+        return 0
 
     if ns.mode == "project":
         repo_dir = Path(ns.path)

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -1997,6 +1997,7 @@ def main(argv: list[str] | None = None) -> int:
             return 2
 
         drifted: list[tuple[str, Path]] = []
+        errors = 0
         for target_repo, repo_dir in targets:
             try:
                 drift_summary: SettingsCheckSummary = check_repository_settings(
@@ -2006,6 +2007,7 @@ def main(argv: list[str] | None = None) -> int:
                 )
             except RuntimeError as exc:
                 print(str(exc), file=sys.stderr)
+                errors += 1
                 continue
             print(
                 f"  {target_repo}: {drift_summary.failed} drifted, {len(drift_summary.drifts)} drift items"
@@ -2016,7 +2018,7 @@ def main(argv: list[str] | None = None) -> int:
         if not drifted:
             print("")
             print("No drift found. Nothing to apply.")
-            return 0
+            return 1 if errors else 0
 
         print("")
         applied = 0
@@ -2037,13 +2039,14 @@ def main(argv: list[str] | None = None) -> int:
                 applied += 1
             except RuntimeError as exc:
                 print(str(exc), file=sys.stderr)
+                errors += 1
 
         print("")
         print("Summary:")
         print(f"  repos checked: {len(targets)}")
         print(f"  repos drifted: {len(drifted)}")
         print(f"  repos applied: {applied}")
-        return 0
+        return 1 if errors else 0
 
     if ns.mode == "project":
         repo_dir = Path(ns.path)

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -498,6 +498,7 @@ def _compare_ruleset_against_baseline(
     rulesets: list[dict[str, object]],
     *,
     default_branch: str,
+    languages: list[str] | None = None,
 ) -> list[str]:
     drifts: list[str] = []
     managed_rulesets = [
@@ -628,6 +629,35 @@ def _compare_ruleset_against_baseline(
                 if actual != expected:
                     drifts.append(
                         f"copilot_code_review.{key} expected {expected!r} got {actual!r}"
+                    )
+
+    if languages:
+        expected_contexts = list(
+            dict.fromkeys(
+                _LANGUAGE_CI_CONTEXT[lang]
+                for lang in languages
+                if lang in _LANGUAGE_CI_CONTEXT
+            )
+        )
+        if expected_contexts:
+            status_checks_rule = rule_map.get("required_status_checks")
+            if not isinstance(status_checks_rule, dict):
+                drifts.append("missing rule: required_status_checks")
+            else:
+                status_parameters = status_checks_rule.get("parameters")
+                actual_contexts = (
+                    [
+                        item.get("context")
+                        for item in status_parameters.get("required_status_checks", [])
+                        if isinstance(item, dict)
+                    ]
+                    if isinstance(status_parameters, dict)
+                    else []
+                )
+                missing = [c for c in expected_contexts if c not in actual_contexts]
+                if missing:
+                    drifts.append(
+                        "required_status_checks missing contexts: " f"{missing!r}"
                     )
 
     return drifts
@@ -914,11 +944,14 @@ def check_repository_settings(
     repo_dir: Path,
     repo: str,
     out: Callable[[str], None] = print,
+    languages: list[str] | None = None,
 ) -> SettingsCheckSummary:
     _ensure_tools()
     env = _build_env(repo_dir)
     _ensure_gh_auth(repo_dir, env)
-    return _check_settings(repo_dir=repo_dir.resolve(), env=env, repo=repo, out=out)
+    return _check_settings(
+        repo_dir=repo_dir.resolve(), env=env, repo=repo, out=out, languages=languages
+    )
 
 
 def _create_or_push_repo(
@@ -1074,6 +1107,7 @@ def _check_settings(
     env: dict[str, str],
     repo: str,
     out: Callable[[str], None],
+    languages: list[str] | None = None,
 ) -> SettingsCheckSummary:
     out(f"check repository settings: {repo}")
     repo_info = _get_repo_info(repo_dir=repo_dir, env=env, repo=repo)
@@ -1123,6 +1157,7 @@ def _check_settings(
     ruleset_drifts = _compare_ruleset_against_baseline(
         detailed_rulesets,
         default_branch=default_branch,
+        languages=languages,
     )
     if ruleset_drifts:
         failed += 1

--- a/src/repo_scaffold/project_config.py
+++ b/src/repo_scaffold/project_config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
 
@@ -48,12 +48,14 @@ class StatusOption:
 class ProjectConfig:
     statuses: list[StatusOption]
     workflows: dict[str, str]
+    languages: list[str] = field(default_factory=list)
 
 
 def default_config() -> ProjectConfig:
     return ProjectConfig(
         statuses=[StatusOption(s["name"], s["color"]) for s in DEFAULT_STATUS_OPTIONS],
         workflows=dict(DEFAULT_WORKFLOW_MAPPINGS),
+        languages=[],
     )
 
 
@@ -93,6 +95,10 @@ def save_config(config: ProjectConfig, path: Path) -> None:
     for key, value in config.workflows.items():
         v = value.replace('"', '\\"')
         lines.append(f'    {key}: "{v}"')
+    if config.languages:
+        lines.append("  languages:")
+        for lang in config.languages:
+            lines.append(f"    - {lang}")
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
@@ -107,6 +113,7 @@ def _parse_yaml_config(text: str) -> ProjectConfig:
     """Parse the specific subset of YAML that save_config writes."""
     statuses: list[StatusOption] = []
     workflows: dict[str, str] = {}
+    languages: list[str] = []
     section: str | None = None
     current: dict[str, str] = {}
 
@@ -123,13 +130,18 @@ def _parse_yaml_config(text: str) -> ProjectConfig:
 
         if indent == 2:
             key = stripped.rstrip(":")
-            if key in ("statuses", "workflows"):
+            if key in ("statuses", "workflows", "languages"):
                 if current.get("name"):
                     statuses.append(
                         StatusOption(current["name"], current.get("color", "GRAY"))
                     )
                     current = {}
                 section = key
+            continue
+
+        if section == "languages":
+            if indent == 4 and stripped.startswith("- "):
+                languages.append(stripped[2:].strip())
             continue
 
         if section == "statuses":
@@ -163,7 +175,20 @@ def _parse_yaml_config(text: str) -> ProjectConfig:
         workflows=(
             {**defaults.workflows, **workflows} if workflows else defaults.workflows
         ),
+        languages=languages if languages else defaults.languages,
     )
+
+
+def resolve_languages(repo_dir: Path) -> list[str]:
+    """Return the repo's declared languages from .repo-scaffold.yml, falling back
+    to file-based detection when the field is absent or the repo has no config."""
+    config = load_config(repo_dir)
+    if config.languages:
+        return config.languages
+
+    from .generator import detect_languages_from_repo
+
+    return list(detect_languages_from_repo(repo_dir))
 
 
 def prompt_config(

--- a/src/repo_scaffold/registry_ops.py
+++ b/src/repo_scaffold/registry_ops.py
@@ -1,0 +1,87 @@
+"""Lightweight local registry of repos repo-scaffold knows about.
+
+Stores only what can't be re-derived live from git/GitHub: a local path and
+free-text notes per repo. Everything else (last commit, owner, status) is one
+git/GitHub call away and isn't worth caching here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+_REGISTRY_ENV_VAR = "REPO_SCAFFOLD_REGISTRY_PATH"
+
+
+@dataclass(frozen=True)
+class RegistryEntry:
+    repo: str
+    local_path: str
+    notes: str = ""
+
+
+def registry_path() -> Path:
+    override = os.environ.get(_REGISTRY_ENV_VAR)
+    if override:
+        return Path(override)
+    return Path.home() / ".repo-scaffold" / "registry.json"
+
+
+def load_registry(path: Path | None = None) -> dict[str, RegistryEntry]:
+    target = path or registry_path()
+    if not target.exists():
+        return {}
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    entries: dict[str, RegistryEntry] = {}
+    for repo, data in raw.items():
+        if not isinstance(data, dict):
+            continue
+        entries[repo] = RegistryEntry(
+            repo=repo,
+            local_path=str(data.get("local_path", "")),
+            notes=str(data.get("notes", "")),
+        )
+    return entries
+
+
+def save_registry(entries: dict[str, RegistryEntry], path: Path | None = None) -> None:
+    target = path or registry_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        repo: {"local_path": entry.local_path, "notes": entry.notes}
+        for repo, entry in entries.items()
+    }
+    target.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def register_repo(
+    repo: str,
+    local_path: str,
+    notes: str = "",
+    path: Path | None = None,
+) -> RegistryEntry:
+    entries = load_registry(path)
+    entry = RegistryEntry(repo=repo, local_path=local_path, notes=notes)
+    entries[repo] = entry
+    save_registry(entries, path)
+    return entry
+
+
+def forget_repo(repo: str, path: Path | None = None) -> bool:
+    entries = load_registry(path)
+    if repo not in entries:
+        return False
+    del entries[repo]
+    save_registry(entries, path)
+    return True
+
+
+def list_registry(path: Path | None = None) -> list[RegistryEntry]:
+    return sorted(load_registry(path).values(), key=lambda e: e.repo)

--- a/src/repo_scaffold/registry_ops.py
+++ b/src/repo_scaffold/registry_ops.py
@@ -68,7 +68,8 @@ def register_repo(
     path: Path | None = None,
 ) -> RegistryEntry:
     entries = load_registry(path)
-    entry = RegistryEntry(repo=repo, local_path=local_path, notes=notes)
+    resolved_path = str(Path(local_path).resolve())
+    entry = RegistryEntry(repo=repo, local_path=resolved_path, notes=notes)
     entries[repo] = entry
     save_registry(entries, path)
     return entry

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2795,6 +2795,8 @@ def test_repo_register_list_forget_roundtrip(
 ) -> None:
     registry_path = tmp_path / "registry.json"
     monkeypatch.setenv("REPO_SCAFFOLD_REGISTRY_PATH", str(registry_path))
+    local_dir = tmp_path / "acme-repo"
+    expected_path = str(local_dir.resolve())
 
     rc = main(
         [
@@ -2803,19 +2805,19 @@ def test_repo_register_list_forget_roundtrip(
             "--repo",
             "acme/repo",
             "--path",
-            "/local/acme-repo",
+            str(local_dir),
             "--notes",
             "primary checkout",
         ]
     )
     assert rc == 0
     stdout = capsys.readouterr().out
-    assert "Registered acme/repo -> /local/acme-repo" in stdout
+    assert f"Registered acme/repo -> {expected_path}" in stdout
 
     rc = main(["repo", "list"])
     assert rc == 0
     stdout = capsys.readouterr().out
-    assert "acme/repo -> /local/acme-repo" in stdout
+    assert f"acme/repo -> {expected_path}" in stdout
     assert "primary checkout" in stdout
 
     rc = main(["repo", "forget", "--repo", "acme/repo"])
@@ -2972,6 +2974,49 @@ def test_sync_rules_no_drift_skips_apply(
     assert apply_called is False
     stdout = capsys.readouterr().out
     assert "No drift found" in stdout
+
+
+def test_sync_rules_returns_nonzero_when_apply_fails(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [RegistryEntry(repo="acme/drifted", local_path="/local/drifted")],
+    )
+
+    def _fake_check(*, repo_dir, repo, out):
+        return SettingsCheckSummary(repo=repo, passed=6, failed=1, skipped=0, drifts=())
+
+    def _fake_apply(*, repo_dir, repo, dry_run, out, warn):
+        raise RuntimeError("apply failed")
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_settings", _fake_check)
+    monkeypatch.setattr("repo_scaffold.cli.apply_repository_settings", _fake_apply)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = main(["sync", "rules", "--all"])
+    assert rc == 1
+
+
+def test_sync_rules_returns_nonzero_when_check_fails(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [RegistryEntry(repo="acme/broken", local_path="/local/broken")],
+    )
+
+    def _fake_check(*, repo_dir, repo, out):
+        raise RuntimeError("check failed")
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_settings", _fake_check)
+
+    rc = main(["sync", "rules", "--all"])
+    assert rc == 1
 
 
 def test_check_settings_uses_resolved_languages(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2788,3 +2788,227 @@ def test_pr_request_reviewer(tmp_path, monkeypatch, capsys) -> None:
     out = capsys.readouterr().out
     assert "blairg23" in out
     assert "42" in out
+
+
+def test_repo_register_list_forget_roundtrip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("REPO_SCAFFOLD_REGISTRY_PATH", str(registry_path))
+
+    rc = main(
+        [
+            "repo",
+            "register",
+            "--repo",
+            "acme/repo",
+            "--path",
+            "/local/acme-repo",
+            "--notes",
+            "primary checkout",
+        ]
+    )
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "Registered acme/repo -> /local/acme-repo" in stdout
+
+    rc = main(["repo", "list"])
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "acme/repo -> /local/acme-repo" in stdout
+    assert "primary checkout" in stdout
+
+    rc = main(["repo", "forget", "--repo", "acme/repo"])
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "Removed acme/repo from the registry." in stdout
+
+    rc = main(["repo", "list"])
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "No repos registered." in stdout
+
+
+def test_repo_forget_missing_repo_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("REPO_SCAFFOLD_REGISTRY_PATH", str(tmp_path / "registry.json"))
+    rc = main(["repo", "forget", "--repo", "acme/missing"])
+    assert rc == 2
+    stderr = capsys.readouterr().err
+    assert "not registered" in stderr
+
+
+def test_apply_rules_with_repos_flag_uses_registry_paths(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [
+            RegistryEntry(repo="acme/a", local_path="/local/a"),
+            RegistryEntry(repo="acme/b", local_path="/local/b"),
+        ],
+    )
+
+    calls: list[dict[str, object]] = []
+
+    def _fake_apply(*, repo_dir, repo, dry_run, out, warn):
+        calls.append({"repo_dir": repo_dir, "repo": repo})
+
+    monkeypatch.setattr("repo_scaffold.cli.apply_repository_settings", _fake_apply)
+
+    rc = main(["apply", "rules", "--repos", "acme/a,acme/b", "--apply"])
+    assert rc == 0
+    assert [c["repo"] for c in calls] == ["acme/a", "acme/b"]
+    assert calls[0]["repo_dir"] == Path("/local/a")
+    assert calls[1]["repo_dir"] == Path("/local/b")
+    stdout = capsys.readouterr().out
+    assert "repos: 2" in stdout
+
+
+def test_apply_rules_with_repos_flag_rejects_unregistered_repo(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("repo_scaffold.cli.list_registry", lambda: [])
+
+    rc = main(["apply", "rules", "--repos", "acme/unknown", "--apply"])
+    assert rc == 2
+    stderr = capsys.readouterr().err
+    assert "not registered" in stderr
+
+
+def test_check_rules_with_all_flag_iterates_registry(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [RegistryEntry(repo="acme/a", local_path="/local/a")],
+    )
+
+    def _fake_check(*, repo_dir, repo, out):
+        out(f"check repository settings: {repo}")
+        return SettingsCheckSummary(repo=repo, passed=8, failed=0, skipped=0, drifts=())
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_settings", _fake_check)
+
+    rc = main(["check", "rules", "--all"])
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "check repository settings: acme/a" in stdout
+
+
+def test_check_rules_rejects_multiple_selectors(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["check", "rules", "--repo", "acme/a", "--all"])
+    assert rc == 2
+    stderr = capsys.readouterr().err
+    assert "only one of" in stderr
+
+
+def test_sync_rules_applies_only_confirmed_repos(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [
+            RegistryEntry(repo="acme/drifted", local_path="/local/drifted"),
+            RegistryEntry(repo="acme/clean", local_path="/local/clean"),
+        ],
+    )
+
+    def _fake_check(*, repo_dir, repo, out):
+        failed = 1 if repo == "acme/drifted" else 0
+        return SettingsCheckSummary(
+            repo=repo, passed=7, failed=failed, skipped=0, drifts=()
+        )
+
+    applied: list[str] = []
+
+    def _fake_apply(*, repo_dir, repo, dry_run, out, warn):
+        applied.append(repo)
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_settings", _fake_check)
+    monkeypatch.setattr("repo_scaffold.cli.apply_repository_settings", _fake_apply)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = main(["sync", "rules", "--all"])
+    assert rc == 0
+    assert applied == ["acme/drifted"]
+    stdout = capsys.readouterr().out
+    assert "repos applied: 1" in stdout
+
+
+def test_sync_rules_no_drift_skips_apply(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [RegistryEntry(repo="acme/clean", local_path="/local/clean")],
+    )
+
+    def _fake_check(*, repo_dir, repo, out):
+        return SettingsCheckSummary(repo=repo, passed=8, failed=0, skipped=0, drifts=())
+
+    apply_called = False
+
+    def _fake_apply(**_kwargs):
+        nonlocal apply_called
+        apply_called = True
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_settings", _fake_check)
+    monkeypatch.setattr("repo_scaffold.cli.apply_repository_settings", _fake_apply)
+
+    rc = main(["sync", "rules", "--all"])
+    assert rc == 0
+    assert apply_called is False
+    stdout = capsys.readouterr().out
+    assert "No drift found" in stdout
+
+
+def test_check_settings_uses_resolved_languages(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "repo_scaffold.cli.resolve_languages", lambda _repo_dir: ["python", "react"]
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_check(*, repo_dir, repo, out, languages):
+        captured["languages"] = languages
+        return SettingsCheckSummary(repo=repo, passed=8, failed=0, skipped=0, drifts=())
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_settings", _fake_check)
+
+    rc = main(["check", "settings", "--repo", "acme/repo"])
+    assert rc == 0
+    assert captured["languages"] == ["python", "react"]
+    stdout = capsys.readouterr().out
+    assert "languages: python, react" in stdout
+
+
+def test_check_settings_languages_flag_overrides_config(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("repo_scaffold.cli.resolve_languages", lambda _repo_dir: ["go"])
+
+    captured: dict[str, object] = {}
+
+    def _fake_check(*, repo_dir, repo, out, languages):
+        captured["languages"] = languages
+        return SettingsCheckSummary(repo=repo, passed=8, failed=0, skipped=0, drifts=())
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_settings", _fake_check)
+
+    rc = main(["check", "settings", "--repo", "acme/repo", "--languages", "python"])
+    assert rc == 0
+    assert captured["languages"] == ["python"]

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -14,6 +14,7 @@ from repo_scaffold.project_config import (
     find_config_file,
     load_config,
     prompt_config,
+    resolve_languages,
     save_config,
 )
 
@@ -143,3 +144,35 @@ def test_prompt_config_overrides_workflow(tmp_path: Path) -> None:
     result = prompt_config(cfg, prompt_fn=_prompt, out=lambda _: None)
     first_workflow_key = next(iter(cfg.workflows))
     assert result.workflows[first_workflow_key] == "Custom Status"
+
+
+def test_default_config_has_no_languages() -> None:
+    cfg = default_config()
+    assert cfg.languages == []
+
+
+def test_save_and_load_config_roundtrips_languages(tmp_path: Path) -> None:
+    cfg = default_config()
+    cfg.languages = ["python", "react"]
+    save_config(cfg, tmp_path / CONFIG_FILENAME)
+    reloaded = load_config(tmp_path)
+    assert reloaded.languages == ["python", "react"]
+
+
+def test_save_config_omits_languages_section_when_empty(tmp_path: Path) -> None:
+    cfg = default_config()
+    save_config(cfg, tmp_path / CONFIG_FILENAME)
+    text = (tmp_path / CONFIG_FILENAME).read_text(encoding="utf-8")
+    assert "languages:" not in text
+
+
+def test_resolve_languages_prefers_declared_config(tmp_path: Path) -> None:
+    cfg = default_config()
+    cfg.languages = ["go"]
+    save_config(cfg, tmp_path / CONFIG_FILENAME)
+    assert resolve_languages(tmp_path) == ["go"]
+
+
+def test_resolve_languages_falls_back_to_detection(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[tool.poetry]\n", encoding="utf-8")
+    assert resolve_languages(tmp_path) == ["python"]

--- a/tests/test_registry_ops.py
+++ b/tests/test_registry_ops.py
@@ -1,0 +1,70 @@
+"""Tests for registry_ops: register/list/forget the local repo registry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repo_scaffold.registry_ops import (
+    forget_repo,
+    list_registry,
+    load_registry,
+    register_repo,
+    save_registry,
+)
+
+
+def test_load_registry_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert load_registry(tmp_path / "registry.json") == {}
+
+
+def test_load_registry_invalid_json_returns_empty(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    path.write_text("not json", encoding="utf-8")
+    assert load_registry(path) == {}
+
+
+def test_register_repo_persists_entry(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    entry = register_repo("acme/repo", "/local/path", "some notes", path=path)
+    assert entry.repo == "acme/repo"
+    assert entry.local_path == "/local/path"
+    assert entry.notes == "some notes"
+
+    reloaded = load_registry(path)
+    assert "acme/repo" in reloaded
+    assert reloaded["acme/repo"].local_path == "/local/path"
+
+
+def test_register_repo_overwrites_existing_entry(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    register_repo("acme/repo", "/old/path", path=path)
+    register_repo("acme/repo", "/new/path", path=path)
+    reloaded = load_registry(path)
+    assert reloaded["acme/repo"].local_path == "/new/path"
+
+
+def test_forget_repo_removes_entry(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    register_repo("acme/repo", "/local/path", path=path)
+    removed = forget_repo("acme/repo", path=path)
+    assert removed is True
+    assert load_registry(path) == {}
+
+
+def test_forget_repo_missing_entry_returns_false(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    assert forget_repo("acme/missing", path=path) is False
+
+
+def test_list_registry_sorted_by_repo_name(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    register_repo("zeta/repo", "/z", path=path)
+    register_repo("alpha/repo", "/a", path=path)
+    entries = list_registry(path=path)
+    assert [e.repo for e in entries] == ["alpha/repo", "zeta/repo"]
+
+
+def test_save_registry_creates_parent_dirs(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "dir" / "registry.json"
+    save_registry({}, path=path)
+    assert path.exists()

--- a/tests/test_registry_ops.py
+++ b/tests/test_registry_ops.py
@@ -25,27 +25,38 @@ def test_load_registry_invalid_json_returns_empty(tmp_path: Path) -> None:
 
 def test_register_repo_persists_entry(tmp_path: Path) -> None:
     path = tmp_path / "registry.json"
-    entry = register_repo("acme/repo", "/local/path", "some notes", path=path)
+    local_dir = tmp_path / "local" / "path"
+    entry = register_repo("acme/repo", str(local_dir), "some notes", path=path)
+    expected = str(local_dir.resolve())
     assert entry.repo == "acme/repo"
-    assert entry.local_path == "/local/path"
+    assert entry.local_path == expected
     assert entry.notes == "some notes"
 
     reloaded = load_registry(path)
     assert "acme/repo" in reloaded
-    assert reloaded["acme/repo"].local_path == "/local/path"
+    assert reloaded["acme/repo"].local_path == expected
+
+
+def test_register_repo_resolves_relative_path(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "registry.json"
+    monkeypatch.chdir(tmp_path)
+    entry = register_repo("acme/repo", ".", path=path)
+    assert entry.local_path == str(tmp_path.resolve())
 
 
 def test_register_repo_overwrites_existing_entry(tmp_path: Path) -> None:
     path = tmp_path / "registry.json"
-    register_repo("acme/repo", "/old/path", path=path)
-    register_repo("acme/repo", "/new/path", path=path)
+    old_dir = tmp_path / "old" / "path"
+    new_dir = tmp_path / "new" / "path"
+    register_repo("acme/repo", str(old_dir), path=path)
+    register_repo("acme/repo", str(new_dir), path=path)
     reloaded = load_registry(path)
-    assert reloaded["acme/repo"].local_path == "/new/path"
+    assert reloaded["acme/repo"].local_path == str(new_dir.resolve())
 
 
 def test_forget_repo_removes_entry(tmp_path: Path) -> None:
     path = tmp_path / "registry.json"
-    register_repo("acme/repo", "/local/path", path=path)
+    register_repo("acme/repo", str(tmp_path / "local" / "path"), path=path)
     removed = forget_repo("acme/repo", path=path)
     assert removed is True
     assert load_registry(path) == {}
@@ -58,8 +69,8 @@ def test_forget_repo_missing_entry_returns_false(tmp_path: Path) -> None:
 
 def test_list_registry_sorted_by_repo_name(tmp_path: Path) -> None:
     path = tmp_path / "registry.json"
-    register_repo("zeta/repo", "/z", path=path)
-    register_repo("alpha/repo", "/a", path=path)
+    register_repo("zeta/repo", str(tmp_path / "z"), path=path)
+    register_repo("alpha/repo", str(tmp_path / "a"), path=path)
     entries = list_registry(path=path)
     assert [e.repo for e in entries] == ["alpha/repo", "zeta/repo"]
 


### PR DESCRIPTION
﻿## 🧾 Title
Add local repo registry, multi-repo check/apply/sync, and declared languages config

## 🧠 Description
We just spent a whole session manually discovering and fixing GitHub merge-settings drift across six repos one at a time, with no record of which repos repo-scaffold even manages. This PR adds a lightweight local registry (`repo register`/`list`/`forget`), a `--repos`/`--all` selector on `check rules` and `apply rules`, and a new `sync rules` command that checks every selected repo for drift, then prompts per repo before applying fixes. It also adds an explicit `languages:` field to `.repo-scaffold.yml` so a repo can declare its CI language checks instead of relying solely on file-based detection, plus a new `check settings` command that reads it.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [ ] Added/updated documentation
- [ ] Refactored existing code
- [ ] Improved error handling or logging
- [ ] Updated environment configuration
- [ ] Other (specify)

## 🎯 Purpose
Give repo-scaffold a way to know which repos it manages and check/fix drift across many of them in one pass, instead of repeating the same manual `check rules`/`apply rules` invocation per repo by hand.

## 🔗 Related Issues / Epics
- **Issue:** #172
- Closes #172

## 🧪 Testing
1. `poetry run repo-scaffold repo register --repo acme/repo --path /local/checkout` then `repo list` and `repo forget` round-trip correctly
2. `check rules --repos a,b` / `--all` and `apply rules --repos a,b` / `--all` resolve local paths from the registry and iterate every target
3. `sync rules --all` shows per-repo drift, prompts y/n, and only applies confirmed repos; with no drift it reports "No drift found" and applies nothing
4. `.repo-scaffold.yml` round-trips a `languages:` list; `check settings` reads it, falling back to `detect_languages_from_repo()` when absent
5. `poetry run pytest` and `poetry run tox -e precommit` pass (71.13% coverage, threshold 70%)

## 🧰 Developer Notes
- Registry lives at `~/.repo-scaffold/registry.json` by default (override via `REPO_SCAFFOLD_REGISTRY_PATH`), storing only `local_path`/`notes` per repo since everything else is one git/GitHub call away
- OAuth-based bulk discovery for repos not explicitly registered is tracked separately in #173
- Scaffold-side drift checking and dashboard export shape are tracked separately in #174
