### PR TITLE
feat(rules): add dependabot version updates to check/sync rules baseline (#223)

### DIFF
--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -1437,7 +1437,7 @@ def _check_settings(
 
     # Dependabot malware alerts have no separate REST endpoint -- they are bundled
     # with Dependabot alerts (checked above via /vulnerability-alerts).
-    enabled, detail = _optional_endpoint_feature_enabled(
+    enabled, _ = _optional_endpoint_feature_enabled(
         repo_dir=repo_dir,
         env=env,
         endpoint=f"/repos/{repo}/contents/{_DEPENDABOT_YML_PATH}",

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -513,7 +513,9 @@ def _ensure_dependabot_version_updates(
     if create_cp.returncode == 0:
         out(f"Created {_DEPENDABOT_YML_PATH}.")
         return
-    feature_err = create_cp.stderr.strip() or create_cp.stdout.strip() or "unknown error"
+    feature_err = (
+        create_cp.stderr.strip() or create_cp.stdout.strip() or "unknown error"
+    )
     warn(f"Warning: could not create {_DEPENDABOT_YML_PATH}: {feature_err}")
 
 

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -1201,6 +1201,7 @@ def _apply_settings(
     out(f"{'[dry-run] ' if dry_run else ''}apply repository settings: {repo}")
     if dry_run:
         out("[dry-run] sync repository merge settings")
+        out(f"[dry-run] create {_DEPENDABOT_YML_PATH} if not present")
         out(
             "[dry-run] sync managed default-branch ruleset "
             "(pull request required, 0 approvals, squash-only, no force-push, no delete, "
@@ -1211,7 +1212,6 @@ def _apply_settings(
         out("[dry-run] enable secret scanning push protection")
         for feature_name, _ in _BEST_EFFORT_SECURITY_FEATURES:
             out(f"[dry-run] enable {feature_name.lower()}")
-        out(f"[dry-run] create {_DEPENDABOT_YML_PATH} if not present")
         out("[dry-run] enable code scanning default setup")
         out("[dry-run] enable private vulnerability reporting when supported")
         return
@@ -1232,6 +1232,15 @@ def _apply_settings(
             patch_cp.stderr.strip() or "Failed applying repository merge settings."
         )
     out("Applied repository merge settings.")
+
+    _ensure_dependabot_version_updates(
+        repo_dir=repo_dir,
+        env=env,
+        repo=repo,
+        languages=languages,
+        out=out,
+        warn=warn,
+    )
 
     _sync_default_branch_ruleset(
         repo_dir=repo_dir, env=env, repo=repo, out=out, warn=warn, languages=languages
@@ -1274,15 +1283,6 @@ def _apply_settings(
             out=out,
             warn=warn,
         )
-
-    _ensure_dependabot_version_updates(
-        repo_dir=repo_dir,
-        env=env,
-        repo=repo,
-        languages=languages,
-        out=out,
-        warn=warn,
-    )
 
     _enable_code_scanning_default_setup(
         repo_dir=repo_dir,

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -50,6 +50,15 @@ _BEST_EFFORT_SECURITY_FEATURES: tuple[tuple[str, str], ...] = (
     ("Dependabot security updates", "/repos/{repo}/automated-security-fixes"),
 )
 
+_DEPENDABOT_YML_PATH = ".github/dependabot.yml"
+
+_LANG_ECOSYSTEM_MAP: dict[str, str] = {
+    "python": "pip",
+    "go": "gomod",
+    "gin": "gomod",
+    "react": "npm",
+}
+
 
 def _is_managed_ruleset_name(name: object) -> bool:
     return isinstance(name, str) and (
@@ -450,6 +459,62 @@ def _sync_default_branch_ruleset(
         if cp2.returncode != 0:
             raise RuntimeError(cp2.stderr.strip() or "Failed creating managed ruleset.")
     out(f"Created ruleset '{_SETTINGS_RULESET_NAME}'.")
+
+
+def _minimal_dependabot_yml(languages: list[str] | None) -> str:
+    ecosystems: dict[str, str] = {"github-actions": "/"}
+    for lang in languages or []:
+        eco = _LANG_ECOSYSTEM_MAP.get(lang)
+        if eco and eco not in ecosystems:
+            ecosystems[eco] = "/"
+    entries = []
+    for eco, directory in ecosystems.items():
+        entries += [
+            f'  - package-ecosystem: "{eco}"',
+            f'    directory: "{directory}"',
+            "    schedule:",
+            '      interval: "weekly"',
+        ]
+    return "version: 2\nupdates:\n" + "\n".join(entries) + "\n"
+
+
+def _ensure_dependabot_version_updates(
+    *,
+    repo_dir: Path,
+    env: dict[str, str],
+    repo: str,
+    languages: list[str] | None,
+    out: Callable[[str], None],
+    warn: Callable[[str], None],
+) -> None:
+    check_cp = _api(
+        repo_dir=repo_dir,
+        env=env,
+        method="GET",
+        endpoint=f"/repos/{repo}/contents/{_DEPENDABOT_YML_PATH}",
+    )
+    if check_cp.returncode == 0:
+        out("Dependabot version updates already configured.")
+        return
+    content = _minimal_dependabot_yml(languages)
+    encoded = base64.b64encode(content.encode()).decode()
+    create_cp = _api(
+        repo_dir=repo_dir,
+        env=env,
+        method="PUT",
+        endpoint=f"/repos/{repo}/contents/{_DEPENDABOT_YML_PATH}",
+        stdin_text=json.dumps(
+            {
+                "message": "chore: add dependabot version updates config",
+                "content": encoded,
+            }
+        ),
+    )
+    if create_cp.returncode == 0:
+        out(f"Created {_DEPENDABOT_YML_PATH}.")
+        return
+    feature_err = create_cp.stderr.strip() or create_cp.stdout.strip() or "unknown error"
+    warn(f"Warning: could not create {_DEPENDABOT_YML_PATH}: {feature_err}")
 
 
 def _enable_security_and_analysis_feature(
@@ -1144,6 +1209,7 @@ def _apply_settings(
         out("[dry-run] enable secret scanning push protection")
         for feature_name, _ in _BEST_EFFORT_SECURITY_FEATURES:
             out(f"[dry-run] enable {feature_name.lower()}")
+        out(f"[dry-run] create {_DEPENDABOT_YML_PATH} if not present")
         out("[dry-run] enable code scanning default setup")
         out("[dry-run] enable private vulnerability reporting when supported")
         return
@@ -1206,6 +1272,15 @@ def _apply_settings(
             out=out,
             warn=warn,
         )
+
+    _ensure_dependabot_version_updates(
+        repo_dir=repo_dir,
+        env=env,
+        repo=repo,
+        languages=languages,
+        out=out,
+        warn=warn,
+    )
 
     _enable_code_scanning_default_setup(
         repo_dir=repo_dir,
@@ -1357,6 +1432,22 @@ def _check_settings(
     else:
         skipped += 1
         out("SKIP  private vulnerability reporting (repo is not public)")
+
+    # Dependabot malware alerts have no separate REST endpoint -- they are bundled
+    # with Dependabot alerts (checked above via /vulnerability-alerts).
+    enabled, detail = _optional_endpoint_feature_enabled(
+        repo_dir=repo_dir,
+        env=env,
+        endpoint=f"/repos/{repo}/contents/{_DEPENDABOT_YML_PATH}",
+    )
+    if enabled:
+        passed += 1
+        out("PASS  dependabot version updates")
+    else:
+        failed += 1
+        drift = f"dependabot version updates: {_DEPENDABOT_YML_PATH} not configured"
+        drifts.append(drift)
+        out(f"DRIFT dependabot version updates: {_DEPENDABOT_YML_PATH} not configured")
 
     return SettingsCheckSummary(
         repo=repo,

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -1306,9 +1306,7 @@ def test_apply_settings_dry_run_previews_ruleset_and_security_defaults() -> None
     assert "0 approvals" in "\n".join(lines)
     assert "[dry-run] enable secret scanning" in lines
     assert "[dry-run] enable secret scanning push protection" in lines
-    assert (
-        f"[dry-run] create {create_ops._DEPENDABOT_YML_PATH} if not present" in lines
-    )
+    assert f"[dry-run] create {create_ops._DEPENDABOT_YML_PATH} if not present" in lines
 
 
 def test_apply_settings_uses_ruleset_and_public_security_defaults(

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -2037,9 +2037,16 @@ def test_ensure_dependabot_version_updates_skips_when_present(
     out_lines: list[str] = []
     api_calls: list[str] = []
 
-    def _fake_api(*, method: str, endpoint: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    def _fake_api(
+        *,
+        method: str,
+        endpoint: str,
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
         api_calls.append(f"{method} {endpoint}")
-        return subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="{}", stderr=""
+        )
 
     monkeypatch.setattr(create_ops, "_api", _fake_api)
     create_ops._ensure_dependabot_version_updates(
@@ -2062,11 +2069,20 @@ def test_ensure_dependabot_version_updates_creates_when_missing(
     out_lines: list[str] = []
     call_count = {"n": 0}
 
-    def _fake_api(*, method: str, endpoint: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    def _fake_api(
+        *,
+        method: str,
+        endpoint: str,
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
         call_count["n"] += 1
         if method == "GET":
-            return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="HTTP 404")
-        return subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="HTTP 404"
+            )
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="{}", stderr=""
+        )
 
     monkeypatch.setattr(create_ops, "_api", _fake_api)
     create_ops._ensure_dependabot_version_updates(

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -1306,6 +1306,9 @@ def test_apply_settings_dry_run_previews_ruleset_and_security_defaults() -> None
     assert "0 approvals" in "\n".join(lines)
     assert "[dry-run] enable secret scanning" in lines
     assert "[dry-run] enable secret scanning push protection" in lines
+    assert (
+        f"[dry-run] create {create_ops._DEPENDABOT_YML_PATH} if not present" in lines
+    )
 
 
 def test_apply_settings_uses_ruleset_and_public_security_defaults(
@@ -1371,6 +1374,11 @@ def test_apply_settings_uses_ruleset_and_public_security_defaults(
     monkeypatch.setattr(
         create_ops,
         "_enable_code_scanning_default_setup",
+        lambda **_: None,
+    )
+    monkeypatch.setattr(
+        create_ops,
+        "_ensure_dependabot_version_updates",
         lambda **_: None,
     )
 

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -1444,12 +1444,13 @@ def test_check_settings_reports_clean_public_repo(
     )
 
     assert summary.repo == "acme/repo"
-    assert summary.passed == 8
+    assert summary.passed == 9
     assert summary.failed == 0
     assert summary.skipped == 0
     assert summary.drifts == ()
     assert "check repository settings: acme/repo" in lines
     assert "PASS  managed default-branch ruleset" in lines
+    assert "PASS  dependabot version updates" in lines
 
 
 def test_check_settings_fetches_ruleset_details_and_accepts_expanded_default_branch(
@@ -1501,8 +1502,9 @@ def test_check_settings_fetches_ruleset_details_and_accepts_expanded_default_bra
     )
 
     assert summary.failed == 0
-    assert summary.passed == 8
+    assert summary.passed == 9
     assert "PASS  managed default-branch ruleset" in lines
+    assert "PASS  dependabot version updates" in lines
 
 
 def test_check_settings_reports_drift_and_skips_private_repo_only_feature(
@@ -1544,7 +1546,7 @@ def test_check_settings_reports_drift_and_skips_private_repo_only_feature(
         out=lines.append,
     )
 
-    assert summary.failed == 7
+    assert summary.failed == 8
     assert summary.passed == 0
     assert summary.skipped == 1
     assert any("merge settings" in drift for drift in summary.drifts)
@@ -2009,3 +2011,72 @@ def test_create_repository_rejects_invalid_visibility(
             out=lambda _line: None,
             err=lambda _line: None,
         )
+
+
+def test_minimal_dependabot_yml_always_includes_github_actions() -> None:
+    yml = create_ops._minimal_dependabot_yml(None)
+    assert "version: 2" in yml
+    assert 'package-ecosystem: "github-actions"' in yml
+
+
+def test_minimal_dependabot_yml_adds_language_ecosystems() -> None:
+    yml = create_ops._minimal_dependabot_yml(["python", "react"])
+    assert 'package-ecosystem: "pip"' in yml
+    assert 'package-ecosystem: "npm"' in yml
+    assert 'package-ecosystem: "github-actions"' in yml
+
+
+def test_minimal_dependabot_yml_deduplicates_go_gin() -> None:
+    yml = create_ops._minimal_dependabot_yml(["go", "gin"])
+    assert yml.count('package-ecosystem: "gomod"') == 1
+
+
+def test_ensure_dependabot_version_updates_skips_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out_lines: list[str] = []
+    api_calls: list[str] = []
+
+    def _fake_api(*, method: str, endpoint: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        api_calls.append(f"{method} {endpoint}")
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(create_ops, "_api", _fake_api)
+    create_ops._ensure_dependabot_version_updates(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        languages=["python"],
+        out=out_lines.append,
+        warn=lambda _: None,
+    )
+
+    assert any("GET" in c for c in api_calls)
+    assert len([c for c in api_calls if "PUT" in c]) == 0
+    assert any("already configured" in line for line in out_lines)
+
+
+def test_ensure_dependabot_version_updates_creates_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out_lines: list[str] = []
+    call_count = {"n": 0}
+
+    def _fake_api(*, method: str, endpoint: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        call_count["n"] += 1
+        if method == "GET":
+            return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="HTTP 404")
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(create_ops, "_api", _fake_api)
+    create_ops._ensure_dependabot_version_updates(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        languages=["python"],
+        out=out_lines.append,
+        warn=lambda _: None,
+    )
+
+    assert call_count["n"] == 2
+    assert any("Created" in line for line in out_lines)


### PR DESCRIPTION
## 🧾 Title
feat(rules): add dependabot version updates to check/sync rules baseline (#223)

## 🧠 Description
Adds PASS/DRIFT check and auto-apply for Dependabot version updates to `check rules` and `sync rules`.

The check uses the GitHub contents API (`GET /repos/{repo}/contents/.github/dependabot.yml`) -- 200 means configured, 404 means not. The apply path creates a minimal `dependabot.yml` seeded from the repo's language list when the file is absent.

Dependabot malware alerts have no separate REST endpoint -- they are bundled with Dependabot alerts (already checked via `/vulnerability-alerts`). A comment in `_check_settings` documents this finding.

## 🧩 Changes Included
- [x] New helpers: `_minimal_dependabot_yml`, `_ensure_dependabot_version_updates`
- [x] New constants: `_DEPENDABOT_YML_PATH`, `_LANG_ECOSYSTEM_MAP`
- [x] `_check_settings`: adds PASS/DRIFT for dependabot version updates
- [x] `_apply_settings`: calls `_ensure_dependabot_version_updates` after the best-effort security features loop
- [x] Dry-run output updated
- [x] Tests: passed counts 8- (public repos), failed count 7- (all-drift private repos); 4 new unit tests

## 🎯 Purpose
`check rules` on downstream repos was missing coverage for whether Dependabot version updates were configured at all. This closes the gap.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #223
- Closes #223

## 🧪 Testing
1. Run `check rules --repo OWNER/REPO` on a repo without `dependabot.yml` -- verify DRIFT appears
2. Run `sync rules --repo OWNER/REPO --yes` -- verify `.github/dependabot.yml` is created
3. Run `check rules` again -- verify PASS

## 🧰 Developer Notes
- Malware alerts REST endpoint does not exist separately; bundled with vulnerability alerts (documented in code comment)
- `_minimal_dependabot_yml` always includes `github-actions`; adds `pip`/`gomod`/`npm` based on language list