### PR TITLE
docs(agents): document all three PR feedback endpoints in SOP (#227)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,27 @@ The issue number at the end is required so the PR is immediately traceable to it
 
 ---
 
+## Reading all PR feedback
+
+GitHub stores PR feedback across three separate endpoints. Always check all three before
+concluding there is no feedback -- each covers a different type:
+
+```bash
+# 1. Inline review threads (line-level comments, may be unresolved)
+poetry run repo-scaffold pr review-threads --repo OWNER/REPO --pr-number N --json
+
+# 2. General conversation comments (posted in the PR timeline)
+poetry run repo-scaffold pr list-comments --repo OWNER/REPO --pr-number N --json
+
+# 3. Submitted PR reviews (approve / request-changes / comment with a body)
+poetry run repo-scaffold pr reviews --repo OWNER/REPO --pr-number N --json
+```
+
+`pr check-sop` only covers inline review threads (endpoint 1). Endpoints 2 and 3 must
+be checked manually.
+
+---
+
 ## Review thread SOP
 
 For every review thread on a PR you are working on, complete ALL four steps in order:


### PR DESCRIPTION
## 🧾 Title
Document all three PR feedback endpoints in AGENTS.md SOP

## 🧠 Description
This pull request adds a "Reading all PR feedback" section to AGENTS.md above the review thread SOP.

## 🧩 Changes Included
- [x] Added/updated documentation

## 🎯 Purpose
GitHub stores PR feedback across three endpoints (pr review-threads, pr list-comments, pr reviews). Agents were only checking the first two before concluding a PR had no feedback. This caused cmFrameShift's review submission on ThePRIMEForge/muster-deck#190 to be missed entirely, delaying the fix by a full session.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #227
- Closes #227

## 🧪 Testing
1. Read AGENTS.md and confirm the "Reading all PR feedback" section appears above "Review thread SOP"
2. Confirm all three commands are listed with example syntax
3. Confirm the note that pr check-sop only covers endpoint 1 is present

## 🧰 Developer Notes
- Docs-only change, no code touched