### PR TITLE
feat(project): add issue re-parent and project setup-views commands

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -20,6 +20,7 @@ from .github_api import (
     branch_create,
     branch_delete,
     issue_add_sub_issue,
+    issue_node_id,
     issue_remove_sub_issue,
     issue_assign,
     issue_close,
@@ -2697,6 +2698,12 @@ def main(argv: list[str] | None = None) -> int:
 
         if ns.issue_command == "re-parent":
             owner, _, repo_name = target_repo.partition("/")
+            if not issue_node_id(owner, repo_name, ns.new_parent_number, token):
+                print(
+                    f"Error: could not resolve --to-parent #{ns.new_parent_number}.",
+                    file=sys.stderr,
+                )
+                return 1
             rm_cp = issue_remove_sub_issue(
                 owner, repo_name, ns.old_parent_number, ns.child_number, token
             )
@@ -2714,6 +2721,19 @@ def main(argv: list[str] | None = None) -> int:
                     add_cp.stderr.strip() or "Failed linking to new parent.",
                     file=sys.stderr,
                 )
+                rb_cp = issue_add_sub_issue(
+                    owner, repo_name, ns.old_parent_number, ns.child_number, token
+                )
+                if rb_cp.returncode != 0:
+                    print(
+                        f"Rollback failed. Issue #{ns.child_number} is now detached.",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(
+                        f"Rolled back: #{ns.child_number} re-linked to #{ns.old_parent_number}.",
+                        file=sys.stderr,
+                    )
                 return 1
             print(
                 f"Issue #{ns.child_number} re-parented: "

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -20,6 +20,7 @@ from .github_api import (
     branch_create,
     branch_delete,
     issue_add_sub_issue,
+    issue_remove_sub_issue,
     issue_assign,
     issue_close,
     issue_comment,
@@ -90,6 +91,7 @@ from .project_ops import (
     list_projects,
     setup_project,
     setup_project_statuses,
+    setup_project_views,
     sync_project_metadata,
     undo_project_backup,
     update_project_item_status,
@@ -890,6 +892,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_project_target_args(project_setup_statuses_cmd)
 
+    project_setup_views_cmd = project_sub.add_parser(
+        "setup-views",
+        help=(
+            "Ensure 'Kanban Board' (board layout) and 'Progress View' "
+            "(table layout, Labels + Parent issue columns, grouped by Parent issue) "
+            "exist on the project"
+        ),
+    )
+    project_setup_views_cmd.add_argument(
+        "--path",
+        default=".",
+        help="Workspace path used for .env resolution (default: .)",
+    )
+    _add_project_target_args(project_setup_views_cmd)
+
     project_edit_cmd = project_sub.add_parser(
         "edit", help="Edit metadata for an existing project"
     )
@@ -1209,6 +1226,39 @@ def build_parser() -> argparse.ArgumentParser:
         "--apply",
         action="store_true",
         help="Apply the backfill (default is dry-run)",
+    )
+
+    issue_reparent_cmd = issue_sub.add_parser(
+        "re-parent",
+        help=(
+            "Move a sub-issue to a new parent: removes it from its current parent "
+            "then links it under the new one"
+        ),
+    )
+    issue_reparent_cmd.add_argument("--repo", required=True)
+    issue_reparent_cmd.add_argument(
+        "--issue",
+        type=int,
+        required=True,
+        dest="child_number",
+        metavar="N",
+        help="Issue number to re-parent",
+    )
+    issue_reparent_cmd.add_argument(
+        "--from-parent",
+        type=int,
+        required=True,
+        dest="old_parent_number",
+        metavar="N",
+        help="Current parent issue number (will be removed)",
+    )
+    issue_reparent_cmd.add_argument(
+        "--to-parent",
+        type=int,
+        required=True,
+        dest="new_parent_number",
+        metavar="N",
+        help="New parent issue number (will be linked)",
     )
 
     pr_cmd = subparsers.add_parser("pr", help="Interact with GitHub pull requests")
@@ -2235,6 +2285,14 @@ def main(argv: list[str] | None = None) -> int:
                     project_title=ns.project_title,
                     out=print,
                 )
+            elif ns.project_command == "setup-views":
+                mutation_summary = setup_project_views(
+                    repo_dir=repo_dir,
+                    owner=ns.project_owner,
+                    project_number=ns.project_number,
+                    project_title=ns.project_title,
+                    out=print,
+                )
             elif ns.project_command == "edit":
                 mutation_summary = edit_project(
                     repo_dir=repo_dir,
@@ -2635,6 +2693,32 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  {key}: {len(items)}")
                 for item in items:
                     print(f"    {item}")
+            return 0
+
+        if ns.issue_command == "re-parent":
+            owner, _, repo_name = target_repo.partition("/")
+            rm_cp = issue_remove_sub_issue(
+                owner, repo_name, ns.old_parent_number, ns.child_number, token
+            )
+            if rm_cp.returncode != 0:
+                print(
+                    rm_cp.stderr.strip() or "Failed removing existing parent link.",
+                    file=sys.stderr,
+                )
+                return 1
+            add_cp = issue_add_sub_issue(
+                owner, repo_name, ns.new_parent_number, ns.child_number, token
+            )
+            if add_cp.returncode != 0:
+                print(
+                    add_cp.stderr.strip() or "Failed linking to new parent.",
+                    file=sys.stderr,
+                )
+                return 1
+            print(
+                f"Issue #{ns.child_number} re-parented: "
+                f"#{ns.old_parent_number} -> #{ns.new_parent_number}."
+            )
             return 0
 
     if ns.mode == "pr":

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1322,6 +1322,116 @@ def issue_sync_hierarchy(
     return _ok(json.dumps(report))
 
 
+_GQL_REMOVE_SUB_ISSUE = """
+mutation($issueId: ID!, $subIssueId: ID!) {
+  removeSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) {
+    issue { id number }
+    subIssue { id number }
+  }
+}
+"""
+
+
+def issue_remove_sub_issue(
+    owner: str,
+    repo: str,
+    parent_number: int,
+    child_number: int,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    """Remove child_number from its current parent parent_number."""
+    parent_id = _resolve_issue_node_id(owner, repo, parent_number, token)
+    if not parent_id:
+        return _err(f"Could not resolve node ID for parent issue #{parent_number}.")
+    child_id = _resolve_issue_node_id(owner, repo, child_number, token)
+    if not child_id:
+        return _err(f"Could not resolve node ID for child issue #{child_number}.")
+    cp = graphql(
+        _GQL_REMOVE_SUB_ISSUE,
+        {"issueId": parent_id, "subIssueId": child_id},
+        token,
+    )
+    if cp.returncode != 0:
+        return cp
+    try:
+        data = json.loads(cp.stdout)
+        result = data.get("removeSubIssue")
+        if not isinstance(result, dict) or "issue" not in result:
+            return _err(
+                "removeSubIssue returned null or unexpected data; GitHub may have rejected the mutation."
+            )
+        return _ok(json.dumps(result))
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response from removeSubIssue.")
+
+
+# ---------------------------------------------------------------------------
+# GitHub Projects v2 — views
+# ---------------------------------------------------------------------------
+
+_GQL_ALL_PROJECT_FIELDS = """
+query($projectId: ID!) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      fields(first: 50) {
+        nodes {
+          ... on ProjectV2Field { id name dataType }
+          ... on ProjectV2SingleSelectField { id name dataType options { id name } }
+          ... on ProjectV2IterationField { id name dataType }
+        }
+      }
+    }
+  }
+}
+"""
+
+_GQL_PROJECT_VIEWS = """
+query($projectId: ID!) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      views(first: 20) {
+        nodes { id name layout }
+      }
+    }
+  }
+}
+"""
+
+
+def project_all_fields(
+    project_id: str,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    """Return all project fields including system fields (Labels, Parent issue, etc.)."""
+    cp = graphql(_GQL_ALL_PROJECT_FIELDS, {"projectId": project_id}, token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        data = json.loads(cp.stdout)
+        nodes = data.get("node", {}).get("fields", {}).get("nodes", [])
+        fields = [n for n in nodes if isinstance(n, dict) and n.get("id")]
+        return _ok(json.dumps({"fields": fields}))
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response fetching all project fields.")
+
+
+def project_views(
+    project_id: str,
+    token: str,
+) -> subprocess.CompletedProcess[str]:
+    """Return the list of views on a project."""
+    cp = graphql(_GQL_PROJECT_VIEWS, {"projectId": project_id}, token)
+    if cp.returncode != 0:
+        return cp
+    try:
+        data = json.loads(cp.stdout)
+        nodes = data.get("node", {}).get("views", {}).get("nodes", [])
+        views = [n for n in nodes if isinstance(n, dict) and n.get("id")]
+        return _ok(json.dumps({"views": views}))
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response fetching project views.")
+
+
 # ---------------------------------------------------------------------------
 # Repo labels
 # ---------------------------------------------------------------------------

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -777,7 +777,7 @@ def setup_project_views(
         owner=project.owner,
         project_number=project.number,
         project_title=project.title,
-        failures=0,
+        failures=len(needs_manual),
         changed=False,
         metadata_file=None,
     )

--- a/src/repo_scaffold/project_ops.py
+++ b/src/repo_scaffold/project_ops.py
@@ -672,6 +672,117 @@ def setup_project_statuses(
     )
 
 
+# Layout constants for readability
+_BOARD_LAYOUT = "BOARD_LAYOUT"
+_TABLE_LAYOUT = "TABLE_LAYOUT"
+
+
+def setup_project_views(
+    *,
+    repo_dir: Path,
+    owner: str | None,
+    project_number: int | None,
+    project_title: str | None,
+    out: Callable[[str], None] = print,
+) -> ProjectMutationSummary:
+    """Verify standard project views exist and print guidance for any manual steps.
+
+    GitHub's public GraphQL API does not expose mutations to create or configure
+    project views, so this function reports the current view state and prints
+    step-by-step UI instructions for anything that still needs manual setup.
+
+    Expected views:
+    - "Kanban Board": BOARD_LAYOUT
+    - "Progress View": TABLE_LAYOUT, Labels + Parent issue columns, grouped by Parent issue
+    """
+    from .github_api import (
+        project_views,
+        token_from_repo,
+    )
+
+    token = token_from_repo(repo_dir) or ""
+    project = _find_existing_project(
+        repo_dir=repo_dir,
+        owner=owner,
+        project_number=project_number,
+        project_title=project_title,
+    )
+    if not project.id:
+        raise RuntimeError(f"Could not resolve project ID for '{project.title}'.")
+
+    project_id = project.id
+
+    cp = project_views(project_id, token)
+    if cp.returncode != 0:
+        raise RuntimeError(cp.stderr.strip() or "Failed fetching project views.")
+    try:
+        existing_views: list[dict[str, object]] = json.loads(cp.stdout).get("views", [])
+    except (json.JSONDecodeError, AttributeError):
+        existing_views = []
+
+    def _find_view(name: str, layout: str) -> dict[str, object] | None:
+        return next(
+            (
+                v
+                for v in existing_views
+                if isinstance(v, dict)
+                and v.get("name") == name
+                and v.get("layout") == layout
+            ),
+            None,
+        )
+
+    needs_manual: list[str] = []
+
+    if _find_view("Kanban Board", _BOARD_LAYOUT):
+        out("'Kanban Board' view exists (BOARD_LAYOUT). OK.")
+    else:
+        out("'Kanban Board' view is missing or has the wrong layout.")
+        needs_manual.append("kanban")
+
+    if _find_view("Progress View", _TABLE_LAYOUT):
+        out("'Progress View' view exists (TABLE_LAYOUT). OK.")
+    else:
+        out("'Progress View' view is missing or has the wrong layout.")
+        needs_manual.append("progress")
+
+    if needs_manual:
+        out("")
+        out(
+            "GitHub's API does not support creating or configuring project views. "
+            "Complete the following steps in the GitHub UI:"
+        )
+        if "kanban" in needs_manual:
+            out(
+                "  Kanban Board: click '+ New view', choose 'Board',"
+                " name it 'Kanban Board'."
+            )
+        if "progress" in needs_manual:
+            out(
+                "  Progress View: click '+ New view', choose 'Table',"
+                " name it 'Progress View'."
+            )
+        out("  In 'Progress View': click Fields, add 'Labels' and 'Parent issue'.")
+        out("  In 'Progress View': click Group by, select 'Parent issue'.")
+    else:
+        out("")
+        out(
+            "Both views present. Verify in GitHub UI that 'Progress View' shows"
+            " 'Labels' and 'Parent issue' columns with Group by = 'Parent issue'."
+        )
+        out("  GitHub's API cannot check or set column visibility or group-by.")
+
+    return ProjectMutationSummary(
+        action="setup-views",
+        owner=project.owner,
+        project_number=project.number,
+        project_title=project.title,
+        failures=0,
+        changed=False,
+        metadata_file=None,
+    )
+
+
 def create_project(
     *,
     repo_dir: Path,
@@ -803,6 +914,17 @@ def create_project(
             )
         except RuntimeError as exc:
             out(f"Warning: could not setup status field: {exc}")
+
+        try:
+            setup_project_views(
+                repo_dir=repo_dir,
+                owner=project_owner,
+                project_number=number,
+                project_title=None,
+                out=out,
+            )
+        except RuntimeError as exc:
+            out(f"Warning: could not setup project views: {exc}")
 
     return ProjectMutationSummary(
         action="create",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3359,3 +3359,39 @@ def test_issue_reparent_add_failure_rolls_back(
     mock_add.assert_has_calls(
         [call("acme", "repo", 20, 5, "tok"), call("acme", "repo", 10, 5, "tok")]
     )
+
+
+def test_issue_reparent_rollback_also_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import subprocess as _sub
+    from unittest.mock import MagicMock
+
+    ok = _sub.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+    fail = _sub.CompletedProcess(args=[], returncode=1, stdout="", stderr="add failed")
+    monkeypatch.setattr(
+        "repo_scaffold.cli.issue_node_id", MagicMock(return_value="I_20")
+    )
+    monkeypatch.setattr(
+        "repo_scaffold.cli.issue_remove_sub_issue", MagicMock(return_value=ok)
+    )
+    mock_add = MagicMock(side_effect=[fail, fail])
+    monkeypatch.setattr("repo_scaffold.cli.issue_add_sub_issue", mock_add)
+    monkeypatch.setenv("GH_TOKEN", "tok")
+
+    rc = main(
+        [
+            "issue",
+            "re-parent",
+            "--repo",
+            "acme/repo",
+            "--issue",
+            "5",
+            "--from-parent",
+            "10",
+            "--to-parent",
+            "20",
+        ]
+    )
+    assert rc == 1
+    assert mock_add.call_count == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3182,3 +3182,108 @@ def test_check_settings_languages_flag_overrides_config(
     rc = main(["check", "settings", "--repo", "acme/repo", "--languages", "python"])
     assert rc == 0
     assert captured["languages"] == ["python"]
+
+
+# ---------------------------------------------------------------------------
+# project setup-views CLI dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_project_setup_views_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI routes 'project setup-views' to setup_project_views and prints summary."""
+    from unittest.mock import MagicMock
+
+    from repo_scaffold.project_ops import ProjectMutationSummary
+
+    summary = ProjectMutationSummary(
+        action="setup-views",
+        owner="acme",
+        project_number=1,
+        project_title="Test Project",
+        failures=0,
+        changed=True,
+        metadata_file=None,
+    )
+    mock_fn = MagicMock(return_value=summary)
+    monkeypatch.setattr("repo_scaffold.cli.setup_project_views", mock_fn)
+    monkeypatch.setenv("GH_TOKEN", "tok")
+
+    rc = main(["project", "setup-views", "--project-title", "Test Project"])
+    assert rc == 0
+    mock_fn.assert_called_once()
+
+
+def test_project_setup_views_propagates_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from unittest.mock import MagicMock
+
+    mock_fn = MagicMock(side_effect=RuntimeError("API call failed"))
+    monkeypatch.setattr("repo_scaffold.cli.setup_project_views", mock_fn)
+    monkeypatch.setenv("GH_TOKEN", "tok")
+
+    rc = main(["project", "setup-views", "--project-title", "Test Project"])
+    assert rc != 0
+
+
+# ---------------------------------------------------------------------------
+# issue re-parent CLI dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_issue_reparent_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    import subprocess as _sub
+    from unittest.mock import MagicMock
+
+    ok = _sub.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+    mock_remove = MagicMock(return_value=ok)
+    mock_add = MagicMock(return_value=ok)
+    monkeypatch.setattr("repo_scaffold.cli.issue_remove_sub_issue", mock_remove)
+    monkeypatch.setattr("repo_scaffold.cli.issue_add_sub_issue", mock_add)
+    monkeypatch.setenv("GH_TOKEN", "tok")
+
+    rc = main(
+        [
+            "issue",
+            "re-parent",
+            "--repo",
+            "acme/repo",
+            "--issue",
+            "5",
+            "--from-parent",
+            "10",
+            "--to-parent",
+            "20",
+        ]
+    )
+    assert rc == 0
+    mock_remove.assert_called_once_with("acme", "repo", 10, 5, "tok")
+    mock_add.assert_called_once_with("acme", "repo", 20, 5, "tok")
+
+
+def test_issue_reparent_remove_failure_returns_1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import subprocess as _sub
+    from unittest.mock import MagicMock
+
+    fail = _sub.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="remove failed"
+    )
+    mock_remove = MagicMock(return_value=fail)
+    monkeypatch.setattr("repo_scaffold.cli.issue_remove_sub_issue", mock_remove)
+    monkeypatch.setenv("GH_TOKEN", "tok")
+
+    rc = main(
+        [
+            "issue",
+            "re-parent",
+            "--repo",
+            "acme/repo",
+            "--issue",
+            "5",
+            "--from-parent",
+            "10",
+            "--to-parent",
+            "20",
+        ]
+    )
+    assert rc == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3234,8 +3234,10 @@ def test_issue_reparent_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
     from unittest.mock import MagicMock
 
     ok = _sub.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+    mock_node_id = MagicMock(return_value="I_20")
     mock_remove = MagicMock(return_value=ok)
     mock_add = MagicMock(return_value=ok)
+    monkeypatch.setattr("repo_scaffold.cli.issue_node_id", mock_node_id)
     monkeypatch.setattr("repo_scaffold.cli.issue_remove_sub_issue", mock_remove)
     monkeypatch.setattr("repo_scaffold.cli.issue_add_sub_issue", mock_add)
     monkeypatch.setenv("GH_TOKEN", "tok")
@@ -3255,8 +3257,34 @@ def test_issue_reparent_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
         ]
     )
     assert rc == 0
+    mock_node_id.assert_called_once_with("acme", "repo", 20, "tok")
     mock_remove.assert_called_once_with("acme", "repo", 10, 5, "tok")
     mock_add.assert_called_once_with("acme", "repo", 20, 5, "tok")
+
+
+def test_issue_reparent_invalid_new_parent_returns_1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import MagicMock
+
+    monkeypatch.setattr("repo_scaffold.cli.issue_node_id", MagicMock(return_value=None))
+    monkeypatch.setenv("GH_TOKEN", "tok")
+
+    rc = main(
+        [
+            "issue",
+            "re-parent",
+            "--repo",
+            "acme/repo",
+            "--issue",
+            "5",
+            "--from-parent",
+            "10",
+            "--to-parent",
+            "99",
+        ]
+    )
+    assert rc == 1
 
 
 def test_issue_reparent_remove_failure_returns_1(
@@ -3267,6 +3295,9 @@ def test_issue_reparent_remove_failure_returns_1(
 
     fail = _sub.CompletedProcess(
         args=[], returncode=1, stdout="", stderr="remove failed"
+    )
+    monkeypatch.setattr(
+        "repo_scaffold.cli.issue_node_id", MagicMock(return_value="I_20")
     )
     mock_remove = MagicMock(return_value=fail)
     monkeypatch.setattr("repo_scaffold.cli.issue_remove_sub_issue", mock_remove)
@@ -3287,3 +3318,44 @@ def test_issue_reparent_remove_failure_returns_1(
         ]
     )
     assert rc == 1
+
+
+def test_issue_reparent_add_failure_rolls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import subprocess as _sub
+    from unittest.mock import MagicMock, call
+
+    ok = _sub.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+    fail = _sub.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="already has parent"
+    )
+    monkeypatch.setattr(
+        "repo_scaffold.cli.issue_node_id", MagicMock(return_value="I_20")
+    )
+    monkeypatch.setattr(
+        "repo_scaffold.cli.issue_remove_sub_issue", MagicMock(return_value=ok)
+    )
+    mock_add = MagicMock(side_effect=[fail, ok])
+    monkeypatch.setattr("repo_scaffold.cli.issue_add_sub_issue", mock_add)
+    monkeypatch.setenv("GH_TOKEN", "tok")
+
+    rc = main(
+        [
+            "issue",
+            "re-parent",
+            "--repo",
+            "acme/repo",
+            "--issue",
+            "5",
+            "--from-parent",
+            "10",
+            "--to-parent",
+            "20",
+        ]
+    )
+    assert rc == 1
+    assert mock_add.call_count == 2
+    mock_add.assert_has_calls(
+        [call("acme", "repo", 20, 5, "tok"), call("acme", "repo", 10, 5, "tok")]
+    )

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1133,3 +1133,111 @@ def test_label_apply_preset_create_error_propagates() -> None:
     ):
         cp = github_api.label_apply_preset("acme/repo", "tok")
     assert cp.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# issue_remove_sub_issue
+# ---------------------------------------------------------------------------
+
+
+def test_issue_remove_sub_issue_success() -> None:
+    node_id_resp = {"repository": {"issue": {"id": "I_child"}}}
+    parent_id_resp = {"repository": {"issue": {"id": "I_parent"}}}
+    remove_resp = {
+        "removeSubIssue": {
+            "issue": {"id": "I_parent", "number": 1},
+            "subIssue": {"id": "I_child", "number": 2},
+        }
+    }
+    with patch.object(
+        github_api,
+        "graphql",
+        side_effect=[
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(parent_id_resp), stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(node_id_resp), stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(remove_resp), stderr=""
+            ),
+        ],
+    ):
+        cp = github_api.issue_remove_sub_issue("owner", "repo", 1, 2, "tok")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert "issue" in result
+
+
+def test_issue_remove_sub_issue_null_response() -> None:
+    node_id_resp = {"repository": {"issue": {"id": "I_child"}}}
+    parent_id_resp = {"repository": {"issue": {"id": "I_parent"}}}
+    remove_resp = {"removeSubIssue": None}
+    with patch.object(
+        github_api,
+        "graphql",
+        side_effect=[
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(parent_id_resp), stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(node_id_resp), stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(remove_resp), stderr=""
+            ),
+        ],
+    ):
+        cp = github_api.issue_remove_sub_issue("owner", "repo", 1, 2, "tok")
+    assert cp.returncode != 0
+    assert "null" in cp.stderr.lower() or "unexpected" in cp.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# project_all_fields
+# ---------------------------------------------------------------------------
+
+
+def test_project_all_fields_returns_all_types() -> None:
+    fields = [
+        {"id": "F_title", "name": "Title", "dataType": "TITLE"},
+        {
+            "id": "F_status",
+            "name": "Status",
+            "dataType": "SINGLE_SELECT",
+            "options": [],
+        },
+        {"id": "F_labels", "name": "Labels", "dataType": "LABELS"},
+        {"id": "F_parent", "name": "Parent issue", "dataType": "PARENT_ISSUE"},
+    ]
+    payload = {"node": {"fields": {"nodes": fields}}}
+    with patch("urllib.request.urlopen", return_value=_gql_resp(payload)):
+        cp = github_api.project_all_fields("PVT_x", "tok")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert len(result["fields"]) == 4
+    dtypes = {f["dataType"] for f in result["fields"]}
+    assert "LABELS" in dtypes
+    assert "PARENT_ISSUE" in dtypes
+
+
+# ---------------------------------------------------------------------------
+# project_views
+# ---------------------------------------------------------------------------
+
+
+def test_project_views_returns_list() -> None:
+    views = [
+        {"id": "PVV_1", "name": "Kanban Board", "layout": "BOARD_LAYOUT"},
+        {"id": "PVV_2", "name": "Progress View", "layout": "TABLE_LAYOUT"},
+    ]
+    payload = {"node": {"views": {"nodes": views}}}
+    with patch("urllib.request.urlopen", return_value=_gql_resp(payload)):
+        cp = github_api.project_views("PVT_x", "tok")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert len(result["views"]) == 2
+    names = {v["name"] for v in result["views"]}
+    assert "Kanban Board" in names
+    assert "Progress View" in names

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1241,3 +1241,43 @@ def test_project_views_returns_list() -> None:
     names = {v["name"] for v in result["views"]}
     assert "Kanban Board" in names
     assert "Progress View" in names
+
+
+def test_issue_remove_sub_issue_parent_not_found() -> None:
+    with patch.object(github_api, "_resolve_issue_node_id", return_value=None):
+        cp = github_api.issue_remove_sub_issue("owner", "repo", 1, 2, "tok")
+    assert cp.returncode != 0
+    assert "parent" in cp.stderr.lower()
+
+
+def test_issue_remove_sub_issue_child_not_found() -> None:
+    with patch.object(
+        github_api, "_resolve_issue_node_id", side_effect=["I_parent", None]
+    ):
+        cp = github_api.issue_remove_sub_issue("owner", "repo", 1, 2, "tok")
+    assert cp.returncode != 0
+    assert "child" in cp.stderr.lower()
+
+
+def test_project_all_fields_graphql_error() -> None:
+    with patch.object(github_api, "graphql", return_value=github_api._err("API error")):
+        cp = github_api.project_all_fields("PVT_x", "tok")
+    assert cp.returncode != 0
+
+
+def test_project_all_fields_unexpected_response() -> None:
+    with patch.object(github_api, "graphql", return_value=github_api._ok("not-json")):
+        cp = github_api.project_all_fields("PVT_x", "tok")
+    assert cp.returncode != 0
+
+
+def test_project_views_graphql_error() -> None:
+    with patch.object(github_api, "graphql", return_value=github_api._err("API error")):
+        cp = github_api.project_views("PVT_x", "tok")
+    assert cp.returncode != 0
+
+
+def test_project_views_unexpected_response() -> None:
+    with patch.object(github_api, "graphql", return_value=github_api._ok("not-json")):
+        cp = github_api.project_views("PVT_x", "tok")
+    assert cp.returncode != 0

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1250,6 +1250,28 @@ def test_issue_remove_sub_issue_parent_not_found() -> None:
     assert "parent" in cp.stderr.lower()
 
 
+def test_issue_remove_sub_issue_graphql_failure() -> None:
+    with patch.object(
+        github_api, "_resolve_issue_node_id", side_effect=["I_parent", "I_child"]
+    ):
+        with patch.object(
+            github_api, "graphql", return_value=github_api._err("GQL error")
+        ):
+            cp = github_api.issue_remove_sub_issue("owner", "repo", 1, 2, "tok")
+    assert cp.returncode != 0
+
+
+def test_issue_remove_sub_issue_bad_json() -> None:
+    with patch.object(
+        github_api, "_resolve_issue_node_id", side_effect=["I_parent", "I_child"]
+    ):
+        with patch.object(
+            github_api, "graphql", return_value=github_api._ok("not-json{")
+        ):
+            cp = github_api.issue_remove_sub_issue("owner", "repo", 1, 2, "tok")
+    assert cp.returncode != 0
+
+
 def test_issue_remove_sub_issue_child_not_found() -> None:
     with patch.object(
         github_api, "_resolve_issue_node_id", side_effect=["I_parent", None]

--- a/tests/test_project_ops.py
+++ b/tests/test_project_ops.py
@@ -847,3 +847,129 @@ def test_setup_project_no_project_id_raises(
             project_title="Roadmap",
             out=lambda _: None,
         )
+
+
+# ---------------------------------------------------------------------------
+# setup_project_views
+# ---------------------------------------------------------------------------
+
+
+def _cp_err(stderr: str = "boom") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+def test_setup_project_views_both_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import repo_scaffold.github_api as _ga
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    project = project_ops.ProjectInfo(
+        owner="acme", number=1, title="Roadmap", id="PVT_x"
+    )
+    monkeypatch.setattr(project_ops, "_find_existing_project", lambda **_kw: project)
+    monkeypatch.setattr(_ga, "token_from_repo", lambda _: "tok")
+
+    views_payload = json.dumps(
+        {
+            "views": [
+                {"id": "V1", "name": "Kanban Board", "layout": "BOARD_LAYOUT"},
+                {"id": "V2", "name": "Progress View", "layout": "TABLE_LAYOUT"},
+            ]
+        }
+    )
+    monkeypatch.setattr(_ga, "project_views", lambda *_a, **_kw: _cp_ok(views_payload))
+
+    messages: list[str] = []
+    summary = project_ops.setup_project_views(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=1,
+        project_title="Roadmap",
+        out=messages.append,
+    )
+
+    assert summary.failures == 0
+    assert any("Both views present" in m for m in messages)
+
+
+def test_setup_project_views_missing_views(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import repo_scaffold.github_api as _ga
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    project = project_ops.ProjectInfo(
+        owner="acme", number=1, title="Roadmap", id="PVT_x"
+    )
+    monkeypatch.setattr(project_ops, "_find_existing_project", lambda **_kw: project)
+    monkeypatch.setattr(_ga, "token_from_repo", lambda _: "tok")
+    monkeypatch.setattr(
+        _ga, "project_views", lambda *_a, **_kw: _cp_ok('{"views": []}')
+    )
+
+    messages: list[str] = []
+    summary = project_ops.setup_project_views(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=1,
+        project_title="Roadmap",
+        out=messages.append,
+    )
+
+    assert summary.failures == 2
+    assert any("Kanban Board" in m for m in messages)
+    assert any("Progress View" in m for m in messages)
+
+
+def test_setup_project_views_fetch_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import repo_scaffold.github_api as _ga
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    project = project_ops.ProjectInfo(
+        owner="acme", number=1, title="Roadmap", id="PVT_x"
+    )
+    monkeypatch.setattr(project_ops, "_find_existing_project", lambda **_kw: project)
+    monkeypatch.setattr(_ga, "token_from_repo", lambda _: "tok")
+    monkeypatch.setattr(
+        _ga, "project_views", lambda *_a, **_kw: _cp_err("connection refused")
+    )
+
+    with pytest.raises(RuntimeError, match="connection refused"):
+        project_ops.setup_project_views(
+            repo_dir=repo_dir,
+            owner="acme",
+            project_number=1,
+            project_title="Roadmap",
+            out=lambda _: None,
+        )
+
+
+def test_setup_project_views_no_project_id_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import repo_scaffold.github_api as _ga
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    project = project_ops.ProjectInfo(owner="acme", number=1, title="Roadmap", id=None)
+    monkeypatch.setattr(project_ops, "_find_existing_project", lambda **_kw: project)
+    monkeypatch.setattr(_ga, "token_from_repo", lambda _: "tok")
+
+    with pytest.raises(RuntimeError, match="Could not resolve project ID"):
+        project_ops.setup_project_views(
+            repo_dir=repo_dir,
+            owner="acme",
+            project_number=1,
+            project_title="Roadmap",
+            out=lambda _: None,
+        )

--- a/tests/test_project_ops.py
+++ b/tests/test_project_ops.py
@@ -973,3 +973,208 @@ def test_setup_project_views_no_project_id_raises(
             project_title="Roadmap",
             out=lambda _: None,
         )
+
+
+def test_setup_project_views_bad_json_response(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import repo_scaffold.github_api as _ga
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    project = project_ops.ProjectInfo(
+        owner="acme", number=1, title="Roadmap", id="PVT_x"
+    )
+    monkeypatch.setattr(project_ops, "_find_existing_project", lambda **_kw: project)
+    monkeypatch.setattr(_ga, "token_from_repo", lambda _: "tok")
+    monkeypatch.setattr(_ga, "project_views", lambda *_a, **_kw: _cp_ok("not-json{"))
+
+    messages: list[str] = []
+    summary = project_ops.setup_project_views(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=1,
+        project_title="Roadmap",
+        out=messages.append,
+    )
+
+    assert summary.failures == 2
+
+
+def test_setup_project_views_only_kanban_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import repo_scaffold.github_api as _ga
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    project = project_ops.ProjectInfo(
+        owner="acme", number=1, title="Roadmap", id="PVT_x"
+    )
+    monkeypatch.setattr(project_ops, "_find_existing_project", lambda **_kw: project)
+    monkeypatch.setattr(_ga, "token_from_repo", lambda _: "tok")
+    views_payload = json.dumps(
+        {"views": [{"id": "V2", "name": "Progress View", "layout": "TABLE_LAYOUT"}]}
+    )
+    monkeypatch.setattr(_ga, "project_views", lambda *_a, **_kw: _cp_ok(views_payload))
+
+    messages: list[str] = []
+    summary = project_ops.setup_project_views(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=1,
+        project_title="Roadmap",
+        out=messages.append,
+    )
+
+    assert summary.failures == 1
+    assert any("Kanban Board" in m for m in messages)
+    assert not any("Progress View: click" in m for m in messages)
+
+
+def test_setup_project_views_only_progress_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import repo_scaffold.github_api as _ga
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    project = project_ops.ProjectInfo(
+        owner="acme", number=1, title="Roadmap", id="PVT_x"
+    )
+    monkeypatch.setattr(project_ops, "_find_existing_project", lambda **_kw: project)
+    monkeypatch.setattr(_ga, "token_from_repo", lambda _: "tok")
+    views_payload = json.dumps(
+        {"views": [{"id": "V1", "name": "Kanban Board", "layout": "BOARD_LAYOUT"}]}
+    )
+    monkeypatch.setattr(_ga, "project_views", lambda *_a, **_kw: _cp_ok(views_payload))
+
+    messages: list[str] = []
+    summary = project_ops.setup_project_views(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_number=1,
+        project_title="Roadmap",
+        out=messages.append,
+    )
+
+    assert summary.failures == 1
+    assert any("Progress View" in m for m in messages)
+    assert not any("Kanban Board: click" in m for m in messages)
+
+
+def test_create_project_calls_setup_views_when_repo_given(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    monkeypatch.setattr(
+        project_ops,
+        "_resolve_project_owner",
+        lambda _owner, **_kw: "acme",
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "_run_gh",
+        lambda _repo_dir, args: _cp_ok(json.dumps({"number": 9, "title": "Roadmap"})),
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "edit_project",
+        lambda **_kw: project_ops.ProjectMutationSummary(
+            action="edit",
+            owner="acme",
+            project_number=9,
+            project_title="Roadmap",
+            failures=0,
+            changed=True,
+        ),
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "link_project_repo",
+        lambda **_kw: None,
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "setup_project_statuses",
+        lambda **_kw: None,
+    )
+    setup_calls: list[str] = []
+    monkeypatch.setattr(
+        project_ops,
+        "setup_project_views",
+        lambda **_kw: setup_calls.append("called"),
+    )
+
+    project_ops.create_project(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_title="Roadmap",
+        description="desc",
+        readme=None,
+        visibility=None,
+        repo="acme/my-repo",
+        dry_run=False,
+        out=lambda _: None,
+    )
+
+    assert setup_calls == ["called"]
+
+
+def test_create_project_setup_views_error_is_warned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    monkeypatch.setattr(
+        project_ops,
+        "_resolve_project_owner",
+        lambda _owner, **_kw: "acme",
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "_run_gh",
+        lambda _repo_dir, args: _cp_ok(json.dumps({"number": 9, "title": "Roadmap"})),
+    )
+    monkeypatch.setattr(
+        project_ops,
+        "edit_project",
+        lambda **_kw: project_ops.ProjectMutationSummary(
+            action="edit",
+            owner="acme",
+            project_number=9,
+            project_title="Roadmap",
+            failures=0,
+            changed=True,
+        ),
+    )
+    monkeypatch.setattr(project_ops, "link_project_repo", lambda **_kw: None)
+    monkeypatch.setattr(project_ops, "setup_project_statuses", lambda **_kw: None)
+    monkeypatch.setattr(
+        project_ops,
+        "setup_project_views",
+        lambda **_kw: (_ for _ in ()).throw(RuntimeError("API unavailable")),
+    )
+
+    messages: list[str] = []
+    project_ops.create_project(
+        repo_dir=repo_dir,
+        owner="acme",
+        project_title="Roadmap",
+        description="desc",
+        readme=None,
+        visibility=None,
+        repo="acme/my-repo",
+        dry_run=False,
+        out=messages.append,
+    )
+
+    assert any("Warning" in m and "setup project views" in m for m in messages)


### PR DESCRIPTION
﻿## 🧾 Title
feat(project): add issue re-parent and project setup-views commands

## 🧠 Description
Adds two new capabilities to unblock the GitHub Projects roadmap view and fix swapped sub-issue parents in muster-deck.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [x] Improved error handling or logging

## 🎯 Purpose
Two gaps were blocking a usable Roadmap view:

1. Two muster-deck issues (#157, #115) have swapped native parents relative to their epic labels. Fixing them requires removeSubIssue before addSubIssue -- this PR adds that mutation and an `issue re-parent` CLI command.

2. Newly created projects had no standard views. GitHub's public GraphQL API does not expose mutations to create or configure project views (addProjectV2View, updateProjectV2View all return "field doesn't exist on type Mutation"). The new `project setup-views` command queries current views via the working project_views GraphQL query, reports pass/fail for the expected "Kanban Board" (BOARD_LAYOUT) and "Progress View" (TABLE_LAYOUT), and prints step-by-step GitHub UI instructions for any view that is missing or misconfigured. It is wired into the `project create` flow.

## 🔗 Related Issues / Epics
- **Epic:** #105
- **Issue:** #178
- Closes #178

## 🧪 Testing
- [x] `poetry run tox -e precommit` -- green, 72.22% coverage
- [x] Codecov patch coverage met (ea97122 adds error-path and setup_project_views unit tests)
- [x] Live test: `project setup-views --project-title "Roadmap"` reports both views OK against the live blairg23/repo-scaffold project
- [ ] Once merged, use `issue re-parent --repo ThePRIMEForge/muster-deck --issue 157 --from-parent 105 --to-parent 108` and `--issue 115 --from-parent 108 --to-parent 105` to fix the swapped muster-deck parents

## 🧰 Developer Notes
- GitHub's public API limitation (no view creation/config mutations) is documented in the command output and the function docstring; no workaround exists in the public API
- `project_all_fields` query is retained for read-only field introspection