### PR TITLE
fix(workspace): add configure-auth command to silence GCM popups (#190)

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -1492,6 +1492,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     ws_prune.add_argument("--repo", required=True, help="OWNER/REPO")
 
+    ws_configure_auth = workspace_sub.add_parser(
+        "configure-auth",
+        help=(
+            "Configure git credential-store from .env GH_TOKEN, "
+            "bypassing Windows Credential Manager (GCM)"
+        ),
+    )
+    ws_configure_auth.add_argument(
+        "--path",
+        default=None,
+        dest="auth_path",
+        help="Path to a git working tree (default: current directory)",
+    )
+
     return parser
 
 
@@ -3110,6 +3124,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if ns.mode == "workspace":
         from .workspace_ops import (
+            workspace_configure_auth,
             workspace_create,
             workspace_delete,
             workspace_list,
@@ -3147,6 +3162,15 @@ def main(argv: list[str] | None = None) -> int:
 
         if ns.workspace_command == "prune":
             cp = workspace_prune(ns.repo)
+            if cp.returncode != 0:
+                print(cp.stderr.strip(), file=sys.stderr)
+                return 1
+            print(cp.stdout.strip())
+            return 0
+
+        if ns.workspace_command == "configure-auth":
+            auth_path = Path(ns.auth_path) if ns.auth_path else None
+            cp = workspace_configure_auth(token, path=auth_path)
             if cp.returncode != 0:
                 print(cp.stderr.strip(), file=sys.stderr)
                 return 1

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -3169,8 +3169,9 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         if ns.workspace_command == "configure-auth":
-            auth_path = Path(ns.auth_path) if ns.auth_path else None
-            cp = workspace_configure_auth(token, path=auth_path)
+            auth_path = Path(ns.auth_path).resolve() if ns.auth_path else None
+            effective_token = (auth_path and token_from_repo(auth_path)) or token
+            cp = workspace_configure_auth(effective_token, path=auth_path)
             if cp.returncode != 0:
                 print(cp.stderr.strip(), file=sys.stderr)
                 return 1

--- a/src/repo_scaffold/workspace_ops.py
+++ b/src/repo_scaffold/workspace_ops.py
@@ -188,7 +188,7 @@ def workspace_configure_auth(
     Manager (GCM) in non-interactive contexts. Safe to run multiple times -- clears
     any accumulated helper entries before writing fresh config.
     """
-    worktree = path or Path.cwd()
+    worktree = (path or Path.cwd()).resolve()
     git_dir = worktree / ".git"
     if not git_dir.is_dir():
         return _err(f"Not a git repository: {worktree}")

--- a/src/repo_scaffold/workspace_ops.py
+++ b/src/repo_scaffold/workspace_ops.py
@@ -177,6 +177,49 @@ def _setup_bare_auth(bare: Path, token: str) -> None:
     )
 
 
+def workspace_configure_auth(
+    token: str,
+    path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Configure git credential-store for a regular (non-bare) working tree.
+
+    Writes credentials to .git/.git-credentials (inside the .git dir, never tracked)
+    and configures the local credential.helper chain to bypass Windows Credential
+    Manager (GCM) in non-interactive contexts. Safe to run multiple times -- clears
+    any accumulated helper entries before writing fresh config.
+    """
+    worktree = path or Path.cwd()
+    git_dir = worktree / ".git"
+    if not git_dir.is_dir():
+        return _err(f"Not a git repository: {worktree}")
+
+    username = _github_username(token)
+    creds_file = git_dir / ".git-credentials"
+    # LF-only, no BOM: git-credential-store rejects BOM and CRLF on all platforms
+    creds_file.write_bytes(f"https://{username}:{token}@github.com\n".encode())
+    try:
+        creds_file.chmod(0o600)
+    except NotImplementedError:
+        pass
+
+    creds_posix = creds_file.as_posix()
+    # Clear any accumulated local helpers (idempotent -- exit 5 = key not found = ok)
+    _run(["git", "config", "--unset-all", "credential.helper"], cwd=worktree)
+    # Empty string resets the credential helper list, overriding the system GCM
+    _run(["git", "config", "credential.helper", ""], cwd=worktree)
+    _run(
+        [
+            "git",
+            "config",
+            "--add",
+            "credential.helper",
+            f'store --file "{creds_posix}"',
+        ],
+        cwd=worktree,
+    )
+    return _ok(f"Configured credential-store for {worktree}")
+
+
 def workspace_create(
     repo: str,
     branch: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3395,3 +3395,38 @@ def test_issue_reparent_rollback_also_fails(
     )
     assert rc == 1
     assert mock_add.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# workspace configure-auth
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_configure_auth_cli_returns_1_on_error(
+    tmp_path: Path,
+) -> None:
+    not_a_repo = tmp_path / "not-a-repo"
+    not_a_repo.mkdir()
+    rc = main(["workspace", "configure-auth", "--path", str(not_a_repo)])
+    assert rc == 1
+
+
+def test_workspace_configure_auth_cli_defaults_to_cwd_on_error(
+    tmp_path: Path,
+) -> None:
+    # autouse fixture already chdirs to tmp_path (not a git repo)
+    rc = main(["workspace", "configure-auth"])
+    assert rc == 1
+
+
+def test_workspace_configure_auth_cli_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "repo_scaffold.workspace_ops.workspace_configure_auth",
+        lambda token, path=None: SimpleNamespace(
+            returncode=0, stdout="Configured.", stderr=""
+        ),
+    )
+    rc = main(["workspace", "configure-auth"])
+    assert rc == 0

--- a/tests/test_workspace_ops.py
+++ b/tests/test_workspace_ops.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 from repo_scaffold.workspace_ops import (
     _copy_ignored_files,
@@ -486,7 +488,7 @@ def test_workspace_configure_auth_writes_credentials(tmp_path: Path):
     raw = creds.read_bytes()
     assert not raw.startswith(b"\xef\xbb\xbf"), "must not have UTF-8 BOM"
     assert b"fake-token" in raw
-    assert b"github.com" in raw
+    assert b"@github.com\n" in raw, "token must appear immediately before @github.com"
     assert raw.endswith(b"\n"), "must have trailing LF"
     assert b"\r" not in raw, "must not have CRLF"
 
@@ -532,3 +534,16 @@ def test_workspace_configure_auth_fails_for_non_repo(tmp_path: Path):
     cp = workspace_configure_auth("fake-token", path=not_a_repo)
     assert cp.returncode != 0
     assert "Not a git repository" in cp.stderr
+
+
+def test_workspace_configure_auth_chmod_not_implemented_is_swallowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    repo = _init_working_tree(tmp_path)
+
+    def _raise_not_implemented(self: Path, mode: int) -> None:
+        raise NotImplementedError
+
+    monkeypatch.setattr(Path, "chmod", _raise_not_implemented)
+    cp = workspace_configure_auth("fake-token", path=repo)
+    assert cp.returncode == 0

--- a/tests/test_workspace_ops.py
+++ b/tests/test_workspace_ops.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from repo_scaffold.workspace_ops import (
     _copy_ignored_files,
     _slug,
+    workspace_configure_auth,
     workspace_create,
     workspace_delete,
     workspace_list,
@@ -449,3 +450,85 @@ def test_workspace_create_missing_env_source_warns_not_errors(tmp_path: Path):
 
     assert cp.returncode == 0
     assert "Warning" in cp.stdout
+
+
+# ---------------------------------------------------------------------------
+# workspace_configure_auth
+# ---------------------------------------------------------------------------
+
+
+def _init_working_tree(tmp_path: Path, name: str = "worktree") -> Path:
+    """Create a regular (non-bare) git repo for configure-auth tests."""
+    repo = tmp_path / name
+    repo.mkdir()
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    return repo
+
+
+def test_workspace_configure_auth_writes_credentials(tmp_path: Path):
+    repo = _init_working_tree(tmp_path)
+    cp = workspace_configure_auth("fake-token", path=repo)
+    assert cp.returncode == 0
+    creds = repo / ".git" / ".git-credentials"
+    assert creds.exists()
+    raw = creds.read_bytes()
+    assert not raw.startswith(b"\xef\xbb\xbf"), "must not have UTF-8 BOM"
+    assert b"fake-token" in raw
+    assert b"github.com" in raw
+    assert raw.endswith(b"\n"), "must have trailing LF"
+    assert b"\r" not in raw, "must not have CRLF"
+
+
+def _local_credential_helpers(repo: Path) -> list[str]:
+    """Return credential.helper values from local git config as 'key=value' strings."""
+    r = subprocess.run(
+        ["git", "config", "--local", "--list"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    return [
+        line for line in r.stdout.splitlines() if line.startswith("credential.helper=")
+    ]
+
+
+def test_workspace_configure_auth_sets_credential_helper(tmp_path: Path):
+    repo = _init_working_tree(tmp_path)
+    workspace_configure_auth("fake-token", path=repo)
+    helpers = _local_credential_helpers(repo)
+    assert (
+        helpers[0] == "credential.helper="
+    ), "first entry must be empty string (chain reset)"
+    assert any(
+        "store" in h and ".git-credentials" in h for h in helpers
+    ), "must include a store helper pointing at .git-credentials"
+
+
+def test_workspace_configure_auth_is_idempotent(tmp_path: Path):
+    repo = _init_working_tree(tmp_path)
+    workspace_configure_auth("fake-token", path=repo)
+    workspace_configure_auth("fake-token", path=repo)
+    helpers = _local_credential_helpers(repo)
+    assert (
+        len(helpers) == 2
+    ), f"expected exactly 2 entries (empty + store), got {helpers}"
+
+
+def test_workspace_configure_auth_fails_for_non_repo(tmp_path: Path):
+    not_a_repo = tmp_path / "not-a-repo"
+    not_a_repo.mkdir()
+    cp = workspace_configure_auth("fake-token", path=not_a_repo)
+    assert cp.returncode != 0
+    assert "Not a git repository" in cp.stderr


### PR DESCRIPTION
﻿## 🧾 Title
Add workspace configure-auth command to silence GCM popups

## 🧠 Description
The main working tree (and any other regular git repo using repo-scaffold) was
missing the credential-store setup that workspace_create applies to managed
worktrees via _setup_bare_auth. Without it, the first git push triggers a Windows
Credential Manager GUI popup in non-interactive contexts.

This PR adds workspace configure-auth, a one-time command that reads GH_TOKEN from
.env and configures the local credential.helper chain to use git-credential-store
instead of GCM. Run once after cloning and all future pushes are silent.

Root cause of previous failed manual attempts: UTF-8 BOM in the credentials file
(Set-Content -Encoding utf8 in PS5 adds BOM; git-credential-store rejects it) and
missing empty-string chain reset (GCM was still in the system-level helper chain).
The fix uses write_bytes() to guarantee LF-only, no-BOM output and --unset-all
before writing to prevent accumulated duplicate entries.

## 🧩 Changes Included
- [x] workspace_ops.py: workspace_configure_auth(token, path) function
- [x] cli.py: workspace configure-auth [--path PATH] subcommand
- [x] tests/test_workspace_ops.py: 4 tests covering credentials format, helper chain, idempotency, and error on non-repo

## 🎯 Purpose
Eliminates Windows Credential Manager GUI popups from the main working tree. The
command is idempotent (safe to re-run when the token rotates) and works for any
regular git working tree, not just managed worktrees.

## 🔗 Related Issues / Epics
- **Epic:** #48
- Closes #190

## 🧪 Testing
1. poetry run pytest tests/test_workspace_ops.py -q -k configure_auth -- 4 pass
2. poetry run tox -e precommit -- green
3. Manual: run poetry run repo-scaffold workspace configure-auth, then git push -- no GCM popup

## 🧰 Developer Notes
- Credentials stored in .git/.git-credentials (inside .git dir, never tracked by git)
- git config --unset-all before setting ensures idempotency regardless of prior state
- Path uses as_posix() for cross-platform compatibility in the store --file argument