### PR TITLE
fix(create_ops): detect GitHub's Invalid property /rules/N as code_quality rejection (#204)

### DIFF
--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -396,7 +396,7 @@ def _sync_default_branch_ruleset(
         if cp.returncode == 0:
             return True
         err = cp.stderr.strip() or cp.stdout.strip() or ""
-        if "code_quality" in err.lower():
+        if "code_quality" in err.lower() or "invalid property /rules/" in err.lower():
             return False
         raise RuntimeError(err or f"Failed applying managed ruleset ({method}).")
 

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -930,6 +930,43 @@ def test_apply_payload_raises_for_non_code_quality_error(
         )
 
 
+def test_apply_payload_falls_back_on_github_invalid_property_rules_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GitHub returns 'Invalid property /rules/N' rather than 'code_quality' when
+    the rule type is unsupported -- the fallback must trigger on that pattern too."""
+    lines: list[str] = []
+    warnings: list[str] = []
+
+    api_responses = iter(
+        [
+            subprocess.CompletedProcess(
+                args=["gh"],
+                returncode=1,
+                stdout="",
+                stderr="Invalid property /rules/5: data matches no possible input.",
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="", stderr=""
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(create_ops, "_list_repo_rulesets", lambda **_: [])
+    monkeypatch.setattr(create_ops, "_api", lambda **_: next(api_responses))
+
+    create_ops._sync_default_branch_ruleset(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        out=lines.append,
+        warn=warnings.append,
+    )
+
+    assert any("Created ruleset" in line for line in lines)
+    assert any("code_quality" in w.lower() for w in warnings)
+
+
 def test_tool_auth_remote_and_push_helpers_cover_common_error_paths(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## 🧾 Title
fix(create_ops): detect GitHub's `Invalid property /rules/N` as code_quality rejection

## 🧠 Summary
When `_sync_default_branch_ruleset` applies a ruleset with the `code_quality` rule to a personal or Free-plan repo, GitHub returns a 422 with body `"Invalid property /rules/5: data matches no possible input."` -- no mention of `code_quality`. The existing fallback only matched on the string `"code_quality"`, so it never triggered and the command raised RuntimeError instead of retrying without the rule.

## 📦 Scope
- `src/repo_scaffold/create_ops.py` -- added `"invalid property /rules/"` as a second fallback trigger in `_apply_payload`
- `tests/test_create_ops.py` -- added `test_apply_payload_falls_back_on_github_invalid_property_rules_error` covering the GitHub-style error message

## ✅ Acceptance Criteria
- `apply settings --repo blairg23/toolshed` applies the ruleset without `code_quality` and logs a warning
- All existing fallback tests still pass

## 🔗 References
- Closes #204
- Follows up on #202 / #203

## 🧪 Testing / Validation
- `tox -e precommit` green (73.07% coverage)
- Manual: `poetry run repo-scaffold apply settings --repo blairg23/toolshed`