### PR TITLE
fix(pr): include general conversation comments in pr list-comments (#224)

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -1421,7 +1421,8 @@ def build_parser() -> argparse.ArgumentParser:
     pr_reviews_cmd.add_argument("--json", action="store_true", dest="json_output")
 
     pr_list_comments_cmd = pr_sub.add_parser(
-        "list-comments", help="List all comments on a PR (inline review and general conversation)"
+        "list-comments",
+        help="List all comments on a PR (inline review and general conversation)",
     )
     pr_list_comments_cmd.add_argument("--repo", required=True)
     pr_list_comments_cmd.add_argument(

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -1421,7 +1421,7 @@ def build_parser() -> argparse.ArgumentParser:
     pr_reviews_cmd.add_argument("--json", action="store_true", dest="json_output")
 
     pr_list_comments_cmd = pr_sub.add_parser(
-        "list-comments", help="List all inline review comments on a PR"
+        "list-comments", help="List all comments on a PR (inline review and general conversation)"
     )
     pr_list_comments_cmd.add_argument("--repo", required=True)
     pr_list_comments_cmd.add_argument(
@@ -3085,7 +3085,7 @@ def main(argv: list[str] | None = None) -> int:
             cp = pr_list_comments(target_repo, ns.pr_number, token)
             if cp.returncode != 0:
                 print(
-                    cp.stderr.strip() or "Failed fetching review comments.",
+                    cp.stderr.strip() or "Failed fetching PR comments.",
                     file=sys.stderr,
                 )
                 return 1
@@ -3094,13 +3094,17 @@ def main(argv: list[str] | None = None) -> int:
                 print(_json.dumps(comments, indent=2))
             else:
                 if not comments:
-                    print("No inline review comments found.")
+                    print("No comments found.")
                 for c in comments:
                     author = c.get("user", {}).get("login", "?")
-                    path = c.get("path", "")
-                    line = c.get("line") or c.get("original_line") or "?"
                     body = (c.get("body") or "").strip()
-                    print(f"{author} on {path}:{line}")
+                    path = c.get("path", "")
+                    if path:
+                        line = c.get("line") or c.get("original_line") or "?"
+                        print(f"{author} on {path}:{line}")
+                    else:
+                        created = (c.get("created_at") or "")[:10]
+                        print(f"{author} ({created})")
                     print(f"  {body[:200]}")
             return 0
 

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1556,11 +1556,19 @@ def pr_view(repo: str, number: int, token: str) -> subprocess.CompletedProcess[s
 def pr_list_comments(
     repo: str, number: int, token: str
 ) -> subprocess.CompletedProcess[str]:
-    """Return all PR comments: inline review comments and general conversation comments."""
-    review_cp = rest_paginated(f"/repos/{repo}/pulls/{number}/comments?per_page=100", token)
+    """Return all PR comments: inline review comments and general conversation comments.
+
+    Fetches both the pull request review comments endpoint and the issue comments
+    endpoint, merges, and sorts by created_at.
+    """
+    review_cp = rest_paginated(
+        f"/repos/{repo}/pulls/{number}/comments?per_page=100", token
+    )
     if review_cp.returncode != 0:
         return review_cp
-    issue_cp = rest_paginated(f"/repos/{repo}/issues/{number}/comments?per_page=100", token)
+    issue_cp = rest_paginated(
+        f"/repos/{repo}/issues/{number}/comments?per_page=100", token
+    )
     if issue_cp.returncode != 0:
         return issue_cp
     all_comments = json.loads(review_cp.stdout) + json.loads(issue_cp.stdout)

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1556,7 +1556,16 @@ def pr_view(repo: str, number: int, token: str) -> subprocess.CompletedProcess[s
 def pr_list_comments(
     repo: str, number: int, token: str
 ) -> subprocess.CompletedProcess[str]:
-    return rest_paginated(f"/repos/{repo}/pulls/{number}/comments?per_page=100", token)
+    """Return all PR comments: inline review comments and general conversation comments."""
+    review_cp = rest_paginated(f"/repos/{repo}/pulls/{number}/comments?per_page=100", token)
+    if review_cp.returncode != 0:
+        return review_cp
+    issue_cp = rest_paginated(f"/repos/{repo}/issues/{number}/comments?per_page=100", token)
+    if issue_cp.returncode != 0:
+        return issue_cp
+    all_comments = json.loads(review_cp.stdout) + json.loads(issue_cp.stdout)
+    all_comments.sort(key=lambda c: c.get("created_at", ""))
+    return _ok(json.dumps(all_comments))
 
 
 def pr_comment(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2634,6 +2634,122 @@ def test_pr_annotations_json(tmp_path, monkeypatch, capsys) -> None:
     assert data[0]["path"] == "x.ts"
 
 
+def test_pr_list_comments_inline_review(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    comments = [
+        {
+            "id": 1,
+            "user": {"login": "alice"},
+            "body": "nit: rename this",
+            "path": "src/foo.py",
+            "line": 42,
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_list_comments",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(comments), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["pr", "list-comments", "--repo", "acme/repo", "--pr-number", "42"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "alice" in out
+    assert "src/foo.py:42" in out
+    assert "nit: rename this" in out
+
+
+def test_pr_list_comments_general_conversation(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    comments = [
+        {
+            "id": 2,
+            "user": {"login": "bob"},
+            "body": "lgtm overall",
+            "created_at": "2026-01-02T00:00:00Z",
+        }
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_list_comments",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(comments), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["pr", "list-comments", "--repo", "acme/repo", "--pr-number", "42"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "bob" in out
+    assert "2026-01-02" in out
+    assert "lgtm overall" in out
+
+
+def test_pr_list_comments_json(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    comments = [{"id": 1, "user": {"login": "alice"}, "body": "nit"}]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_list_comments",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(comments), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(
+        ["pr", "list-comments", "--repo", "acme/repo", "--pr-number", "42", "--json"]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert json.loads(out)[0]["user"]["login"] == "alice"
+
+
+def test_pr_list_comments_empty(tmp_path, monkeypatch, capsys) -> None:
+    import json
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_list_comments",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps([]), stderr=""
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["pr", "list-comments", "--repo", "acme/repo", "--pr-number", "42"])
+    assert rc == 0
+    assert "No comments found" in capsys.readouterr().out
+
+
+def test_pr_list_comments_error(tmp_path, monkeypatch, capsys) -> None:
+    import subprocess
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_scaffold.cli.pr_list_comments",
+        lambda repo, pr_number, token: subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="API error"
+        ),
+    )
+    from repo_scaffold.cli import main
+
+    rc = main(["pr", "list-comments", "--repo", "acme/repo", "--pr-number", "42"])
+    assert rc != 0
+
+
 def test_pr_rerun(tmp_path, monkeypatch, capsys) -> None:
     import json
     import subprocess

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1054,10 +1054,21 @@ def test_pr_reviews_api_error_propagates() -> None:
 
 def test_pr_list_comments_merges_both_endpoints() -> None:
     review_comments = [
-        {"id": 1, "user": {"login": "alice"}, "body": "nit", "path": "foo.py", "created_at": "2026-01-01T00:00:00Z"},
+        {
+            "id": 1,
+            "user": {"login": "alice"},
+            "body": "nit",
+            "path": "foo.py",
+            "created_at": "2026-01-01T00:00:00Z",
+        },
     ]
     issue_comments = [
-        {"id": 2, "user": {"login": "bob"}, "body": "lgtm", "created_at": "2026-01-02T00:00:00Z"},
+        {
+            "id": 2,
+            "user": {"login": "bob"},
+            "body": "lgtm",
+            "created_at": "2026-01-02T00:00:00Z",
+        },
     ]
     with patch(
         "urllib.request.urlopen",
@@ -1076,10 +1087,21 @@ def test_pr_list_comments_merges_both_endpoints() -> None:
 
 def test_pr_list_comments_sorted_by_created_at() -> None:
     review_comments = [
-        {"id": 1, "user": {"login": "alice"}, "body": "later", "path": "foo.py", "created_at": "2026-01-03T00:00:00Z"},
+        {
+            "id": 1,
+            "user": {"login": "alice"},
+            "body": "later",
+            "path": "foo.py",
+            "created_at": "2026-01-03T00:00:00Z",
+        },
     ]
     issue_comments = [
-        {"id": 2, "user": {"login": "bob"}, "body": "earlier", "created_at": "2026-01-01T00:00:00Z"},
+        {
+            "id": 2,
+            "user": {"login": "bob"},
+            "body": "earlier",
+            "created_at": "2026-01-01T00:00:00Z",
+        },
     ]
     with patch(
         "urllib.request.urlopen",

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1048,6 +1048,73 @@ def test_pr_reviews_api_error_propagates() -> None:
 
 
 # ---------------------------------------------------------------------------
+# pr_list_comments -- merges inline review comments and general conversation comments
+# ---------------------------------------------------------------------------
+
+
+def test_pr_list_comments_merges_both_endpoints() -> None:
+    review_comments = [
+        {"id": 1, "user": {"login": "alice"}, "body": "nit", "path": "foo.py", "created_at": "2026-01-01T00:00:00Z"},
+    ]
+    issue_comments = [
+        {"id": 2, "user": {"login": "bob"}, "body": "lgtm", "created_at": "2026-01-02T00:00:00Z"},
+    ]
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            _mock_resp(200, json.dumps(review_comments)),
+            _mock_resp(200, json.dumps(issue_comments)),
+        ],
+    ):
+        cp = github_api.pr_list_comments("acme/repo", 42, "tok")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert len(result) == 2
+    logins = {c["user"]["login"] for c in result}
+    assert logins == {"alice", "bob"}
+
+
+def test_pr_list_comments_sorted_by_created_at() -> None:
+    review_comments = [
+        {"id": 1, "user": {"login": "alice"}, "body": "later", "path": "foo.py", "created_at": "2026-01-03T00:00:00Z"},
+    ]
+    issue_comments = [
+        {"id": 2, "user": {"login": "bob"}, "body": "earlier", "created_at": "2026-01-01T00:00:00Z"},
+    ]
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            _mock_resp(200, json.dumps(review_comments)),
+            _mock_resp(200, json.dumps(issue_comments)),
+        ],
+    ):
+        cp = github_api.pr_list_comments("acme/repo", 42, "tok")
+    assert cp.returncode == 0
+    result = json.loads(cp.stdout)
+    assert result[0]["user"]["login"] == "bob"
+    assert result[1]["user"]["login"] == "alice"
+
+
+def test_pr_list_comments_review_endpoint_error_propagates() -> None:
+    with patch("urllib.request.urlopen", side_effect=_http_error(404, "Not Found")):
+        cp = github_api.pr_list_comments("acme/repo", 42, "tok")
+    assert cp.returncode != 0
+
+
+def test_pr_list_comments_issue_endpoint_error_propagates() -> None:
+    review_comments: list[dict[str, object]] = []
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            _mock_resp(200, json.dumps(review_comments)),
+            _http_error(403, "Forbidden"),
+        ],
+    ):
+        cp = github_api.pr_list_comments("acme/repo", 42, "tok")
+    assert cp.returncode != 0
+
+
+# ---------------------------------------------------------------------------
 # issue_label -- auto-remove needs-triage when epic:slug is added
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 🧾 Title
Include general conversation comments in pr list-comments

## 🧠 Description
This pull request fixes pr list-comments to return all PR comments, not just inline review comments.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [x] Improved error handling or logging

## 🎯 Purpose
pr list-comments only queried /pulls/{number}/comments (inline review comments), silently dropping general PR conversation comments stored at /issues/{number}/comments. This meant agents and users couldn't see comments left in the PR conversation tab -- discovered when cmFrameShift left a comment on ThePRIMEForge/muster-deck#190 and pr list-comments --json returned [].

## 🔗 Related Issues / Epics
- **Epic:** #48
- **Issue:** #224
- Closes #224

## 🧪 Testing
1. Run: poetry run repo-scaffold pr list-comments --repo ThePRIMEForge/muster-deck --pr-number 190
2. Verify cmFrameShift's general comment appears in the output
3. Run with --json and confirm both inline review comments and general comments are present
4. poetry run pytest tests/test_github_api.py -q -- four new tests cover merge, sort, and per-endpoint error propagation

## 🧰 Developer Notes
- github_api.py: pr_list_comments now fetches both /pulls/{number}/comments and /issues/{number}/comments, merges and sorts by created_at
- cli.py: display branch checks for path field presence to distinguish inline vs general comments
- Help text and error messages updated to reflect broader scope