### PR TITLE
fix(templates): use bare Closes keyword so GitHub auto-closes issues on merge (#199)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ This PR aims to [describe the goal or intended outcome].
 <!-- Link GitHub issues/epics for traceability. -->
 - **Epic:** #<epic-issue-number>
 - **Issue:** #<issue-number>
-- **Closes:** Fixes #<issue-number>
+- Closes #<issue-number>
 
 ## 🧪 Testing
 <!-- Describe how reviewers can verify this PR works as intended. -->

--- a/src/repo_scaffold/templates/github/pull_request_template.md
+++ b/src/repo_scaffold/templates/github/pull_request_template.md
@@ -22,7 +22,7 @@ This PR aims to [describe the goal or intended outcome].
 <!-- Link GitHub issues/epics for traceability. -->
 - **Epic:** #<epic-issue-number>
 - **Issue:** #<issue-number>
-- **Closes:** Fixes #<issue-number>
+- Closes #<issue-number>
 
 ## 🧪 Testing
 <!-- Describe how reviewers can verify this PR works as intended. -->


### PR DESCRIPTION
## 🧾 Title
fix(templates): use bare Closes keyword so GitHub auto-closes issues on merge

## 🧠 Description
The PR template had `- **Closes:** Fixes #N` which GitHub does not recognize as an auto-close keyword. GitHub only fires auto-close when the keyword appears as bare text: `- Closes #N`. The bold markdown wrapper and the colon both break detection.

This caused multiple issues (#195, #196) to remain open after their fixing PRs merged, requiring manual closes every time.

## 🩹 Changes Included
- `.github/pull_request_template.md`: `- **Closes:** Fixes #N` → `- Closes #N`
- `src/repo_scaffold/templates/github/pull_request_template.md`: same fix (source of truth for scaffolded repos)

## 🎯 Purpose
Stop requiring manual issue closes after every merged PR.

## 🔗 Related Issues / Epics
- **Epic:** #48
- Closes #199

## 🧪 Testing
1. Merge a PR whose body contains `- Closes #N` and confirm the linked issue auto-closes
