### PR TITLE
fix(generator): pin SARIF uploads to PR HEAD commit SHA (#200)

### DIFF
--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -373,7 +373,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v4
       - name: Check for source files
         id: check-src
         run: |
@@ -382,6 +381,8 @@ jobs:
           else
             echo "has_source=false" >> $GITHUB_OUTPUT
           fi
+      - uses: github/codeql-action/init@v4
+        if: steps.check-src.outputs.has_source == 'true'
       - uses: github/codeql-action/autobuild@v4
         if: steps.check-src.outputs.has_source == 'true'
       - uses: github/codeql-action/analyze@v4
@@ -435,9 +436,6 @@ jobs:
 {matrix_lines}
     steps:
       - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v4
-        with:
-          languages: ${{{{ matrix.language }}}}
       - name: Check for source files
         id: check-src
         run: |
@@ -446,6 +444,10 @@ jobs:
           else
             echo "has_source=false" >> $GITHUB_OUTPUT
           fi
+      - uses: github/codeql-action/init@v4
+        if: steps.check-src.outputs.has_source == 'true'
+        with:
+          languages: ${{{{ matrix.language }}}}
       - uses: github/codeql-action/autobuild@v4
         if: steps.check-src.outputs.has_source == 'true'
       - uses: github/codeql-action/analyze@v4

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -373,6 +373,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v4
       - name: Check for source files
         id: check-src
         run: |
@@ -381,26 +382,23 @@ jobs:
           else
             echo "has_source=false" >> $GITHUB_OUTPUT
           fi
-      - uses: github/codeql-action/init@v4
-        if: steps.check-src.outputs.has_source == 'true'
       - uses: github/codeql-action/autobuild@v4
         if: steps.check-src.outputs.has_source == 'true'
       - uses: github/codeql-action/analyze@v4
         if: steps.check-src.outputs.has_source == 'true'
+        with:
+          sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.event.pull_request.head.ref) || github.ref }}
       - name: Upload empty SARIF (no source files found)
         if: steps.check-src.outputs.has_source == 'false'
         run: |
-          cat > empty.sarif <<'SARIF'
-          {
-            "version": "2.1.0",
-            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-            "runs": [{"tool": {"driver": {"name": "CodeQL", "version": "0.0.0", "rules": []}}, "results": []}]
-          }
-          SARIF
+          echo '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL","version":"0.0.0","rules":[]}},"results":[]}]}' > empty.sarif
       - uses: github/codeql-action/upload-sarif@v4
         if: steps.check-src.outputs.has_source == 'false'
         with:
           sarif_file: empty.sarif
+          sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.event.pull_request.head.ref) || github.ref }}
 """
 
     src_globs = {
@@ -437,6 +435,9 @@ jobs:
 {matrix_lines}
     steps:
       - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{{{ matrix.language }}}}
       - name: Check for source files
         id: check-src
         run: |
@@ -445,29 +446,24 @@ jobs:
           else
             echo "has_source=false" >> $GITHUB_OUTPUT
           fi
-      - uses: github/codeql-action/init@v4
-        if: steps.check-src.outputs.has_source == 'true'
-        with:
-          languages: ${{{{ matrix.language }}}}
       - uses: github/codeql-action/autobuild@v4
         if: steps.check-src.outputs.has_source == 'true'
       - uses: github/codeql-action/analyze@v4
         if: steps.check-src.outputs.has_source == 'true'
+        with:
+          sha: ${{{{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}}}
+          ref: ${{{{ github.event_name == 'pull_request' && format('refs/heads/{{0}}', github.event.pull_request.head.ref) || github.ref }}}}
       - name: Upload empty SARIF (no source files found)
         if: steps.check-src.outputs.has_source == 'false'
         run: |
-          cat > empty.sarif <<'SARIF'
-          {{
-            "version": "2.1.0",
-            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-            "runs": [{{"tool": {{"driver": {{"name": "CodeQL", "version": "0.0.0", "rules": []}}}}, "results": []}}]
-          }}
-          SARIF
+          echo '{{"version":"2.1.0","runs":[{{"tool":{{"driver":{{"name":"CodeQL","version":"0.0.0","rules":[]}}}},"results":[]}}]}}' > empty.sarif
       - uses: github/codeql-action/upload-sarif@v4
         if: steps.check-src.outputs.has_source == 'false'
         with:
           sarif_file: empty.sarif
           category: /language:${{{{ matrix.language }}}}
+          sha: ${{{{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}}}
+          ref: ${{{{ github.event_name == 'pull_request' && format('refs/heads/{{0}}', github.event.pull_request.head.ref) || github.ref }}}}
 """
 
 


### PR DESCRIPTION
## 🧾 Title
fix(generator): pin SARIF uploads to PR HEAD commit SHA

## 🧠 Description
CodeQL `analyze@v4` and `upload-sarif@v4` default to the merge commit SHA in
`pull_request` events. GitHub's code scanning branch protection tracks results
by PR branch HEAD, so results posted for the merge commit are never matched and
branch protection is permanently blocked with "1 configuration not found."

This was visible on every ToolShed PR (#54-#60): `Analyze (python)` succeeded
but GitHub Advanced Security still showed "expecting 1 result from CodeQL for
`<head-sha>`" because the SARIF was uploaded against the merge commit, not the branch HEAD.

## 🧩 Changes Included
- `_render_codeql_yaml` (both matrix and auto-detect variants): move `init@v4`
  before the `check-src` step so CodeQL context is established unconditionally
- Add explicit `sha`/`ref` overrides to `analyze@v4` (normal path) using the PR
  head commit for `pull_request` events and `github.sha` for push events
- Add the same `sha`/`ref` overrides to `upload-sarif@v4` (empty-SARIF fallback)
- Replace heredoc-based empty SARIF creation with a single `echo` line to avoid
  shell heredoc indentation issues

## 🎯 Purpose
Stop ToolShed (and any downstream scaffold repo) from being permanently blocked
on code scanning branch protection when `analyze@v4` posts SARIF for the wrong
commit SHA.

## 🔗 Related Issues / Epics
- **Epic:** #48
- **Issue:** #200
- Closes #200

## 🧪 Testing
1. Open a PR with Python source files against a repo with code scanning branch protection
2. Verify `Analyze (python)` completes and the `CodeQL` GHAS check shows success (not "1 configuration not found")
3. Open a PR with no Python source files (config-only branch)
4. Verify the empty SARIF fallback runs and the `CodeQL` GHAS check shows success
5. Merge a PR and confirm the linked issue auto-closes
