### PR TITLE
feat(pr): add pr react subcommand for PR review comment reactions (#206)

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -42,6 +42,7 @@ from .github_api import (
     pr_list,
     pr_list_comments,
     pr_merge,
+    react,
     pr_rerun,
     pr_resolve_thread,
     pr_review_threads,
@@ -1291,6 +1292,19 @@ def build_parser() -> argparse.ArgumentParser:
     )
     pr_comment_cmd.add_argument(
         "--reply-to", type=int, dest="reply_to", help="Comment ID to reply to"
+    )
+
+    pr_react_cmd = pr_sub.add_parser(
+        "react", help="Add a reaction to a PR review comment"
+    )
+    pr_react_cmd.add_argument("--repo", required=True)
+    pr_react_cmd.add_argument(
+        "--comment-id", type=int, required=True, dest="comment_id"
+    )
+    pr_react_cmd.add_argument(
+        "--reaction",
+        required=True,
+        choices=["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"],
     )
 
     pr_create_cmd = pr_sub.add_parser("create", help="Open a new pull request")
@@ -2818,6 +2832,21 @@ def main(argv: list[str] | None = None) -> int:
                 return 1
             comment = _json.loads(cp.stdout)
             print(f"Comment posted: {comment.get('html_url', '')}")
+            return 0
+
+        if ns.pr_command == "react":
+            cp = react(
+                target_repo,
+                "pull_request_review_comment",
+                ns.comment_id,
+                ns.reaction,
+                token,
+            )
+            if cp.returncode not in (0, 201):
+                print(cp.stderr.strip() or "Failed adding reaction.", file=sys.stderr)
+                return 1
+            reaction = _json.loads(cp.stdout)
+            print(f"Reaction added: {reaction.get('content', ns.reaction)}")
             return 0
 
         if ns.pr_command == "resolve-thread":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2325,6 +2325,79 @@ def test_pr_comment_posts_and_prints_url(
     assert "Comment posted" in capsys.readouterr().out
 
 
+def test_pr_react_posts_reaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.react",
+        lambda repo, subject, subject_id, content, token: subprocess.CompletedProcess(
+            args=[],
+            returncode=201,
+            stdout=json.dumps({"content": "+1", "id": 99}),
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(
+        [
+            "pr",
+            "react",
+            "--repo",
+            "acme/repo",
+            "--comment-id",
+            "12345",
+            "--reaction",
+            "+1",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Reaction added" in out
+    assert "+1" in out
+
+
+def test_pr_react_error_returns_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.react",
+        lambda repo, subject, subject_id, content, token: subprocess.CompletedProcess(
+            args=[],
+            returncode=422,
+            stdout="",
+            stderr="Unprocessable Entity",
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(
+        [
+            "pr",
+            "react",
+            "--repo",
+            "acme/repo",
+            "--comment-id",
+            "12345",
+            "--reaction",
+            "+1",
+        ]
+    )
+    assert rc == 1
+    assert "Unprocessable Entity" in capsys.readouterr().err
+
+
 def test_pr_resolve_thread(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## 🧾 Title
feat(pr): add pr react subcommand for PR review comment reactions (#206)

## 🧠 Description
The `pr react` command lets you add emoji reactions to PR review comments (inline code comments) via the GitHub REST API. Needed for reacting to bot reviewer feedback such as thumbs up/down on Codex comments to close the feedback loop.

## 🧩 Changes Included
- Import `react` from `github_api` into `cli.py`
- Add `pr react` subparser with `--repo`, `--comment-id`, and `--reaction` args
- Add dispatch block calling `react()` with `subject="pull_request_review_comment"`
- Add `test_pr_react_posts_reaction` and `test_pr_react_error_returns_nonzero` in `test_cli.py`

## 🎯 Purpose
Enable reacting to bot (e.g. Codex) PR review comments to improve model feedback quality.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #206
- Closes #206

## 🧪 Testing
- `poetry run tox -e precommit` green (73.12% coverage)
- Two new unit tests covering success (201) and error (422) paths

## 🧰 Developer Notes
`react()` already existed in `github_api.py`; this PR only adds the CLI wiring.

## 🧰 Notes / Links

## ✅ Addendum: Bugs Found/Fixed

## ⏳ Addendum: Pending
