### PR TITLE
chore(ruleset): require check-sop and validate-pr as mandatory status checks (#218)

### DIFF
--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -84,6 +84,8 @@ _LANGUAGE_CI_CONTEXT: dict[str, str] = {
     "gin": "go",
 }
 
+_ALWAYS_REQUIRED_CONTEXTS: list[str] = ["check-sop", "validate-pr"]
+
 
 def _default_branch_ruleset_payload(
     languages: list[str] | None = None,
@@ -143,26 +145,24 @@ def _default_branch_ruleset_payload(
         }
     )
 
+    contexts = list(_ALWAYS_REQUIRED_CONTEXTS)
     if languages:
-        contexts = list(
-            dict.fromkeys(
-                _LANGUAGE_CI_CONTEXT[lang]
-                for lang in languages
-                if lang in _LANGUAGE_CI_CONTEXT
-            )
-        )
-        if contexts:
-            rules.append(
-                {
-                    "type": "required_status_checks",
-                    "parameters": {
-                        "required_status_checks": [
-                            {"context": ctx} for ctx in contexts
-                        ],
-                        "strict_required_status_checks_policy": False,
-                    },
-                }
-            )
+        for ctx in dict.fromkeys(
+            _LANGUAGE_CI_CONTEXT[lang]
+            for lang in languages
+            if lang in _LANGUAGE_CI_CONTEXT
+        ):
+            if ctx not in contexts:
+                contexts.append(ctx)
+    rules.append(
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "required_status_checks": [{"context": ctx} for ctx in contexts],
+                "strict_required_status_checks_policy": False,
+            },
+        }
+    )
     return json.dumps(
         {
             "name": _SETTINGS_RULESET_NAME,
@@ -727,34 +727,33 @@ def _compare_ruleset_against_baseline(
                         f"copilot_code_review.{key} expected {expected!r} got {actual!r}"
                     )
 
+    expected_contexts = list(_ALWAYS_REQUIRED_CONTEXTS)
     if languages:
-        expected_contexts = list(
-            dict.fromkeys(
-                _LANGUAGE_CI_CONTEXT[lang]
-                for lang in languages
-                if lang in _LANGUAGE_CI_CONTEXT
-            )
+        for ctx in dict.fromkeys(
+            _LANGUAGE_CI_CONTEXT[lang]
+            for lang in languages
+            if lang in _LANGUAGE_CI_CONTEXT
+        ):
+            if ctx not in expected_contexts:
+                expected_contexts.append(ctx)
+
+    status_checks_rule = rule_map.get("required_status_checks")
+    if not isinstance(status_checks_rule, dict):
+        drifts.append("missing rule: required_status_checks")
+    else:
+        status_parameters = status_checks_rule.get("parameters")
+        actual_contexts = (
+            [
+                item.get("context")
+                for item in status_parameters.get("required_status_checks", [])
+                if isinstance(item, dict)
+            ]
+            if isinstance(status_parameters, dict)
+            else []
         )
-        if expected_contexts:
-            status_checks_rule = rule_map.get("required_status_checks")
-            if not isinstance(status_checks_rule, dict):
-                drifts.append("missing rule: required_status_checks")
-            else:
-                status_parameters = status_checks_rule.get("parameters")
-                actual_contexts = (
-                    [
-                        item.get("context")
-                        for item in status_parameters.get("required_status_checks", [])
-                        if isinstance(item, dict)
-                    ]
-                    if isinstance(status_parameters, dict)
-                    else []
-                )
-                missing = [c for c in expected_contexts if c not in actual_contexts]
-                if missing:
-                    drifts.append(
-                        "required_status_checks missing contexts: " f"{missing!r}"
-                    )
+        missing = [c for c in expected_contexts if c not in actual_contexts]
+        if missing:
+            drifts.append("required_status_checks missing contexts: " f"{missing!r}")
 
     return drifts
 

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -181,6 +181,10 @@ def _render_validate_issue_workflow() -> str:
     return _load_template("github/workflows/validate-issue.yml", "")
 
 
+def _render_validate_pr_workflow() -> str:
+    return _load_template("github/workflows/validate-pr.yml", "")
+
+
 def _render_validate_pr_sop_workflow() -> str:
     return _load_template("github/workflows/validate-pr-sop.yml", "")
 
@@ -3217,6 +3221,10 @@ def build_scaffold_files(config: ScaffoldConfig) -> list[ScaffoldFile]:
             _render_validate_issue_workflow(),
         ),
         ScaffoldFile(
+            config.out_dir / ".github" / "workflows" / "validate-pr.yml",
+            _render_validate_pr_workflow(),
+        ),
+        ScaffoldFile(
             config.out_dir / ".github" / "workflows" / "validate-pr-sop.yml",
             _render_validate_pr_sop_workflow(),
         ),
@@ -3355,6 +3363,7 @@ TEMPLATE_FILE_PATHS = (
     ".github/ISSUE_TEMPLATE/ticket.md",
     ".github/ISSUE_TEMPLATE/config.yml",
     ".github/workflows/validate-issue.yml",
+    ".github/workflows/validate-pr.yml",
     ".github/workflows/validate-pr-sop.yml",
 )
 

--- a/src/repo_scaffold/templates/github/workflows/validate-pr.yml
+++ b/src/repo_scaffold/templates/github/workflows/validate-pr.yml
@@ -1,0 +1,67 @@
+name: Validate PR body format
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Check PR body and flag if malformed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const number = context.payload.pull_request.number;
+
+            const required = ["## 🧾 Title"];
+            const missing = required.filter(h => !body.includes(h));
+
+            if (missing.length === 0) {
+              core.info(`PR #${number} body looks good.`);
+              // Remove needs-format if it was added by a previous failed check
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  name: "needs-format",
+                });
+                core.info(`Removed needs-format label from PR #${number}.`);
+              } catch (_) {}
+              return;
+            }
+
+            // Create needs-format label if it does not exist yet (422 = already exists)
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: "needs-format",
+                color: "e11d48",
+                description: "Issue body does not match the required template format",
+              });
+            } catch (_) {}
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              labels: ["needs-format"],
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: [
+                "This PR is missing required body sections:",
+                ...missing.map(h => `- \`${h}\``),
+                "",
+                "Please update the PR description to match the [pull request template](../.github/pull_request_template.md).",
+              ].join("\n"),
+            });

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -159,12 +159,18 @@ def test_default_branch_ruleset_payload_uses_zero_review_baseline() -> None:
     assert copilot_code_review_rule["parameters"]["review_on_push"] is True
 
 
-def test_default_branch_ruleset_payload_without_languages_has_no_required_status_checks() -> (
+def test_default_branch_ruleset_payload_always_includes_required_status_checks() -> (
     None
 ):
     payload = json.loads(create_ops._default_branch_ruleset_payload())
-    types = [rule["type"] for rule in payload["rules"]]
-    assert "required_status_checks" not in types
+    rule = next(
+        (r for r in payload["rules"] if r["type"] == "required_status_checks"), None
+    )
+    assert rule is not None
+    contexts = [c["context"] for c in rule["parameters"]["required_status_checks"]]
+    assert "check-sop" in contexts
+    assert "validate-pr" in contexts
+    assert rule["parameters"]["strict_required_status_checks_policy"] is False
 
 
 def test_default_branch_ruleset_payload_with_react_adds_required_status_checks() -> (
@@ -178,7 +184,7 @@ def test_default_branch_ruleset_payload_with_react_adds_required_status_checks()
     )
     assert rule is not None
     contexts = [c["context"] for c in rule["parameters"]["required_status_checks"]]
-    assert contexts == ["react"]
+    assert contexts == ["check-sop", "validate-pr", "react"]
     assert rule["parameters"]["strict_required_status_checks_policy"] is False
 
 
@@ -188,7 +194,7 @@ def test_default_branch_ruleset_payload_deduplicates_go_gin_context() -> None:
     )
     rule = next(r for r in payload["rules"] if r["type"] == "required_status_checks")
     contexts = [c["context"] for c in rule["parameters"]["required_status_checks"]]
-    assert contexts == ["go"]
+    assert contexts == ["check-sop", "validate-pr", "go"]
 
 
 def test_apply_repository_settings_forwards_languages(
@@ -333,11 +339,140 @@ def test_compare_ruleset_against_baseline_reports_multiple_drifts() -> None:
     assert any("pull_request.allowed_merge_methods" in item for item in drifts)
     assert any("code_scanning.code_scanning_tools" in item for item in drifts)
     assert "missing rule: code_quality" in drifts
+    assert "missing rule: required_status_checks" in drifts
     assert (
         "copilot_code_review.review_draft_pull_requests expected True got False"
         in drifts
     )
     assert "copilot_code_review.review_on_push expected True got False" in drifts
+
+
+def _clean_baseline_ruleset(
+    extra_rules: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    rules: list[dict[str, object]] = [
+        {"type": "deletion"},
+        {"type": "non_fast_forward"},
+        {"type": "required_linear_history"},
+        {
+            "type": "pull_request",
+            "parameters": {
+                "allowed_merge_methods": ["squash"],
+                "dismiss_stale_reviews_on_push": False,
+                "require_code_owner_review": False,
+                "require_last_push_approval": False,
+                "required_approving_review_count": 0,
+                "required_review_thread_resolution": True,
+            },
+        },
+        {
+            "type": "code_scanning",
+            "parameters": {
+                "code_scanning_tools": [
+                    {
+                        "tool": "CodeQL",
+                        "alerts_threshold": "errors_and_warnings",
+                        "security_alerts_threshold": "high_or_higher",
+                    }
+                ]
+            },
+        },
+        {
+            "type": "code_quality",
+            "parameters": {
+                "code_quality_tools": [{"tool": "CodeQL", "severity": "notes"}]
+            },
+        },
+        {
+            "type": "copilot_code_review",
+            "parameters": {"review_draft_pull_requests": True, "review_on_push": True},
+        },
+    ]
+    if extra_rules:
+        rules.extend(extra_rules)
+    return {
+        "name": create_ops._SETTINGS_RULESET_NAME,
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": rules,
+    }
+
+
+def test_compare_ruleset_missing_required_status_checks_reports_drift() -> None:
+    drifts = create_ops._compare_ruleset_against_baseline(
+        [_clean_baseline_ruleset()],
+        default_branch="main",
+    )
+    assert "missing rule: required_status_checks" in drifts
+
+
+def test_compare_ruleset_required_status_checks_missing_always_required_contexts() -> (
+    None
+):
+    ruleset = _clean_baseline_ruleset(
+        extra_rules=[
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "required_status_checks": [{"context": "python"}],
+                    "strict_required_status_checks_policy": False,
+                },
+            }
+        ]
+    )
+    drifts = create_ops._compare_ruleset_against_baseline(
+        [ruleset], default_branch="main"
+    )
+    assert any("required_status_checks missing contexts" in d for d in drifts)
+    missing_drift = next(
+        d for d in drifts if "required_status_checks missing contexts" in d
+    )
+    assert "check-sop" in missing_drift
+    assert "validate-pr" in missing_drift
+
+
+def test_compare_ruleset_required_status_checks_all_contexts_present_no_drift() -> None:
+    ruleset = _clean_baseline_ruleset(
+        extra_rules=[
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "required_status_checks": [
+                        {"context": "check-sop"},
+                        {"context": "validate-pr"},
+                    ],
+                    "strict_required_status_checks_policy": False,
+                },
+            }
+        ]
+    )
+    drifts = create_ops._compare_ruleset_against_baseline(
+        [ruleset], default_branch="main"
+    )
+    assert not any("required_status_checks" in d for d in drifts)
+
+
+def test_compare_ruleset_always_required_plus_language_contexts() -> None:
+    ruleset = _clean_baseline_ruleset(
+        extra_rules=[
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "required_status_checks": [
+                        {"context": "check-sop"},
+                        {"context": "validate-pr"},
+                        {"context": "python"},
+                    ],
+                    "strict_required_status_checks_policy": False,
+                },
+            }
+        ]
+    )
+    drifts = create_ops._compare_ruleset_against_baseline(
+        [ruleset], default_branch="main", languages=["python"]
+    )
+    assert not any("required_status_checks" in d for d in drifts)
 
 
 def test_repo_metadata_and_ruleset_loaders_cover_success_and_error_paths(
@@ -1852,9 +1987,15 @@ def test_create_repository_covers_success_skip_and_error_paths(
     assert errors == ["bad repo"]
 
 
-def test_create_repository_rejects_invalid_visibility(tmp_path: Path) -> None:
+def test_create_repository_rejects_invalid_visibility(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir()
+
+    monkeypatch.setattr(create_ops, "_ensure_tools", lambda: None)
+    monkeypatch.setattr(create_ops, "_build_env", lambda _: {"GH_TOKEN": "x"})
+    monkeypatch.setattr(create_ops, "_ensure_gh_auth", lambda _d, _e: None)
 
     with pytest.raises(RuntimeError, match="Visibility must be one of"):
         create_ops.create_repository(


### PR DESCRIPTION
## 🧾 Title
Require check-sop and validate-pr as mandatory status checks in the branch ruleset

## 🧠 Description
We added `validate-pr-sop.yml` (job: `check-sop`) and `validate-pr.yml` (job: `validate-pr`) to enforce the review comment SOP and PR body template format. Without making them required status checks, CI failure does not block merges -- the workflows are advisory only.

This PR makes both jobs required on the default branch, unconditionally (no language flag required). It also adds `_ALWAYS_REQUIRED_CONTEXTS = ["check-sop", "validate-pr"]` as a named constant so the list is maintained in one place.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement

## 🎯 Purpose
Turn the SOP and format validators into true build stoppers: a PR with unresolved review threads or a malformed body cannot be merged, not just warned about.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #218
- Closes #218

## 🧪 Testing
1. `poetry run tox -e precommit` -- green
2. Unit tests verify `_default_branch_ruleset_payload()` always includes `check-sop` and `validate-pr` in required_status_checks, even with no languages
3. Drift detection tests verify missing or wrong required_status_checks contexts are reported

## 🧰 Developer Notes
- **Merge order:** This PR MUST be merged AFTER #215 (validate-pr-sop.yml) and #217 (validate-pr.yml) land on main. Adding a required check for a workflow that does not exist on main causes all PRs to show "waiting for status" indefinitely
- `_ALWAYS_REQUIRED_CONTEXTS` is the single place to add new always-required contexts in future
- `validate-pr.yml` job was renamed from `validate` to `validate-pr` in #217 (more specific, avoids collisions)
- Also fixed `test_create_repository_rejects_invalid_visibility` to be hermetic (monkeypatched auth); it was silently passing on main because `.env` in CWD satisfied auth before the visibility check