### PR TITLE
fix(ci): validate-issue.yml removes needs-format when body is corrected (#209)

### DIFF
--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -23,6 +23,16 @@ jobs:
 
             if (missing.length === 0) {
               core.info(`Issue #${number} body looks good.`);
+              // Remove needs-format if it was added by a previous failed check
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  name: "needs-format",
+                });
+                core.info(`Removed needs-format label from issue #${number}.`);
+              } catch (_) {}
               return;
             }
 
@@ -53,6 +63,5 @@ jobs:
                 ...missing.map(h => `- \`${h}\``),
                 "",
                 "Please update the body to match the [epic template](../.github/ISSUE_TEMPLATE/epic.md) or [ticket template](../.github/ISSUE_TEMPLATE/ticket.md).",
-                "Remove the `needs-format` label once the body is corrected.",
               ].join("\n"),
             });

--- a/src/repo_scaffold/templates/github/workflows/validate-issue.yml
+++ b/src/repo_scaffold/templates/github/workflows/validate-issue.yml
@@ -23,6 +23,16 @@ jobs:
 
             if (missing.length === 0) {
               core.info(`Issue #${number} body looks good.`);
+              // Remove needs-format if it was added by a previous failed check
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  name: "needs-format",
+                });
+                core.info(`Removed needs-format label from issue #${number}.`);
+              } catch (_) {}
               return;
             }
 
@@ -53,6 +63,5 @@ jobs:
                 ...missing.map(h => `- \`${h}\``),
                 "",
                 "Please update the body to match the [epic template](../.github/ISSUE_TEMPLATE/epic.md) or [ticket template](../.github/ISSUE_TEMPLATE/ticket.md).",
-                "Remove the `needs-format` label once the body is corrected.",
               ].join("\n"),
             });


### PR DESCRIPTION
## 🧾 Title
Fix validate-issue.yml one-way ratchet: remove needs-format when body is corrected

## 🧠 Description
`validate-issue.yml` added `needs-format` on invalid bodies but never removed it. Once applied, the label stayed forever even after the author fixed the issue body. This PR adds label removal on the "body looks good" path.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement

## 🎯 Purpose
Make `needs-format` a true signal: present means the body is currently invalid, absent means it is currently valid. Before this fix the label was a one-way ratchet with no feedback to the author that their edit worked.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #209
- Closes #209

## 🧪 Testing
1. Open an issue without `## 🧾 Title` -- `needs-format` is added
2. Edit the body to include both required sections -- `needs-format` is removed automatically
3. Remove a section again -- `needs-format` is re-added

## 🧰 Developer Notes
- Both `src/repo_scaffold/templates/github/workflows/validate-issue.yml` and `.github/workflows/validate-issue.yml` updated (template is source of truth; repo copy is the applied instance)
- `removeLabel` call is wrapped in `try/catch` -- silently ignores 404 when the label is not on the issue
- Removed the manual "Remove the needs-format label once the body is corrected" instruction from the posted comment since the workflow now handles that automatically