### PR TITLE
feat(templates): include .gitattributes with LF enforcement in scaffolded repos (#116)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ htmlcov/
 
 # Local machine-only data (do not commit)
 local/
+artifacts/
 
 # Repo-scaffold local metadata (do not commit)
 .repo-scaffold/

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -604,6 +604,21 @@ indent_style = tab
 """
 
 
+def _render_gitattributes() -> str:
+    return """* text=auto eol=lf
+*.sh text eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.cfg text eol=lf
+*.ini text eol=lf
+*.txt text eol=lf
+"""
+
+
 def _render_makefile() -> str:
     return """.PHONY: format lint typecheck test build
 
@@ -3248,6 +3263,7 @@ def build_scaffold_files(config: ScaffoldConfig) -> list[ScaffoldFile]:
         ScaffoldFile(
             config.out_dir / ".gitignore", _render_gitignore(config.languages)
         ),
+        ScaffoldFile(config.out_dir / ".gitattributes", _render_gitattributes()),
         ScaffoldFile(config.out_dir / ".editorconfig", _render_editorconfig()),
         ScaffoldFile(config.out_dir / "Makefile", _render_makefile()),
         ScaffoldFile(

--- a/src/repo_scaffold/generator.py
+++ b/src/repo_scaffold/generator.py
@@ -3446,6 +3446,7 @@ def build_ci_files(
         build_scaffold_files(cfg),
         target_dir,
         [
+            ".gitattributes",
             ".github/workflows/ci.yml",
             "web/.husky/pre-commit",
         ],

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -359,6 +359,7 @@ def test_build_ci_files_includes_husky_for_react(tmp_path: Path) -> None:
 
     files = build_ci_files(tmp_path, languages=("react",))
     rel_paths = {f.path.relative_to(tmp_path).as_posix() for f in files}
+    assert ".gitattributes" in rel_paths
     assert "web/.husky/pre-commit" in rel_paths
 
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -55,6 +55,7 @@ def test_generate_full_scaffold(tmp_path: Path) -> None:
         ".claude/settings.local.json",
         "LICENSE",
         ".gitignore",
+        ".gitattributes",
         ".editorconfig",
         "Makefile",
         "scripts/first_time_setup.sh",


### PR DESCRIPTION
## 🧾 Title
Include .gitattributes with LF enforcement in all scaffolded repos

## 🧠 Description
Adds a `.gitattributes` file to every repo generated by `repo-scaffold init` or `apply ci`. The file enforces LF line endings for all common text file types (`.py`, `.yml`, `.md`, `.json`, `.toml`, etc.), preventing CRLF/LF drift on Windows dev machines from causing spurious Black diffs or CI format failures.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement

## 🎯 Purpose
Repos scaffolded on Windows were susceptible to line-ending inconsistencies that caused Black to reformat files on CI even when no logic changed, failing the precommit gate. `.gitattributes` with `text=auto eol=lf` is the canonical fix.

## 🔗 Related Issues / Epics
Closes #116

## 🧪 Testing
1. Run `poetry run repo-scaffold init --name test --languages python --owner acme --out /tmp/test --yes`
2. Confirm `.gitattributes` is present in the output directory
3. `poetry run pytest tests/test_generation.py -q` passes

## 🧰 Developer Notes
- Template is rendered inline (no separate template file needed -- content is static)