### PR TITLE
fix(generator): propagate validate-issue.yml to downstream repos via apply templates (#192)

### DIFF
--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -26,6 +26,17 @@ jobs:
               return;
             }
 
+            // Create needs-format label if it does not exist yet (422 = already exists)
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: "needs-format",
+                color: "e11d48",
+                description: "Issue body does not match the required template format",
+              });
+            } catch (_) {}
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -177,6 +177,10 @@ contact_links:
 """
 
 
+def _render_validate_issue_workflow() -> str:
+    return _load_template("github/workflows/validate-issue.yml", "")
+
+
 def _render_ci_yaml(languages: Iterable[str]) -> str:
     selected = set(languages)
     parts: list[str] = [
@@ -3188,6 +3192,10 @@ def build_scaffold_files(config: ScaffoldConfig) -> list[ScaffoldFile]:
             _render_codeql_yaml(config.languages),
         ),
         ScaffoldFile(
+            config.out_dir / ".github" / "workflows" / "validate-issue.yml",
+            _render_validate_issue_workflow(),
+        ),
+        ScaffoldFile(
             config.out_dir / ".github" / "dependabot.yml",
             _render_dependabot_yaml(config.languages),
         ),
@@ -3321,6 +3329,7 @@ TEMPLATE_FILE_PATHS = (
     ".github/ISSUE_TEMPLATE/epic.md",
     ".github/ISSUE_TEMPLATE/ticket.md",
     ".github/ISSUE_TEMPLATE/config.yml",
+    ".github/workflows/validate-issue.yml",
 )
 
 

--- a/src/repo_scaffold/templates/github/workflows/validate-issue.yml
+++ b/src/repo_scaffold/templates/github/workflows/validate-issue.yml
@@ -26,6 +26,17 @@ jobs:
               return;
             }
 
+            // Create needs-format label if it does not exist yet (422 = already exists)
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: "needs-format",
+                color: "e11d48",
+                description: "Issue body does not match the required template format",
+              });
+            } catch (_) {}
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,7 @@ def test_apply_templates_only_writes_template_files(tmp_path: Path) -> None:
     assert (repo_dir / ".github" / "ISSUE_TEMPLATE" / "ticket.md").exists()
     assert (repo_dir / ".github" / "ISSUE_TEMPLATE" / "epic.md").exists()
     assert (repo_dir / ".github" / "CODEOWNERS").exists()
+    assert (repo_dir / ".github" / "workflows" / "validate-issue.yml").exists()
     assert not (repo_dir / "go.mod").exists()
     assert (repo_dir / "README.md").read_text(encoding="utf-8") == "# Existing\n"
 


### PR DESCRIPTION
﻿## 🧾 Title
Fix generator to propagate validate-issue.yml to downstream repos via apply templates

## 🧠 Description
validate-issue.yml was added in PR #187 to TEMPLATE_FILE_PATHS but was never added to
the build_scaffold_files output. The _filter_files_for_paths function can only select
files that build_scaffold_files already generates -- a path in TEMPLATE_FILE_PATHS
with no matching ScaffoldFile is silently skipped. So every apply templates run on a
downstream repo (ToolShed, muster-deck, etc.) produced 5 files instead of 6.

Two things were missing: a _render_validate_issue_workflow() function that loads the
template, and a ScaffoldFile entry in build_scaffold_files that places it at
.github/workflows/validate-issue.yml. Both are added in this PR.

## 🧩 Changes Included
- [x] generator.py: _render_validate_issue_workflow() using existing _load_template() pattern
- [x] generator.py: ScaffoldFile entry for .github/workflows/validate-issue.yml in build_scaffold_files
- [x] tests/test_cli.py: assert validate-issue.yml is created by apply templates

## 🎯 Purpose
Ensures apply templates propagates the issue-body validation workflow to all downstream
repos. Without this fix, ToolShed and muster-deck would not receive validate-issue.yml.

## 🔗 Related Issues / Epics
- **Epic:** #48
- Closes #192

## 🧪 Testing
1. poetry run pytest tests/test_cli.py -q -k apply_templates -- passes (6 files created)
2. poetry run tox -e precommit -- green

## 🧰 Developer Notes
- Template source: src/repo_scaffold/templates/github/workflows/validate-issue.yml (already exists since #187)
- Fallback is empty string (template file is always present in the package)
- After this merges: re-run apply templates on ToolShed worktree to pick up the workflow