### PR TITLE
fix(ci): upgrade GitHub Actions to Node 24-compatible versions (#180)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         tox-env: [lint, type, coverage]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload coverage.xml artifact
         if: matrix.tox-env == 'coverage'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-xml
           path: coverage.xml

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -381,11 +381,11 @@ jobs:
           else
             echo "has_source=false" >> $GITHUB_OUTPUT
           fi
-      - uses: github/codeql-action/init@v5
+      - uses: github/codeql-action/init@v4
         if: steps.check-src.outputs.has_source == 'true'
-      - uses: github/codeql-action/autobuild@v5
+      - uses: github/codeql-action/autobuild@v4
         if: steps.check-src.outputs.has_source == 'true'
-      - uses: github/codeql-action/analyze@v5
+      - uses: github/codeql-action/analyze@v4
         if: steps.check-src.outputs.has_source == 'true'
         with:
           sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -394,7 +394,7 @@ jobs:
         if: steps.check-src.outputs.has_source == 'false'
         run: |
           echo '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL","version":"0.0.0","rules":[]}},"results":[]}]}' > empty.sarif
-      - uses: github/codeql-action/upload-sarif@v5
+      - uses: github/codeql-action/upload-sarif@v4
         if: steps.check-src.outputs.has_source == 'false'
         with:
           sarif_file: empty.sarif
@@ -444,13 +444,13 @@ jobs:
           else
             echo "has_source=false" >> $GITHUB_OUTPUT
           fi
-      - uses: github/codeql-action/init@v5
+      - uses: github/codeql-action/init@v4
         if: steps.check-src.outputs.has_source == 'true'
         with:
           languages: ${{{{ matrix.language }}}}
-      - uses: github/codeql-action/autobuild@v5
+      - uses: github/codeql-action/autobuild@v4
         if: steps.check-src.outputs.has_source == 'true'
-      - uses: github/codeql-action/analyze@v5
+      - uses: github/codeql-action/analyze@v4
         if: steps.check-src.outputs.has_source == 'true'
         with:
           sha: ${{{{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}}}
@@ -459,7 +459,7 @@ jobs:
         if: steps.check-src.outputs.has_source == 'false'
         run: |
           echo '{{"version":"2.1.0","runs":[{{"tool":{{"driver":{{"name":"CodeQL","version":"0.0.0","rules":[]}}}},"results":[]}}]}}' > empty.sarif
-      - uses: github/codeql-action/upload-sarif@v5
+      - uses: github/codeql-action/upload-sarif@v4
         if: steps.check-src.outputs.has_source == 'false'
         with:
           sarif_file: empty.sarif

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -192,7 +192,7 @@ def _render_ci_yaml(languages: Iterable[str]) -> str:
   pre-commit-hooks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -215,7 +215,7 @@ def _render_ci_yaml(languages: Iterable[str]) -> str:
   go:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -241,7 +241,7 @@ def _render_ci_yaml(languages: Iterable[str]) -> str:
   gin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -273,7 +273,7 @@ def _render_ci_yaml(languages: Iterable[str]) -> str:
       matrix:
         tox-env: [lint, type, coverage]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -285,7 +285,7 @@ def _render_ci_yaml(languages: Iterable[str]) -> str:
         run: tox -e ${{ matrix.tox-env }}
       - name: Upload coverage.xml artifact
         if: matrix.tox-env == 'coverage'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-xml
           path: coverage.xml
@@ -309,8 +309,8 @@ def _render_ci_yaml(languages: Iterable[str]) -> str:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: npm
@@ -372,7 +372,7 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check for source files
         id: check-src
         run: |
@@ -381,11 +381,11 @@ jobs:
           else
             echo "has_source=false" >> $GITHUB_OUTPUT
           fi
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@v5
         if: steps.check-src.outputs.has_source == 'true'
-      - uses: github/codeql-action/autobuild@v4
+      - uses: github/codeql-action/autobuild@v5
         if: steps.check-src.outputs.has_source == 'true'
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@v5
         if: steps.check-src.outputs.has_source == 'true'
         with:
           sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -394,7 +394,7 @@ jobs:
         if: steps.check-src.outputs.has_source == 'false'
         run: |
           echo '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"CodeQL","version":"0.0.0","rules":[]}},"results":[]}]}' > empty.sarif
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@v5
         if: steps.check-src.outputs.has_source == 'false'
         with:
           sarif_file: empty.sarif
@@ -435,7 +435,7 @@ jobs:
         language:
 {matrix_lines}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check for source files
         id: check-src
         run: |
@@ -444,13 +444,13 @@ jobs:
           else
             echo "has_source=false" >> $GITHUB_OUTPUT
           fi
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@v5
         if: steps.check-src.outputs.has_source == 'true'
         with:
           languages: ${{{{ matrix.language }}}}
-      - uses: github/codeql-action/autobuild@v4
+      - uses: github/codeql-action/autobuild@v5
         if: steps.check-src.outputs.has_source == 'true'
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@v5
         if: steps.check-src.outputs.has_source == 'true'
         with:
           sha: ${{{{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}}}
@@ -459,7 +459,7 @@ jobs:
         if: steps.check-src.outputs.has_source == 'false'
         run: |
           echo '{{"version":"2.1.0","runs":[{{"tool":{{"driver":{{"name":"CodeQL","version":"0.0.0","rules":[]}}}},"results":[]}}]}}' > empty.sarif
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@v5
         if: steps.check-src.outputs.has_source == 'false'
         with:
           sarif_file: empty.sarif


### PR DESCRIPTION
## 🧾 Title
fix(ci): upgrade GitHub Actions to Node 24-compatible versions

## 🧠 Summary
Closes #180

GitHub Actions runners now default to Node 24. Actions bundling a Node 20 runtime emit a deprecation warning. This bumps all v4 action pins to v5 across both the repo-scaffold own CI and the generator templates used by downstream repos.

## 📦 Changes

Actions bumped from v4 to v5:
- `actions/checkout`
- `actions/upload-artifact`
- `actions/setup-node`
- `github/codeql-action/{init,autobuild,analyze,upload-sarif}`

Actions already at v5+ (no change):
- `actions/setup-python@v5`
- `actions/setup-go@v5`
- `codecov/codecov-action@v5`
- `golangci/golangci-lint-action@v6`

Files changed:
- `.github/workflows/ci.yml` -- repo-scaffold own CI
- `src/repo_scaffold/generator.py` -- templates emitted by `init`, `apply ci`, `apply templates`

## 🧪 Test plan
- [ ] CI passes on this PR with no Node 20 deprecation warnings
- [ ] No DEP0040 punycode warning in CI output
- [ ] `poetry run tox -e precommit` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)