### PR TITLE
fix(generator): align ruleset and CodeQL setup with golden standard (#202)

### DIFF
--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -105,8 +105,19 @@ def _default_branch_ruleset_payload(
                 "code_scanning_tools": [
                     {
                         "tool": "CodeQL",
-                        "alerts_threshold": "errors",
+                        "alerts_threshold": "errors_and_warnings",
                         "security_alerts_threshold": "high_or_higher",
+                    }
+                ]
+            },
+        },
+        {
+            "type": "code_quality",
+            "parameters": {
+                "code_quality_tools": [
+                    {
+                        "tool": "CodeQL",
+                        "severity": "notes",
                     }
                 ]
             },
@@ -114,7 +125,7 @@ def _default_branch_ruleset_payload(
         {
             "type": "copilot_code_review",
             "parameters": {
-                "review_draft_pull_requests": False,
+                "review_draft_pull_requests": True,
                 "review_on_push": True,
             },
         },
@@ -435,6 +446,28 @@ def _enable_optional_endpoint_feature(
     warn(f"Warning: could not enable {feature_name.lower()}: {feature_err}")
 
 
+def _enable_code_scanning_default_setup(
+    *,
+    repo_dir: Path,
+    env: dict[str, str],
+    repo: str,
+    out: Callable[[str], None],
+    warn: Callable[[str], None],
+) -> None:
+    cp = _api(
+        repo_dir=repo_dir,
+        env=env,
+        method="PATCH",
+        endpoint=f"/repos/{repo}/code-scanning/default-setup",
+        stdin_text=json.dumps({"state": "configured"}),
+    )
+    if cp.returncode == 0:
+        out("Enabled code scanning default setup.")
+        return
+    feature_err = cp.stderr.strip() or cp.stdout.strip() or "unknown error"
+    warn(f"Warning: could not enable code scanning default setup: {feature_err}")
+
+
 def _legacy_branch_protection_exists(
     *,
     repo_dir: Path,
@@ -562,6 +595,7 @@ def _compare_ruleset_against_baseline(
         "required_linear_history",
         "pull_request",
         "code_scanning",
+        "code_quality",
         "copilot_code_review",
     ):
         if required_rule not in rule_map:
@@ -604,13 +638,27 @@ def _compare_ruleset_against_baseline(
             expected_tools = [
                 {
                     "tool": "CodeQL",
-                    "alerts_threshold": "errors",
+                    "alerts_threshold": "errors_and_warnings",
                     "security_alerts_threshold": "high_or_higher",
                 }
             ]
             if tools != expected_tools:
                 drifts.append(
                     "code_scanning.code_scanning_tools expected "
+                    f"{expected_tools!r} got {tools!r}"
+                )
+
+    code_quality_rule = rule_map.get("code_quality")
+    if isinstance(code_quality_rule, dict):
+        code_quality_parameters = code_quality_rule.get("parameters")
+        if not isinstance(code_quality_parameters, dict):
+            drifts.append("code_quality rule parameters missing or invalid")
+        else:
+            tools = code_quality_parameters.get("code_quality_tools")
+            expected_tools = [{"tool": "CodeQL", "severity": "notes"}]
+            if tools != expected_tools:
+                drifts.append(
+                    "code_quality.code_quality_tools expected "
                     f"{expected_tools!r} got {tools!r}"
                 )
 
@@ -621,7 +669,7 @@ def _compare_ruleset_against_baseline(
             drifts.append("copilot_code_review rule parameters missing or invalid")
         else:
             expected_copilot_params = {
-                "review_draft_pull_requests": False,
+                "review_draft_pull_requests": True,
                 "review_on_push": True,
             }
             for key, expected in expected_copilot_params.items():
@@ -1028,6 +1076,7 @@ def _apply_settings(
         out("[dry-run] enable secret scanning push protection")
         for feature_name, _ in _BEST_EFFORT_SECURITY_FEATURES:
             out(f"[dry-run] enable {feature_name.lower()}")
+        out("[dry-run] enable code scanning default setup")
         out("[dry-run] enable private vulnerability reporting when supported")
         return
 
@@ -1089,6 +1138,14 @@ def _apply_settings(
             out=out,
             warn=warn,
         )
+
+    _enable_code_scanning_default_setup(
+        repo_dir=repo_dir,
+        env=env,
+        repo=repo,
+        out=out,
+        warn=warn,
+    )
 
     if visibility == "public":
         _enable_optional_endpoint_feature(

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -83,6 +83,8 @@ _LANGUAGE_CI_CONTEXT: dict[str, str] = {
 
 def _default_branch_ruleset_payload(
     languages: list[str] | None = None,
+    *,
+    include_code_quality: bool = True,
 ) -> str:
     rules: list[dict[str, object]] = [
         {"type": "deletion"},
@@ -111,25 +113,30 @@ def _default_branch_ruleset_payload(
                 ]
             },
         },
-        {
-            "type": "code_quality",
-            "parameters": {
-                "code_quality_tools": [
-                    {
-                        "tool": "CodeQL",
-                        "severity": "notes",
-                    }
-                ]
-            },
-        },
+    ]
+    if include_code_quality:
+        rules.append(
+            {
+                "type": "code_quality",
+                "parameters": {
+                    "code_quality_tools": [
+                        {
+                            "tool": "CodeQL",
+                            "severity": "notes",
+                        }
+                    ]
+                },
+            }
+        )
+    rules.append(
         {
             "type": "copilot_code_review",
             "parameters": {
                 "review_draft_pull_requests": True,
                 "review_on_push": True,
             },
-        },
-    ]
+        }
+    )
 
     if languages:
         contexts = list(
@@ -368,40 +375,75 @@ def _sync_default_branch_ruleset(
     env: dict[str, str],
     repo: str,
     out: Callable[[str], None],
+    warn: Callable[[str], None] | None = None,
     languages: list[str] | None = None,
 ) -> None:
+    emit_warn = warn if warn is not None else out
     managed_rulesets = [
         item
         for item in _list_repo_rulesets(repo_dir=repo_dir, env=env, repo=repo)
         if _is_managed_ruleset_name(item.get("name"))
     ]
+
+    def _apply_payload(payload: str, method: str, endpoint: str) -> bool:
+        cp = _api(
+            repo_dir=repo_dir,
+            env=env,
+            method=method,
+            endpoint=endpoint,
+            stdin_text=payload,
+        )
+        if cp.returncode == 0:
+            return True
+        err = cp.stderr.strip() or cp.stdout.strip() or ""
+        if "code_quality" in err.lower():
+            return False
+        raise RuntimeError(err or f"Failed applying managed ruleset ({method}).")
+
     payload = _default_branch_ruleset_payload(languages=languages)
+    fallback_payload = _default_branch_ruleset_payload(
+        languages=languages, include_code_quality=False
+    )
 
     if managed_rulesets:
         ruleset_id = managed_rulesets[0].get("id")
         if not isinstance(ruleset_id, int):
             raise RuntimeError("Managed ruleset exists but is missing a numeric id.")
-        cp = _api(
-            repo_dir=repo_dir,
-            env=env,
-            method="PUT",
-            endpoint=f"/repos/{repo}/rulesets/{ruleset_id}",
-            stdin_text=payload,
-        )
-        if cp.returncode != 0:
-            raise RuntimeError(cp.stderr.strip() or "Failed updating managed ruleset.")
+        endpoint = f"/repos/{repo}/rulesets/{ruleset_id}"
+        if not _apply_payload(payload, "PUT", endpoint):
+            emit_warn(
+                "Warning: code_quality rule not supported on this repo; "
+                "applying ruleset without it."
+            )
+            cp2 = _api(
+                repo_dir=repo_dir,
+                env=env,
+                method="PUT",
+                endpoint=endpoint,
+                stdin_text=fallback_payload,
+            )
+            if cp2.returncode != 0:
+                raise RuntimeError(
+                    cp2.stderr.strip() or "Failed updating managed ruleset."
+                )
         out(f"Updated ruleset '{_SETTINGS_RULESET_NAME}'.")
         return
 
-    cp = _api(
-        repo_dir=repo_dir,
-        env=env,
-        method="POST",
-        endpoint=f"/repos/{repo}/rulesets",
-        stdin_text=payload,
-    )
-    if cp.returncode != 0:
-        raise RuntimeError(cp.stderr.strip() or "Failed creating managed ruleset.")
+    endpoint = f"/repos/{repo}/rulesets"
+    if not _apply_payload(payload, "POST", endpoint):
+        emit_warn(
+            "Warning: code_quality rule not supported on this repo; "
+            "applying ruleset without it."
+        )
+        cp2 = _api(
+            repo_dir=repo_dir,
+            env=env,
+            method="POST",
+            endpoint=endpoint,
+            stdin_text=fallback_payload,
+        )
+        if cp2.returncode != 0:
+            raise RuntimeError(cp2.stderr.strip() or "Failed creating managed ruleset.")
     out(f"Created ruleset '{_SETTINGS_RULESET_NAME}'.")
 
 
@@ -1098,7 +1140,7 @@ def _apply_settings(
     out("Applied repository merge settings.")
 
     _sync_default_branch_ruleset(
-        repo_dir=repo_dir, env=env, repo=repo, out=out, languages=languages
+        repo_dir=repo_dir, env=env, repo=repo, out=out, warn=warn, languages=languages
     )
 
     _clear_legacy_branch_protection(

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -3255,10 +3255,6 @@ def build_scaffold_files(config: ScaffoldConfig) -> list[ScaffoldFile]:
             _render_ci_yaml(config.languages),
         ),
         ScaffoldFile(
-            config.out_dir / ".github" / "workflows" / "codeql.yml",
-            _render_codeql_yaml(config.languages),
-        ),
-        ScaffoldFile(
             config.out_dir / ".github" / "workflows" / "validate-issue.yml",
             _render_validate_issue_workflow(),
         ),
@@ -3397,7 +3393,6 @@ TEMPLATE_FILE_PATHS = (
     ".github/ISSUE_TEMPLATE/ticket.md",
     ".github/ISSUE_TEMPLATE/config.yml",
     ".github/workflows/validate-issue.yml",
-    ".github/workflows/codeql.yml",
 )
 
 
@@ -3464,7 +3459,6 @@ def build_ci_files(
         target_dir,
         [
             ".github/workflows/ci.yml",
-            ".github/workflows/codeql.yml",
             "web/.husky/pre-commit",
         ],
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -169,7 +169,7 @@ def test_apply_templates_only_writes_template_files(tmp_path: Path) -> None:
     assert (repo_dir / ".github" / "ISSUE_TEMPLATE" / "epic.md").exists()
     assert (repo_dir / ".github" / "CODEOWNERS").exists()
     assert (repo_dir / ".github" / "workflows" / "validate-issue.yml").exists()
-    assert (repo_dir / ".github" / "workflows" / "codeql.yml").exists()
+    assert not (repo_dir / ".github" / "workflows" / "codeql.yml").exists()
     assert not (repo_dir / "go.mod").exists()
     assert (repo_dir / "README.md").read_text(encoding="utf-8") == "# Existing\n"
 

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -141,11 +141,17 @@ def test_default_branch_ruleset_payload_uses_zero_review_baseline() -> None:
     assert code_scanning_rule["parameters"]["code_scanning_tools"] == [
         {
             "tool": "CodeQL",
-            "alerts_threshold": "errors",
+            "alerts_threshold": "errors_and_warnings",
             "security_alerts_threshold": "high_or_higher",
         }
     ]
-    assert copilot_code_review_rule["parameters"]["review_draft_pull_requests"] is False
+    code_quality_rule = next(
+        rule for rule in payload["rules"] if rule["type"] == "code_quality"
+    )
+    assert code_quality_rule["parameters"]["code_quality_tools"] == [
+        {"tool": "CodeQL", "severity": "notes"}
+    ]
+    assert copilot_code_review_rule["parameters"]["review_draft_pull_requests"] is True
     assert copilot_code_review_rule["parameters"]["review_on_push"] is True
 
 
@@ -264,7 +270,7 @@ def test_compare_ruleset_against_baseline_reports_multiple_drifts() -> None:
                     {
                         "type": "copilot_code_review",
                         "parameters": {
-                            "review_draft_pull_requests": True,
+                            "review_draft_pull_requests": False,
                             "review_on_push": False,
                         },
                     },
@@ -293,8 +299,9 @@ def test_compare_ruleset_against_baseline_reports_multiple_drifts() -> None:
     assert "pull_request.required_approving_review_count expected 0 got 2" in drifts
     assert any("pull_request.allowed_merge_methods" in item for item in drifts)
     assert any("code_scanning.code_scanning_tools" in item for item in drifts)
+    assert "missing rule: code_quality" in drifts
     assert (
-        "copilot_code_review.review_draft_pull_requests expected False got True"
+        "copilot_code_review.review_draft_pull_requests expected True got False"
         in drifts
     )
     assert "copilot_code_review.review_on_push expected True got False" in drifts
@@ -788,6 +795,11 @@ def test_apply_settings_uses_ruleset_and_public_security_defaults(
         create_ops,
         "_enable_optional_endpoint_feature",
         _fake_enable_optional_endpoint_feature,
+    )
+    monkeypatch.setattr(
+        create_ops,
+        "_enable_code_scanning_default_setup",
+        lambda **_: None,
     )
 
     create_ops._apply_settings(

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -678,6 +678,256 @@ def test_sync_ruleset_falls_back_when_code_quality_rejected(
     assert all(r["type"] != "code_quality" for r in second["rules"])
 
 
+def test_compare_ruleset_code_quality_tools_drift() -> None:
+    """code_quality rule present but tools mismatch → drift reported."""
+    drifts = create_ops._compare_ruleset_against_baseline(
+        [
+            {
+                "name": create_ops._SETTINGS_RULESET_NAME,
+                "target": "branch",
+                "enforcement": "active",
+                "conditions": {
+                    "ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}
+                },
+                "rules": [
+                    {"type": "deletion"},
+                    {"type": "non_fast_forward"},
+                    {"type": "required_linear_history"},
+                    {
+                        "type": "pull_request",
+                        "parameters": {
+                            "allowed_merge_methods": ["squash"],
+                            "dismiss_stale_reviews_on_push": False,
+                            "require_code_owner_review": False,
+                            "require_last_push_approval": False,
+                            "required_approving_review_count": 0,
+                            "required_review_thread_resolution": True,
+                        },
+                    },
+                    {
+                        "type": "code_scanning",
+                        "parameters": {
+                            "code_scanning_tools": [
+                                {
+                                    "tool": "CodeQL",
+                                    "alerts_threshold": "errors_and_warnings",
+                                    "security_alerts_threshold": "high_or_higher",
+                                }
+                            ]
+                        },
+                    },
+                    {
+                        "type": "code_quality",
+                        "parameters": {
+                            "code_quality_tools": [
+                                {"tool": "CodeQL", "severity": "errors"}
+                            ]
+                        },
+                    },
+                    {
+                        "type": "copilot_code_review",
+                        "parameters": {
+                            "review_draft_pull_requests": True,
+                            "review_on_push": True,
+                        },
+                    },
+                ],
+            }
+        ],
+        default_branch="main",
+    )
+    assert any("code_quality.code_quality_tools" in d for d in drifts)
+    assert not any("missing rule: code_quality" in d for d in drifts)
+
+
+def test_compare_ruleset_code_quality_parameters_invalid() -> None:
+    """code_quality rule present but parameters is not a dict → drift reported."""
+    drifts = create_ops._compare_ruleset_against_baseline(
+        [
+            {
+                "name": create_ops._SETTINGS_RULESET_NAME,
+                "target": "branch",
+                "enforcement": "active",
+                "conditions": {
+                    "ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}
+                },
+                "rules": [
+                    {"type": "deletion"},
+                    {"type": "non_fast_forward"},
+                    {"type": "required_linear_history"},
+                    {
+                        "type": "pull_request",
+                        "parameters": {
+                            "allowed_merge_methods": ["squash"],
+                            "dismiss_stale_reviews_on_push": False,
+                            "require_code_owner_review": False,
+                            "require_last_push_approval": False,
+                            "required_approving_review_count": 0,
+                            "required_review_thread_resolution": True,
+                        },
+                    },
+                    {
+                        "type": "code_scanning",
+                        "parameters": {
+                            "code_scanning_tools": [
+                                {
+                                    "tool": "CodeQL",
+                                    "alerts_threshold": "errors_and_warnings",
+                                    "security_alerts_threshold": "high_or_higher",
+                                }
+                            ]
+                        },
+                    },
+                    {"type": "code_quality", "parameters": None},
+                    {
+                        "type": "copilot_code_review",
+                        "parameters": {
+                            "review_draft_pull_requests": True,
+                            "review_on_push": True,
+                        },
+                    },
+                ],
+            }
+        ],
+        default_branch="main",
+    )
+    assert any("code_quality rule parameters missing or invalid" in d for d in drifts)
+
+
+def test_sync_ruleset_falls_back_on_put_when_code_quality_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warnings: list[str] = []
+    lines: list[str] = []
+    payloads: list[str | None] = []
+
+    api_responses = iter(
+        [
+            subprocess.CompletedProcess(
+                args=["gh"],
+                returncode=1,
+                stdout="",
+                stderr="code_quality not supported",
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="", stderr=""
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(
+        create_ops,
+        "_list_repo_rulesets",
+        lambda **_: [{"id": 42, "name": create_ops._SETTINGS_RULESET_NAME}],
+    )
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **kwargs: (payloads.append(kwargs.get("stdin_text")) or next(api_responses)),
+    )
+
+    create_ops._sync_default_branch_ruleset(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        out=lines.append,
+        warn=warnings.append,
+    )
+
+    assert any("Updated ruleset" in line for line in lines)
+    assert any("code_quality" in w.lower() for w in warnings)
+    assert len(payloads) == 2
+    first = json.loads(payloads[0])
+    second = json.loads(payloads[1])
+    assert any(r["type"] == "code_quality" for r in first["rules"])
+    assert all(r["type"] != "code_quality" for r in second["rules"])
+
+
+def test_sync_ruleset_put_fallback_failure_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api_responses = iter(
+        [
+            subprocess.CompletedProcess(
+                args=["gh"],
+                returncode=1,
+                stdout="",
+                stderr="code_quality not supported",
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="internal server error"
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(
+        create_ops,
+        "_list_repo_rulesets",
+        lambda **_: [{"id": 42, "name": create_ops._SETTINGS_RULESET_NAME}],
+    )
+    monkeypatch.setattr(create_ops, "_api", lambda **_: next(api_responses))
+
+    with pytest.raises(RuntimeError, match="internal server error"):
+        create_ops._sync_default_branch_ruleset(
+            repo_dir=Path("/tmp/repo"),
+            env={},
+            repo="acme/repo",
+            out=lambda _: None,
+            warn=lambda _: None,
+        )
+
+
+def test_sync_ruleset_post_fallback_failure_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api_responses = iter(
+        [
+            subprocess.CompletedProcess(
+                args=["gh"],
+                returncode=1,
+                stdout="",
+                stderr="code_quality not supported",
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="permission denied"
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(create_ops, "_list_repo_rulesets", lambda **_: [])
+    monkeypatch.setattr(create_ops, "_api", lambda **_: next(api_responses))
+
+    with pytest.raises(RuntimeError, match="permission denied"):
+        create_ops._sync_default_branch_ruleset(
+            repo_dir=Path("/tmp/repo"),
+            env={},
+            repo="acme/repo",
+            out=lambda _: None,
+            warn=lambda _: None,
+        )
+
+
+def test_apply_payload_raises_for_non_code_quality_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(create_ops, "_list_repo_rulesets", lambda **_: [])
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **_: subprocess.CompletedProcess(
+            args=["gh"], returncode=1, stdout="", stderr="unrelated API error"
+        ),
+    )
+    with pytest.raises(RuntimeError, match="unrelated API error"):
+        create_ops._sync_default_branch_ruleset(
+            repo_dir=Path("/tmp/repo"),
+            env={},
+            repo="acme/repo",
+            out=lambda _: None,
+            warn=lambda _: None,
+        )
+
+
 def test_tool_auth_remote_and_push_helpers_cover_common_error_paths(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -823,7 +823,9 @@ def test_sync_ruleset_falls_back_on_put_when_code_quality_rejected(
     monkeypatch.setattr(
         create_ops,
         "_api",
-        lambda **kwargs: (payloads.append(kwargs.get("stdin_text")) or next(api_responses)),
+        lambda **kwargs: (
+            payloads.append(kwargs.get("stdin_text")) or next(api_responses)
+        ),
     )
 
     create_ops._sync_default_branch_ruleset(

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -506,6 +506,64 @@ def test_ruleset_and_legacy_branch_helpers_cover_error_paths(
     assert any(endpoint.endswith("/protection") for _, endpoint in calls)
 
 
+def test_enable_code_scanning_default_setup_success_and_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out_lines: list[str] = []
+    warn_lines: list[str] = []
+    endpoints: list[str] = []
+    payloads: list[str | None] = []
+
+    api_responses = iter(
+        [
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="", stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="not enabled"
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **kwargs: (
+            endpoints.append(kwargs["endpoint"])
+            or payloads.append(kwargs.get("stdin_text"))
+            or next(api_responses)
+        ),
+    )
+
+    create_ops._enable_code_scanning_default_setup(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        out=out_lines.append,
+        warn=warn_lines.append,
+    )
+    create_ops._enable_code_scanning_default_setup(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        out=out_lines.append,
+        warn=warn_lines.append,
+    )
+
+    assert endpoints == [
+        "/repos/acme/repo/code-scanning/default-setup",
+        "/repos/acme/repo/code-scanning/default-setup",
+    ]
+    assert all(p is not None and '"state"' in p for p in payloads)
+    assert any(
+        "enabled code scanning default setup" in line.lower() for line in out_lines
+    )
+    assert any(
+        "could not enable code scanning default setup" in line.lower()
+        for line in warn_lines
+    )
+
+
 def test_sync_ruleset_covers_update_create_missing_id_and_api_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -621,6 +621,63 @@ def test_sync_ruleset_covers_update_create_missing_id_and_api_failure(
         )
 
 
+def test_default_branch_ruleset_payload_excludes_code_quality_when_flagged() -> None:
+    payload = json.loads(
+        create_ops._default_branch_ruleset_payload(include_code_quality=False)
+    )
+    types = [r["type"] for r in payload["rules"]]
+    assert "code_quality" not in types
+    assert "code_scanning" in types
+    assert "copilot_code_review" in types
+
+
+def test_sync_ruleset_falls_back_when_code_quality_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lines: list[str] = []
+    warnings: list[str] = []
+    payloads: list[str | None] = []
+
+    api_responses = iter(
+        [
+            subprocess.CompletedProcess(
+                args=["gh"],
+                returncode=1,
+                stdout="",
+                stderr="code_quality not supported",
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="", stderr=""
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(create_ops, "_list_repo_rulesets", lambda **_: [])
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **kwargs: (
+            payloads.append(kwargs.get("stdin_text")) or next(api_responses)
+        ),
+    )
+
+    create_ops._sync_default_branch_ruleset(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        out=lines.append,
+        warn=warnings.append,
+    )
+
+    assert any("Created ruleset" in line for line in lines)
+    assert any("code_quality" in w.lower() for w in warnings)
+    assert len(payloads) == 2
+    first = json.loads(payloads[0])
+    second = json.loads(payloads[1])
+    assert any(r["type"] == "code_quality" for r in first["rules"])
+    assert all(r["type"] != "code_quality" for r in second["rules"])
+
+
 def test_tool_auth_remote_and_push_helpers_cover_common_error_paths(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -46,7 +46,6 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
         ".github/ISSUE_TEMPLATE/ticket.md",
         ".github/ISSUE_TEMPLATE/config.yml",
         ".github/workflows/ci.yml",
-        ".github/workflows/codeql.yml",
         ".github/dependabot.yml",
         "docs/requirements.md",
         "docs/api-v1.md",
@@ -101,9 +100,6 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
     assert "Upload coverage.xml artifact" in ci_yaml
     assert "codecov/codecov-action@v5" in ci_yaml
     assert "CODECOV_TOKEN" in ci_yaml
-    assert "language:" in (out_dir / ".github/workflows/codeql.yml").read_text(
-        encoding="utf-8"
-    )
     generated_readme = (out_dir / "README.md").read_text(encoding="utf-8")
     assert "[![codecov](" in generated_readme
     assert "Created by [repo-scaffold]" in generated_readme
@@ -254,7 +250,7 @@ def test_generation_is_deterministic(tmp_path: Path) -> None:
     assert _tree_hash(cfg_a.out_dir) == _tree_hash(cfg_b.out_dir)
 
 
-def test_react_only_codeql_scans_javascript(tmp_path: Path) -> None:
+def test_react_only_dependabot_packages(tmp_path: Path) -> None:
     cfg = ScaffoldConfig(
         name="frontend",
         languages=("react",),
@@ -265,10 +261,7 @@ def test_react_only_codeql_scans_javascript(tmp_path: Path) -> None:
 
     generate_scaffold(cfg)
 
-    codeql = (cfg.out_dir / ".github/workflows/codeql.yml").read_text(encoding="utf-8")
-    assert "javascript-typescript" in codeql
-    assert "Analyze (${{ matrix.language }})" in codeql
-
+    assert not (cfg.out_dir / ".github/workflows/codeql.yml").exists()
     dependabot = (cfg.out_dir / ".github/dependabot.yml").read_text(encoding="utf-8")
     assert 'package-ecosystem: "github-actions"' in dependabot
     assert 'package-ecosystem: "npm"' in dependabot
@@ -462,11 +455,7 @@ def test_gin_scaffold_generates_expected_files(tmp_path: Path) -> None:
     assert "gin:" in ci_yaml
     assert "go mod tidy" in ci_yaml
 
-    codeql_yaml = (out_dir / ".github" / "workflows" / "codeql.yml").read_text(
-        encoding="utf-8"
-    )
-    assert "- go" in codeql_yaml
-    assert "No Go/Python selected" not in codeql_yaml
+    assert not (out_dir / ".github" / "workflows" / "codeql.yml").exists()
 
     dependabot = (out_dir / ".github" / "dependabot.yml").read_text(encoding="utf-8")
     assert 'package-ecosystem: "gomod"' in dependabot


### PR DESCRIPTION
## 🧾 Title
fix(generator): align ruleset and CodeQL setup with golden standard (#202)

## 🧠 Description
Three related fixes that make check rules and apply templates produce settings
matching repo-scaffold's own main ruleset (the golden standard, ID 13751679,
created by the repo owner). Discovered during ToolShed PR #54-#60 unblocking.

## 🧩 Changes Included

**Ruleset payload (create_ops.py):**
- alerts_threshold: "errors" -> "errors_and_warnings"
- Added code_quality rule (severity: notes)
- review_draft_pull_requests: False -> True

**Baseline comparison (_compare_ruleset_against_baseline):**
- Updated expected values to match the corrected payload
- Added code_quality validation

**CodeQL approach (generator.py):**
- Removed codeql.yml from build_scaffold_files, TEMPLATE_FILE_PATHS, and build_ci_files
- Added _enable_code_scanning_default_setup to _apply_settings
- Calls PATCH /repos/{owner}/{repo}/code-scanning/default-setup with {"state": "configured"}

## 🎯 Purpose
Default Setup avoids the SHA mismatch bug inherent in Advanced Setup codeql.yml
workflows: analyze@v4 uploads SARIF for the merge commit SHA while branch
protection tracks by PR HEAD SHA (refs/pull/N/head). This caused every ToolShed
feature PR to be permanently blocked with "1 configuration not found."

## 🔗 Related Issues / Epics
- **Epic:** #48
- Closes #202

## 🧪 Testing
- All existing tests pass (tox -e precommit green)
- Updated test_compare_ruleset_against_baseline_reports_multiple_drifts to expect new drift messages
- Updated test_default_branch_ruleset_payload to assert errors_and_warnings + code_quality + review_draft_pull_requests: True
- apply templates test now asserts codeql.yml is NOT written

## 🧰 Developer Notes
- Downstream repos (ToolShed etc.) will get these ruleset fixes on the next check rules run
- Default Setup is enabled on apply templates / check rules; no workflow file needed