### PR TITLE
docs(agents): align README, WORKFLOW, and prompt.md with AGENTS.md (#221)

### DIFF
--- a/.claude/prompt.md
+++ b/.claude/prompt.md
@@ -10,7 +10,7 @@ For each ticket:
 4. Run the full gate: `poetry run tox -e precommit`
 5. Commit with a subject + blank line + body (verbose, no one-liners)
 6. Push: `git push origin type/NNN-short-description`
-7. Open PR: `poetry run repo-scaffold pr create --repo OWNER/REPO --title "type(scope): description (#NNN)" --head type/NNN-short-description --body "..."`
+7. Open PR: `poetry run repo-scaffold pr create --repo OWNER/REPO --title "type(scope): description (#NNN)" --head type/NNN-short-description --body-file .github/pull_request_template.md`
 8. Add issue to project: `poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N`
 9. Link issue to parent epic: `poetry run repo-scaffold issue add-sub-issue --repo OWNER/REPO --parent EPIC_N --child N`
 10. Keep the PR in your active queue until it is merged -- do not consider a ticket done at push.

--- a/.claude/prompt.md
+++ b/.claude/prompt.md
@@ -5,14 +5,17 @@ You are an autonomous coding agent working on repo-scaffold tickets.
 For each ticket:
 
 1. Read the issue: `poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N`
-2. Create a worktree: `poetry run repo-scaffold workspace create --repo OWNER/REPO --branch feat/SLUG-N`
-3. Work inside `repos/{owner}/feat/SLUG-N/` -- no approval needed, use any tool
+2. Create a worktree: `poetry run repo-scaffold workspace create --repo OWNER/REPO --branch type/NNN-short-description`
+3. Work inside `repos/{owner}/{repo}/type-NNN-short-description/` -- no approval needed, use any tool
 4. Run the full gate: `poetry run tox -e precommit`
 5. Commit with a subject + blank line + body (verbose, no one-liners)
-6. Push: `git push origin feat/SLUG-N`
-7. Open PR: `poetry run repo-scaffold pr create --repo OWNER/REPO --title "..." --head feat/SLUG-N --body "..."`
+6. Push: `git push origin type/NNN-short-description`
+7. Open PR: `poetry run repo-scaffold pr create --repo OWNER/REPO --title "type(scope): description (#NNN)" --head type/NNN-short-description --body "..."`
 8. Add issue to project: `poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N`
-9. Keep the PR in your active queue until it is merged -- do not consider a ticket done at push.
+9. Link issue to parent epic: `poetry run repo-scaffold issue add-sub-issue --repo OWNER/REPO --parent EPIC_N --child N`
+10. Keep the PR in your active queue until it is merged -- do not consider a ticket done at push.
+
+See [AGENTS.md](../AGENTS.md) for branch naming, PR title format, and review SOP -- it is the canonical reference.
 
 ## PR Queue Monitoring (every session)
 
@@ -25,7 +28,7 @@ poetry run repo-scaffold pr list --repo OWNER/REPO --json
 For each open PR:
 
 1. Check review threads: `poetry run repo-scaffold pr review-threads --repo OWNER/REPO --pr-number N --json`
-2. For every unresolved thread -- fix the issue, push, reply with the commit hash and what changed, then resolve.
+2. For every unresolved thread -- complete all 4 SOP steps: fix + push, reply with hash, resolve thread, react +1. See AGENTS.md Review thread SOP.
 3. Check CI: `poetry run repo-scaffold pr checks --repo OWNER/REPO --pr-number N --json`
 4. For any failing check -- read annotations, fix, push.
 5. Check merge status: `poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N --json`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,8 +175,9 @@ The issue number at the end is required so the PR is immediately traceable to it
      --repo blairg23/repo-scaffold \
      --title "feat(scope): your change (#NNN)" \
      --head feat/NNN-short-description \
-     --body "..."
+     --body-file .github/pull_request_template.md
    ```
+   Fill in the template's sections before opening the PR -- `--body-file` preserves the required fields that `--body "..."` would drop.
 6. Add the issue to the project board (issues only -- not PRs):
    ```bash
    poetry run repo-scaffold project item-add \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,48 @@ The issue number at the end is required so the PR is immediately traceable to it
      --repo blairg23/repo-scaffold \
      --issue-number NNN
    ```
+7. Link the issue as a sub-issue of its parent epic:
+   ```bash
+   poetry run repo-scaffold issue add-sub-issue \
+     --repo blairg23/repo-scaffold \
+     --parent EPIC_NUMBER \
+     --child NNN
+   ```
+
+---
+
+## Review thread SOP
+
+For every review thread on a PR you are working on, complete ALL four steps in order:
+
+**Step 1 -- Push the fix.** Make the code change, commit, push. Note the commit hash.
+
+**Step 2 -- Reply to the thread** with the commit hash and a one-sentence explanation:
+```bash
+poetry run repo-scaffold pr comment --repo OWNER/REPO --pr-number N \
+  --body "Fixed in <hash>. <one sentence what changed>." \
+  --reply-to COMMENT_ID
+```
+
+**Step 3 -- Resolve the thread:**
+```bash
+poetry run repo-scaffold pr resolve-thread --repo OWNER/REPO --thread-id THREAD_ID
+```
+
+**Step 4 -- React +1 to the original reviewer comment:**
+```bash
+poetry run repo-scaffold pr react --repo OWNER/REPO --comment-id COMMENT_ID --reaction "+1"
+```
+
+A thread is **NOT done** until all four steps are complete. To get THREAD_ID and COMMENT_ID:
+```bash
+poetry run repo-scaffold pr review-threads --repo OWNER/REPO --pr-number N --json
+```
+
+Verify SOP compliance before declaring work done:
+```bash
+poetry run repo-scaffold pr check-sop --repo OWNER/REPO --pr-number N
+```
 
 ---
 
@@ -226,5 +268,7 @@ poetry run repo-scaffold issue label --repo OWNER/REPO --issue-number N --add ep
 poetry run repo-scaffold issue sync-hierarchy --repo OWNER/REPO --apply
 ```
 
-See [CLAUDE.md](CLAUDE.md) for the full portability and agnosticism requirements.
+This file is the canonical agent reference. All other docs (CLAUDE.md, docs/WORKFLOW.md, .claude/prompt.md) defer to it for branch naming, PR conventions, and review SOP.
+
+See [CLAUDE.md](CLAUDE.md) for portability and agnosticism requirements.
 See [examples/README.md](examples/README.md) for backlog and ticket format examples.

--- a/README.md
+++ b/README.md
@@ -520,8 +520,10 @@ poetry run repo-scaffold pr create \
   --title "type(scope): description (#NNN)" \
   --head <branch> \
   --base main \
-  --body "..."
+  --body-file .github/pull_request_template.md
 ```
+
+Fill in the template's sections (Description, Related Issues, Testing, etc.) before opening the PR -- `--body-file` preserves the required fields that `--body "..."` would otherwise drop.
 
 See [AGENTS.md](AGENTS.md) for the full branch naming convention, PR title format, and review SOP.
 

--- a/README.md
+++ b/README.md
@@ -512,17 +512,18 @@ Edit these source templates to customize generated `.github` markdown:
 
 `repo-scaffold` applies and generates `.github/pull_request_template.md`, which is used by GitHub when opening PRs.
 
-There is currently no dedicated `repo-scaffold` PR-create command. Use `gh` directly:
+Use `repo-scaffold pr create` for all PR operations -- no `gh` CLI required:
 
 ```bash
-gh pr create --base main --head <branch>
+poetry run repo-scaffold pr create \
+  --repo OWNER/REPO \
+  --title "type(scope): description (#NNN)" \
+  --head <branch> \
+  --base main \
+  --body "..."
 ```
 
-If you want to force the local template body explicitly:
-
-```bash
-gh pr create --base main --head <branch> --body-file .github/pull_request_template.md
-```
+See [AGENTS.md](AGENTS.md) for the full branch naming convention, PR title format, and review SOP.
 
 ## Generated structure (init)
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -43,12 +43,14 @@ Each ticket must include:
 - Docs impact (what to update)
 
 ## PR standards
-- Branch name: `issue-<id>-<slug>`
-- PR title: `<type>: <short summary>` (example: `feat: add job schema loader`)
-- Link the issue using `Fixes #<id>`
+
+See [AGENTS.md](../AGENTS.md) for the canonical branch naming and PR title formats. Summary:
+
+- Branch name: `type/NNN-short-description` (e.g., `feat/221-align-docs`)
+- PR title: `type(scope): description (#NNN)` (e.g., `docs(agents): align agent docs (#221)`)
 - Required: tests updated/added
 - Required: screenshots for UI changes
-- Required: `make test` passes locally (or project equivalent)
+- Required: `poetry run tox -e precommit` passes locally
 
 ## Decision locks
 If a PR changes a locked decision, it must:


### PR DESCRIPTION
## 🧾 Title
docs(agents): align README, WORKFLOW, and prompt.md with AGENTS.md

## 🧠 Description
Fixes three doc inconsistencies discovered during an agent onboarding orientation pass. Establishes AGENTS.md as the single canonical reference for branch naming, PR conventions, and review SOP -- other docs now defer to it rather than duplicating content.

## 🧩 Changes Included
- [x] Added/updated documentation

## 🎯 Purpose
Agents reading multiple docs got conflicting instructions on branch naming (three different formats across three files), an incomplete review SOP (3 steps instead of 4), and a stale README section claiming no pr create command existed. This PR makes AGENTS.md the single source of truth and updates all other docs to point to it.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #221
- Closes #221

## 🧪 Testing
1. Read AGENTS.md, README.md, docs/WORKFLOW.md, and .claude/prompt.md
2. Verify branch naming and PR title format are consistent across all files
3. Verify review SOP has all 4 steps: fix + push, reply with hash, resolve thread, react +1
4. Verify README PR Creation section references repo-scaffold pr create, not gh CLI
5. Run: poetry run tox -e precommit (passes at 73.68% coverage)

## 🧰 Developer Notes
- No code changes -- docs only
- tox -e precommit passes: format, lint, type, and coverage all green