### PR TITLE
feat(cli): add pr check-sop command and document PR review comment SOP in CLAUDE.md (#214)

### DIFF
--- a/.github/workflows/validate-pr-sop.yml
+++ b/.github/workflows/validate-pr-sop.yml
@@ -1,0 +1,106 @@
+name: Validate PR review thread SOP
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to check
+        required: true
+        type: number
+
+jobs:
+  check-sop:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+      - name: Check review threads for SOP compliance
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber =
+              context.payload.pull_request?.number ||
+              parseInt(context.payload.inputs?.pr_number || "0");
+
+            if (!prNumber) {
+              core.setFailed("Could not determine PR number from event payload.");
+              return;
+            }
+
+            const data = await github.graphql(`
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    reviewThreads(first: 50) {
+                      nodes {
+                        id
+                        isResolved
+                        comments(first: 50) {
+                          nodes {
+                            databaseId
+                            author { login }
+                            reactions(first: 30) {
+                              nodes { content }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: prNumber,
+            });
+
+            const threads = data.repository.pullRequest.reviewThreads.nodes;
+
+            if (threads.length === 0) {
+              core.info("No review threads found. SOP check passed.");
+              return;
+            }
+
+            const failing = [];
+            for (const thread of threads) {
+              const comments = thread.comments.nodes;
+              const hasReply = comments.length > 1;
+              const isResolved = thread.isResolved;
+              const firstComment = comments[0] || {};
+              const reactions = (firstComment.reactions?.nodes) || [];
+              const hasPlusOne = reactions.some(r => r.content === "THUMBS_UP");
+
+              if (!hasReply || !isResolved || !hasPlusOne) {
+                const missing = [];
+                if (!hasReply) missing.push("reply");
+                if (!isResolved) missing.push("resolved");
+                if (!hasPlusOne) missing.push("reaction(+1)");
+                failing.push({
+                  threadId: thread.id,
+                  commentId: firstComment.databaseId,
+                  missing,
+                });
+              }
+            }
+
+            const total = threads.length;
+            const passed = total - failing.length;
+            core.info(`${passed}/${total} threads SOP-compliant.`);
+
+            if (failing.length > 0) {
+              for (const f of failing) {
+                core.error(
+                  `Thread ${f.threadId} (comment #${f.commentId}) missing: ${f.missing.join(", ")}`
+                );
+              }
+              core.setFailed(
+                `${failing.length} review thread(s) not SOP-compliant. ` +
+                "SOP: push fix -> reply with commit hash -> resolve thread -> react +1."
+              );
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ poetry run repo-scaffold pr annotations --repo OWNER/REPO --pr-number N [--json]
 poetry run repo-scaffold pr rerun --repo OWNER/REPO --pr-number N [--failed-only]
 poetry run repo-scaffold pr list-comments --repo OWNER/REPO --pr-number N [--json]
 poetry run repo-scaffold pr review-threads --repo OWNER/REPO --pr-number N [--json]
+poetry run repo-scaffold pr check-sop --repo OWNER/REPO --pr-number N [--json]
 
 # Branches
 poetry run repo-scaffold branch create --repo OWNER/REPO --name BRANCH [--from main]
@@ -104,6 +105,54 @@ poetry run repo-scaffold apply templates --path . --name NAME --owner OWNER
 poetry run repo-scaffold create --repo OWNER/REPO --visibility public --path /path/to/code
 
 poetry run repo-scaffold check rules --repo OWNER/REPO
+```
+
+## PR Conventions
+
+### Title format (required on every PR)
+
+```
+type(scope): description (#issue-number)
+```
+
+- `type`: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`
+- `(#issue-number)` at the end is **required** -- always include the tracking issue number
+- Example: `feat(ruleset): add DRY sync command (#208)`
+- If you forgot the issue number: `poetry run repo-scaffold pr update --repo OWNER/REPO --pr-number N --title "type(scope): description (#N)"`
+
+### Review comment SOP (all three steps, in order, non-negotiable)
+
+For every review thread on a PR you are working on, complete ALL of the following:
+
+**Step 1 -- Push the fix.** Make the code change, commit, push. Note the commit hash.
+
+**Step 2 -- Reply to the thread** with the commit hash and a one-sentence explanation:
+```bash
+poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N \
+  --body "Fixed in <hash>. <one sentence what changed>." \
+  --reply-to COMMENT_ID
+```
+
+**Step 3 -- Resolve the thread:**
+```bash
+poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
+```
+
+**Step 4 -- React +1 to the original reviewer comment:**
+```bash
+poetry run repo-scaffold pr react --repo OWNER/REPO --comment-id COMMENT_ID --reaction "+1"
+```
+
+A thread is **NOT done** until all four steps are complete (fix, reply, resolve, react).
+
+To get THREAD_ID and COMMENT_ID (databaseId of the first comment in each thread):
+```bash
+poetry run repo-scaffold pr review-threads --repo OWNER/REPO --pr-number N --json
+```
+
+To verify all threads are SOP-compliant before declaring work done:
+```bash
+poetry run repo-scaffold pr check-sop --repo OWNER/REPO --pr-number N
 ```
 
 ## Supported languages for init/apply ci

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -3029,13 +3029,13 @@ def main(argv: list[str] | None = None) -> int:
                 print("No review threads found.")
                 return 0
             non_compliant = 0
-            for entry in report:
-                tid = entry.get("thread_id", "?")
-                cid = entry.get("first_comment_id", "?")
-                if entry.get("compliant"):
+            for t in report:
+                tid = t.get("thread_id", "?")
+                cid = t.get("first_comment_id", "?")
+                if t.get("compliant"):
                     print(f"  OK  thread={tid}  comment={cid}")
                 else:
-                    missing = ", ".join(entry.get("missing", []))
+                    missing = ", ".join(t.get("missing", []))
                     print(f"  FAIL  thread={tid}  comment={cid}  missing: {missing}")
                     non_compliant += 1
             total = len(report)

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -46,6 +46,7 @@ from .github_api import (
     pr_rerun,
     pr_resolve_thread,
     pr_review_threads,
+    pr_check_sop,
     pr_request_reviewer,
     pr_reviews,
     pr_update,
@@ -1394,6 +1395,16 @@ def build_parser() -> argparse.ArgumentParser:
     pr_review_threads_cmd.add_argument(
         "--json", action="store_true", dest="json_output"
     )
+
+    pr_check_sop_cmd = pr_sub.add_parser(
+        "check-sop",
+        help="Check each review thread for SOP compliance: replied, resolved, reacted +1",
+    )
+    pr_check_sop_cmd.add_argument("--repo", required=True)
+    pr_check_sop_cmd.add_argument(
+        "--pr-number", required=True, type=int, dest="pr_number"
+    )
+    pr_check_sop_cmd.add_argument("--json", action="store_true", dest="json_output")
 
     pr_reviews_cmd = pr_sub.add_parser(
         "reviews", help="List submitted reviews for a PR"
@@ -3003,6 +3014,33 @@ def main(argv: list[str] | None = None) -> int:
                         print(f"[{state}] {author} on {path}:{line}")
                         print(f"  {body[:200]}")
             return 0
+
+        if ns.pr_command == "check-sop":
+            owner, repo_name = target_repo.split("/", 1)
+            cp = pr_check_sop(owner, repo_name, ns.pr_number, token)
+            if cp.returncode != 0:
+                print(cp.stderr.strip() or "Failed checking SOP.", file=sys.stderr)
+                return 1
+            report = _json.loads(cp.stdout)
+            if ns.json_output:
+                print(_json.dumps(report, indent=2))
+                return 0
+            if not report:
+                print("No review threads found.")
+                return 0
+            non_compliant = 0
+            for entry in report:
+                tid = entry.get("thread_id", "?")
+                cid = entry.get("first_comment_id", "?")
+                if entry.get("compliant"):
+                    print(f"  OK  thread={tid}  comment={cid}")
+                else:
+                    missing = ", ".join(entry.get("missing", []))
+                    print(f"  FAIL  thread={tid}  comment={cid}  missing: {missing}")
+                    non_compliant += 1
+            total = len(report)
+            print(f"\n{total - non_compliant}/{total} threads SOP-compliant.")
+            return 1 if non_compliant else 0
 
         if ns.pr_command == "reviews":
             cp = pr_reviews(target_repo, ns.pr_number, token)

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -3022,13 +3022,13 @@ def main(argv: list[str] | None = None) -> int:
                 print(cp.stderr.strip() or "Failed checking SOP.", file=sys.stderr)
                 return 1
             report = _json.loads(cp.stdout)
+            non_compliant = sum(1 for t in report if not t.get("compliant"))
             if ns.json_output:
                 print(_json.dumps(report, indent=2))
-                return 0
+                return 1 if non_compliant else 0
             if not report:
                 print("No review threads found.")
                 return 0
-            non_compliant = 0
             for t in report:
                 tid = t.get("thread_id", "?")
                 cid = t.get("first_comment_id", "?")
@@ -3037,7 +3037,6 @@ def main(argv: list[str] | None = None) -> int:
                 else:
                     missing = ", ".join(t.get("missing", []))
                     print(f"  FAIL  thread={tid}  comment={cid}  missing: {missing}")
-                    non_compliant += 1
             total = len(report)
             print(f"\n{total - non_compliant}/{total} threads SOP-compliant.")
             return 1 if non_compliant else 0

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -181,6 +181,10 @@ def _render_validate_issue_workflow() -> str:
     return _load_template("github/workflows/validate-issue.yml", "")
 
 
+def _render_validate_pr_sop_workflow() -> str:
+    return _load_template("github/workflows/validate-pr-sop.yml", "")
+
+
 def _render_ci_yaml(languages: Iterable[str]) -> str:
     selected = set(languages)
     parts: list[str] = [
@@ -3259,6 +3263,10 @@ def build_scaffold_files(config: ScaffoldConfig) -> list[ScaffoldFile]:
             _render_validate_issue_workflow(),
         ),
         ScaffoldFile(
+            config.out_dir / ".github" / "workflows" / "validate-pr-sop.yml",
+            _render_validate_pr_sop_workflow(),
+        ),
+        ScaffoldFile(
             config.out_dir / ".github" / "dependabot.yml",
             _render_dependabot_yaml(config.languages),
         ),
@@ -3393,6 +3401,7 @@ TEMPLATE_FILE_PATHS = (
     ".github/ISSUE_TEMPLATE/ticket.md",
     ".github/ISSUE_TEMPLATE/config.yml",
     ".github/workflows/validate-issue.yml",
+    ".github/workflows/validate-pr-sop.yml",
 )
 
 

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1519,10 +1519,11 @@ mutation($threadId: ID!) {
 """
 
 _GQL_PR_REVIEW_THREADS = """
-query($owner: String!, $repo: String!, $number: Int!) {
+query($owner: String!, $repo: String!, $number: Int!, $after: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
-      reviewThreads(first: 50) {
+      reviewThreads(first: 50, after: $after) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           isResolved
@@ -1530,6 +1531,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
             nodes {
               databaseId
               author { login }
+              body
               reactions(first: 30) {
                 nodes { content user { login } }
               }
@@ -1603,34 +1605,51 @@ def pr_check_sop(
     owner: str, repo: str, number: int, token: str
 ) -> subprocess.CompletedProcess[str]:
     """Check each review thread on a PR for SOP compliance: replied, resolved, reacted +1."""
-    cp = graphql(
-        _GQL_PR_REVIEW_THREADS,
-        {"owner": owner, "repo": repo, "number": number},
-        token,
-    )
-    if cp.returncode != 0:
-        return cp
-    try:
-        data = json.loads(cp.stdout)
-        threads = (
-            data.get("repository", {})
-            .get("pullRequest", {})
-            .get("reviewThreads", {})
-            .get("nodes", [])
-        )
-    except (json.JSONDecodeError, AttributeError):
-        return _err("Unexpected response from GitHub.")
+    all_threads: list[Any] = []
+    cursor: str | None = None
+
+    while True:
+        variables: dict[str, object] = {
+            "owner": owner,
+            "repo": repo,
+            "number": number,
+            "after": cursor,
+        }
+        cp = graphql(_GQL_PR_REVIEW_THREADS, variables, token)
+        if cp.returncode != 0:
+            return cp
+        try:
+            data = json.loads(cp.stdout)
+            review_threads = (
+                data.get("repository", {})
+                .get("pullRequest", {})
+                .get("reviewThreads", {})
+            )
+            all_threads.extend(review_threads.get("nodes", []))
+            page_info = review_threads.get("pageInfo", {})
+        except (json.JSONDecodeError, AttributeError):
+            return _err("Unexpected response from GitHub.")
+
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
 
     report = []
-    for thread in threads:
+    for thread in all_threads:
         thread_id = thread.get("id", "")
         is_resolved = bool(thread.get("isResolved", False))
         comments = thread.get("comments", {}).get("nodes", [])
-        has_reply = len(comments) > 1
         first_comment = comments[0] if comments else {}
         first_comment_id = first_comment.get("databaseId")
+        first_author = first_comment.get("author", {}).get("login", "")
         reactions = first_comment.get("reactions", {}).get("nodes", [])
         has_plus_one = any(r.get("content") == "THUMBS_UP" for r in reactions)
+
+        # A valid SOP reply must come from a different author than the thread opener.
+        # This distinguishes an agent fix-reply from the reviewer adding follow-up comments.
+        has_reply = any(
+            c.get("author", {}).get("login", "") != first_author for c in comments[1:]
+        )
 
         missing = []
         if not has_reply:

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1523,7 +1523,19 @@ query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
       reviewThreads(first: 50) {
-        nodes { id isResolved }
+        nodes {
+          id
+          isResolved
+          comments(first: 50) {
+            nodes {
+              databaseId
+              author { login }
+              reactions(first: 30) {
+                nodes { content user { login } }
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -1585,6 +1597,62 @@ def pr_resolve_thread(thread_id: str, token: str) -> subprocess.CompletedProcess
         return _ok(json.dumps(thread))
     except (json.JSONDecodeError, AttributeError):
         return _err("Unexpected response resolving thread.")
+
+
+def pr_check_sop(
+    owner: str, repo: str, number: int, token: str
+) -> subprocess.CompletedProcess[str]:
+    """Check each review thread on a PR for SOP compliance: replied, resolved, reacted +1."""
+    cp = graphql(
+        _GQL_PR_REVIEW_THREADS,
+        {"owner": owner, "repo": repo, "number": number},
+        token,
+    )
+    if cp.returncode != 0:
+        return cp
+    try:
+        data = json.loads(cp.stdout)
+        threads = (
+            data.get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+            .get("nodes", [])
+        )
+    except (json.JSONDecodeError, AttributeError):
+        return _err("Unexpected response from GitHub.")
+
+    report = []
+    for thread in threads:
+        thread_id = thread.get("id", "")
+        is_resolved = bool(thread.get("isResolved", False))
+        comments = thread.get("comments", {}).get("nodes", [])
+        has_reply = len(comments) > 1
+        first_comment = comments[0] if comments else {}
+        first_comment_id = first_comment.get("databaseId")
+        reactions = first_comment.get("reactions", {}).get("nodes", [])
+        has_plus_one = any(r.get("content") == "THUMBS_UP" for r in reactions)
+
+        missing = []
+        if not has_reply:
+            missing.append("reply")
+        if not is_resolved:
+            missing.append("resolved")
+        if not has_plus_one:
+            missing.append("reaction(+1)")
+
+        report.append(
+            {
+                "thread_id": thread_id,
+                "first_comment_id": first_comment_id,
+                "is_resolved": is_resolved,
+                "has_reply": has_reply,
+                "has_plus_one": has_plus_one,
+                "compliant": not missing,
+                "missing": missing,
+            }
+        )
+
+    return _ok(json.dumps(report))
 
 
 def pr_create(

--- a/src/repo_scaffold/templates/github/workflows/validate-pr-sop.yml
+++ b/src/repo_scaffold/templates/github/workflows/validate-pr-sop.yml
@@ -1,0 +1,106 @@
+name: Validate PR review thread SOP
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to check
+        required: true
+        type: number
+
+jobs:
+  check-sop:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+      - name: Check review threads for SOP compliance
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber =
+              context.payload.pull_request?.number ||
+              parseInt(context.payload.inputs?.pr_number || "0");
+
+            if (!prNumber) {
+              core.setFailed("Could not determine PR number from event payload.");
+              return;
+            }
+
+            const data = await github.graphql(`
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    reviewThreads(first: 50) {
+                      nodes {
+                        id
+                        isResolved
+                        comments(first: 50) {
+                          nodes {
+                            databaseId
+                            author { login }
+                            reactions(first: 30) {
+                              nodes { content }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: prNumber,
+            });
+
+            const threads = data.repository.pullRequest.reviewThreads.nodes;
+
+            if (threads.length === 0) {
+              core.info("No review threads found. SOP check passed.");
+              return;
+            }
+
+            const failing = [];
+            for (const thread of threads) {
+              const comments = thread.comments.nodes;
+              const hasReply = comments.length > 1;
+              const isResolved = thread.isResolved;
+              const firstComment = comments[0] || {};
+              const reactions = (firstComment.reactions?.nodes) || [];
+              const hasPlusOne = reactions.some(r => r.content === "THUMBS_UP");
+
+              if (!hasReply || !isResolved || !hasPlusOne) {
+                const missing = [];
+                if (!hasReply) missing.push("reply");
+                if (!isResolved) missing.push("resolved");
+                if (!hasPlusOne) missing.push("reaction(+1)");
+                failing.push({
+                  threadId: thread.id,
+                  commentId: firstComment.databaseId,
+                  missing,
+                });
+              }
+            }
+
+            const total = threads.length;
+            const passed = total - failing.length;
+            core.info(`${passed}/${total} threads SOP-compliant.`);
+
+            if (failing.length > 0) {
+              for (const f of failing) {
+                core.error(
+                  `Thread ${f.threadId} (comment #${f.commentId}) missing: ${f.missing.join(", ")}`
+                );
+              }
+              core.setFailed(
+                `${failing.length} review thread(s) not SOP-compliant. ` +
+                "SOP: push fix -> reply with commit hash -> resolve thread -> react +1."
+              );
+            }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3505,3 +3505,157 @@ def test_workspace_configure_auth_cli_success(
     )
     rc = main(["workspace", "configure-auth"])
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# pr check-sop
+# ---------------------------------------------------------------------------
+
+
+def test_pr_check_sop_all_compliant(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    report = [
+        {
+            "thread_id": "PRRT_1",
+            "first_comment_id": 100,
+            "is_resolved": True,
+            "has_reply": True,
+            "has_plus_one": True,
+            "compliant": True,
+            "missing": [],
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_check_sop",
+        lambda owner, repo, number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(report), stderr=""
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(["pr", "check-sop", "--repo", "acme/repo", "--pr-number", "42"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "OK" in out
+    assert "1/1 threads SOP-compliant" in out
+
+
+def test_pr_check_sop_non_compliant_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    report = [
+        {
+            "thread_id": "PRRT_2",
+            "first_comment_id": 200,
+            "is_resolved": False,
+            "has_reply": False,
+            "has_plus_one": False,
+            "compliant": False,
+            "missing": ["reply", "resolved", "reaction(+1)"],
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_check_sop",
+        lambda owner, repo, number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(report), stderr=""
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(["pr", "check-sop", "--repo", "acme/repo", "--pr-number", "7"])
+    assert rc != 0
+    out = capsys.readouterr().out
+    assert "FAIL" in out
+    assert "reply" in out
+    assert "0/1 threads SOP-compliant" in out
+
+
+def test_pr_check_sop_no_threads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_check_sop",
+        lambda owner, repo, number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps([]), stderr=""
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(["pr", "check-sop", "--repo", "acme/repo", "--pr-number", "1"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "No review threads" in out
+
+
+def test_pr_check_sop_api_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_check_sop",
+        lambda owner, repo, number, token: subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="GraphQL error"
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(["pr", "check-sop", "--repo", "acme/repo", "--pr-number", "9"])
+    assert rc != 0
+
+
+def test_pr_check_sop_json_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    report = [
+        {
+            "thread_id": "PRRT_3",
+            "first_comment_id": 300,
+            "is_resolved": True,
+            "has_reply": True,
+            "has_plus_one": True,
+            "compliant": True,
+            "missing": [],
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_check_sop",
+        lambda owner, repo, number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(report), stderr=""
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(["pr", "check-sop", "--repo", "acme/repo", "--pr-number", "3", "--json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed[0]["thread_id"] == "PRRT_3"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3659,3 +3659,38 @@ def test_pr_check_sop_json_output(
     out = capsys.readouterr().out
     parsed = json.loads(out)
     assert parsed[0]["thread_id"] == "PRRT_3"
+
+
+def test_pr_check_sop_json_output_non_compliant_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    report = [
+        {
+            "thread_id": "PRRT_4",
+            "first_comment_id": 400,
+            "is_resolved": False,
+            "has_reply": False,
+            "has_plus_one": False,
+            "compliant": False,
+            "missing": ["reply", "resolved", "reaction(+1)"],
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_check_sop",
+        lambda owner, repo, number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(report), stderr=""
+        ),
+    )
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+
+    rc = main(["pr", "check-sop", "--repo", "acme/repo", "--pr-number", "4", "--json"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed[0]["compliant"] is False

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1375,6 +1375,7 @@ def _make_thread(
     is_resolved: bool,
     num_comments: int,
     first_has_thumbs_up: bool,
+    reply_author: str = "agent",
 ) -> dict:
     reactions = (
         [{"content": "THUMBS_UP", "user": {"login": "me"}}]
@@ -1385,6 +1386,7 @@ def _make_thread(
         {
             "databaseId": 100,
             "author": {"login": "reviewer"},
+            "body": "Please fix this.",
             "reactions": {"nodes": reactions},
         }
     ]
@@ -1392,7 +1394,8 @@ def _make_thread(
         comments.append(
             {
                 "databaseId": 100 + i,
-                "author": {"login": "author"},
+                "author": {"login": reply_author},
+                "body": f"Fixed in abc1234. Change #{i}.",
                 "reactions": {"nodes": []},
             }
         )
@@ -1403,9 +1406,23 @@ def _make_thread(
     }
 
 
-def _sop_resp(threads: list) -> str:
+def _sop_resp(
+    threads: list, has_next_page: bool = False, end_cursor: str | None = None
+) -> str:
     return json.dumps(
-        {"repository": {"pullRequest": {"reviewThreads": {"nodes": threads}}}}
+        {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": {
+                            "hasNextPage": has_next_page,
+                            "endCursor": end_cursor,
+                        },
+                        "nodes": threads,
+                    }
+                }
+            }
+        }
     )
 
 
@@ -1495,4 +1512,49 @@ def test_pr_check_sop_api_error_propagates() -> None:
     ):
         cp = github_api.pr_check_sop("acme", "repo", 7, "tok")
     assert cp.returncode != 0
-    assert cp.returncode != 0
+
+
+def test_pr_check_sop_reply_same_author_not_compliant() -> None:
+    thread = _make_thread(
+        "PRRT_8",
+        is_resolved=True,
+        num_comments=2,
+        first_has_thumbs_up=True,
+        reply_author="reviewer",  # same author as thread opener -- not a valid SOP reply
+    )
+    with patch.object(
+        github_api, "graphql", return_value=github_api._ok(_sop_resp([thread]))
+    ):
+        cp = github_api.pr_check_sop("acme", "repo", 8, "tok")
+    assert cp.returncode == 0
+    report = json.loads(cp.stdout)
+    assert report[0]["has_reply"] is False
+    assert "reply" in report[0]["missing"]
+
+
+def test_pr_check_sop_paginates_all_threads() -> None:
+    page1_thread = _make_thread(
+        "PRRT_P1", is_resolved=True, num_comments=2, first_has_thumbs_up=True
+    )
+    page2_thread = _make_thread(
+        "PRRT_P2", is_resolved=False, num_comments=1, first_has_thumbs_up=False
+    )
+    responses = iter(
+        [
+            github_api._ok(
+                _sop_resp([page1_thread], has_next_page=True, end_cursor="cursor1")
+            ),
+            github_api._ok(_sop_resp([page2_thread], has_next_page=False)),
+        ]
+    )
+    with patch.object(
+        github_api, "graphql", side_effect=lambda *_a, **_kw: next(responses)
+    ):
+        cp = github_api.pr_check_sop("acme", "repo", 9, "tok")
+    assert cp.returncode == 0
+    report = json.loads(cp.stdout)
+    assert len(report) == 2
+    assert report[0]["thread_id"] == "PRRT_P1"
+    assert report[0]["compliant"] is True
+    assert report[1]["thread_id"] == "PRRT_P2"
+    assert report[1]["compliant"] is False

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1362,6 +1362,7 @@ def test_project_views_graphql_error() -> None:
 def test_project_views_unexpected_response() -> None:
     with patch.object(github_api, "graphql", return_value=github_api._ok("not-json")):
         cp = github_api.project_views("PVT_x", "tok")
+    assert cp.returncode != 0
 
 
 # ---------------------------------------------------------------------------
@@ -1375,7 +1376,11 @@ def _make_thread(
     num_comments: int,
     first_has_thumbs_up: bool,
 ) -> dict:
-    reactions = [{"content": "THUMBS_UP", "user": {"login": "me"}}] if first_has_thumbs_up else []
+    reactions = (
+        [{"content": "THUMBS_UP", "user": {"login": "me"}}]
+        if first_has_thumbs_up
+        else []
+    )
     comments = [
         {
             "databaseId": 100,
@@ -1398,21 +1403,19 @@ def _make_thread(
     }
 
 
-def _gql_resp(threads: list) -> str:
+def _sop_resp(threads: list) -> str:
     return json.dumps(
-        {
-            "repository": {
-                "pullRequest": {
-                    "reviewThreads": {"nodes": threads}
-                }
-            }
-        }
+        {"repository": {"pullRequest": {"reviewThreads": {"nodes": threads}}}}
     )
 
 
 def test_pr_check_sop_all_compliant() -> None:
-    thread = _make_thread("PRRT_1", is_resolved=True, num_comments=2, first_has_thumbs_up=True)
-    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([thread]))):
+    thread = _make_thread(
+        "PRRT_1", is_resolved=True, num_comments=2, first_has_thumbs_up=True
+    )
+    with patch.object(
+        github_api, "graphql", return_value=github_api._ok(_sop_resp([thread]))
+    ):
         cp = github_api.pr_check_sop("acme", "repo", 1, "tok")
     assert cp.returncode == 0
     report = json.loads(cp.stdout)
@@ -1422,8 +1425,12 @@ def test_pr_check_sop_all_compliant() -> None:
 
 
 def test_pr_check_sop_missing_reply() -> None:
-    thread = _make_thread("PRRT_2", is_resolved=True, num_comments=1, first_has_thumbs_up=True)
-    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([thread]))):
+    thread = _make_thread(
+        "PRRT_2", is_resolved=True, num_comments=1, first_has_thumbs_up=True
+    )
+    with patch.object(
+        github_api, "graphql", return_value=github_api._ok(_sop_resp([thread]))
+    ):
         cp = github_api.pr_check_sop("acme", "repo", 2, "tok")
     assert cp.returncode == 0
     report = json.loads(cp.stdout)
@@ -1432,8 +1439,12 @@ def test_pr_check_sop_missing_reply() -> None:
 
 
 def test_pr_check_sop_not_resolved() -> None:
-    thread = _make_thread("PRRT_3", is_resolved=False, num_comments=2, first_has_thumbs_up=True)
-    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([thread]))):
+    thread = _make_thread(
+        "PRRT_3", is_resolved=False, num_comments=2, first_has_thumbs_up=True
+    )
+    with patch.object(
+        github_api, "graphql", return_value=github_api._ok(_sop_resp([thread]))
+    ):
         cp = github_api.pr_check_sop("acme", "repo", 3, "tok")
     assert cp.returncode == 0
     report = json.loads(cp.stdout)
@@ -1442,8 +1453,12 @@ def test_pr_check_sop_not_resolved() -> None:
 
 
 def test_pr_check_sop_missing_reaction() -> None:
-    thread = _make_thread("PRRT_4", is_resolved=True, num_comments=2, first_has_thumbs_up=False)
-    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([thread]))):
+    thread = _make_thread(
+        "PRRT_4", is_resolved=True, num_comments=2, first_has_thumbs_up=False
+    )
+    with patch.object(
+        github_api, "graphql", return_value=github_api._ok(_sop_resp([thread]))
+    ):
         cp = github_api.pr_check_sop("acme", "repo", 4, "tok")
     assert cp.returncode == 0
     report = json.loads(cp.stdout)
@@ -1452,8 +1467,12 @@ def test_pr_check_sop_missing_reaction() -> None:
 
 
 def test_pr_check_sop_all_missing() -> None:
-    thread = _make_thread("PRRT_5", is_resolved=False, num_comments=1, first_has_thumbs_up=False)
-    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([thread]))):
+    thread = _make_thread(
+        "PRRT_5", is_resolved=False, num_comments=1, first_has_thumbs_up=False
+    )
+    with patch.object(
+        github_api, "graphql", return_value=github_api._ok(_sop_resp([thread]))
+    ):
         cp = github_api.pr_check_sop("acme", "repo", 5, "tok")
     assert cp.returncode == 0
     report = json.loads(cp.stdout)
@@ -1462,14 +1481,18 @@ def test_pr_check_sop_all_missing() -> None:
 
 
 def test_pr_check_sop_empty_pr() -> None:
-    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([]))):
+    with patch.object(
+        github_api, "graphql", return_value=github_api._ok(_sop_resp([]))
+    ):
         cp = github_api.pr_check_sop("acme", "repo", 6, "tok")
     assert cp.returncode == 0
     assert json.loads(cp.stdout) == []
 
 
 def test_pr_check_sop_api_error_propagates() -> None:
-    with patch.object(github_api, "graphql", return_value=github_api._err("GraphQL error")):
+    with patch.object(
+        github_api, "graphql", return_value=github_api._err("GraphQL error")
+    ):
         cp = github_api.pr_check_sop("acme", "repo", 7, "tok")
     assert cp.returncode != 0
     assert cp.returncode != 0

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1362,4 +1362,114 @@ def test_project_views_graphql_error() -> None:
 def test_project_views_unexpected_response() -> None:
     with patch.object(github_api, "graphql", return_value=github_api._ok("not-json")):
         cp = github_api.project_views("PVT_x", "tok")
+
+
+# ---------------------------------------------------------------------------
+# pr_check_sop
+# ---------------------------------------------------------------------------
+
+
+def _make_thread(
+    thread_id: str,
+    is_resolved: bool,
+    num_comments: int,
+    first_has_thumbs_up: bool,
+) -> dict:
+    reactions = [{"content": "THUMBS_UP", "user": {"login": "me"}}] if first_has_thumbs_up else []
+    comments = [
+        {
+            "databaseId": 100,
+            "author": {"login": "reviewer"},
+            "reactions": {"nodes": reactions},
+        }
+    ]
+    for i in range(1, num_comments):
+        comments.append(
+            {
+                "databaseId": 100 + i,
+                "author": {"login": "author"},
+                "reactions": {"nodes": []},
+            }
+        )
+    return {
+        "id": thread_id,
+        "isResolved": is_resolved,
+        "comments": {"nodes": comments},
+    }
+
+
+def _gql_resp(threads: list) -> str:
+    return json.dumps(
+        {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {"nodes": threads}
+                }
+            }
+        }
+    )
+
+
+def test_pr_check_sop_all_compliant() -> None:
+    thread = _make_thread("PRRT_1", is_resolved=True, num_comments=2, first_has_thumbs_up=True)
+    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([thread]))):
+        cp = github_api.pr_check_sop("acme", "repo", 1, "tok")
+    assert cp.returncode == 0
+    report = json.loads(cp.stdout)
+    assert len(report) == 1
+    assert report[0]["compliant"] is True
+    assert report[0]["missing"] == []
+
+
+def test_pr_check_sop_missing_reply() -> None:
+    thread = _make_thread("PRRT_2", is_resolved=True, num_comments=1, first_has_thumbs_up=True)
+    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([thread]))):
+        cp = github_api.pr_check_sop("acme", "repo", 2, "tok")
+    assert cp.returncode == 0
+    report = json.loads(cp.stdout)
+    assert report[0]["compliant"] is False
+    assert "reply" in report[0]["missing"]
+
+
+def test_pr_check_sop_not_resolved() -> None:
+    thread = _make_thread("PRRT_3", is_resolved=False, num_comments=2, first_has_thumbs_up=True)
+    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([thread]))):
+        cp = github_api.pr_check_sop("acme", "repo", 3, "tok")
+    assert cp.returncode == 0
+    report = json.loads(cp.stdout)
+    assert report[0]["compliant"] is False
+    assert "resolved" in report[0]["missing"]
+
+
+def test_pr_check_sop_missing_reaction() -> None:
+    thread = _make_thread("PRRT_4", is_resolved=True, num_comments=2, first_has_thumbs_up=False)
+    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([thread]))):
+        cp = github_api.pr_check_sop("acme", "repo", 4, "tok")
+    assert cp.returncode == 0
+    report = json.loads(cp.stdout)
+    assert report[0]["compliant"] is False
+    assert "reaction(+1)" in report[0]["missing"]
+
+
+def test_pr_check_sop_all_missing() -> None:
+    thread = _make_thread("PRRT_5", is_resolved=False, num_comments=1, first_has_thumbs_up=False)
+    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([thread]))):
+        cp = github_api.pr_check_sop("acme", "repo", 5, "tok")
+    assert cp.returncode == 0
+    report = json.loads(cp.stdout)
+    missing = set(report[0]["missing"])
+    assert missing == {"reply", "resolved", "reaction(+1)"}
+
+
+def test_pr_check_sop_empty_pr() -> None:
+    with patch.object(github_api, "graphql", return_value=github_api._ok(_gql_resp([]))):
+        cp = github_api.pr_check_sop("acme", "repo", 6, "tok")
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout) == []
+
+
+def test_pr_check_sop_api_error_propagates() -> None:
+    with patch.object(github_api, "graphql", return_value=github_api._err("GraphQL error")):
+        cp = github_api.pr_check_sop("acme", "repo", 7, "tok")
+    assert cp.returncode != 0
     assert cp.returncode != 0


### PR DESCRIPTION
## 🧾 Title
Add `pr check-sop` command, document PR review comment SOP, and add validate-pr-sop.yml CI gate

## 🧠 Description
Three related gaps addressed:

1. PR title convention (`type(scope): description (#issue-number)`) was undocumented.
2. The 4-step review comment SOP (push fix, reply with commit hash, resolve thread, react +1) existed only in feedback memory -- no verification mechanism.
3. No automated CI gate blocked merging PRs with non-compliant review threads.

## 🧩 Changes Included
- [x] Added/updated documentation
- [x] Implemented new feature or enhancement

## 🎯 Purpose
Make the PR review comment SOP self-enforcing at two levels: (1) a CLI command agents can run manually, and (2) a CI workflow that fails the check run if any review thread is missing a reply, resolution, or +1 reaction -- blocking merge until SOP is complete.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #214
- Closes #214

## 🧪 Testing
1. `poetry run repo-scaffold pr check-sop --repo blairg23/repo-scaffold --pr-number 212` -- all threads compliant
2. `poetry run pytest tests/test_github_api.py tests/test_cli.py -k pr_check_sop -v` -- 12 tests pass
3. `poetry run tox -e precommit` -- green, 73.36% coverage
4. `validate-pr-sop.yml` is now active on this repo -- it will run on next synchronize event

## 🧰 Developer Notes
- `validate-pr-sop.yml` triggers on `pull_request` (opened/synchronize/reopened), `pull_request_review` (submitted), and `workflow_dispatch`
- Requires only `pull-requests: read` permission -- no write access needed
- Thread is SOP-compliant if: `isResolved AND len(comments) > 1 AND first comment has THUMBS_UP reaction`
- Workflow is wired into `generator.py` (`build_scaffold_files` + `TEMPLATE_FILE_PATHS`) so downstream repos receive it via `apply templates`
- Loop variable in CLI handler is `t` (not `entry`) to avoid shadowing `RegistryEntry`-typed variable in same function scope
- Pre-existing `test_project_views_unexpected_response` missing assertion fixed as a bonus