### PR TITLE
feat(repo): add Device Flow auth and repo discover command (#173)

### DIFF
--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -75,6 +75,7 @@ from .generator import (
 )
 from .overwrite_policy import ApplySummary, OverwritePolicy, apply_files
 from .project_config import resolve_languages
+from .discover_ops import discover_repos, prompt_for_token, upsert_env_var
 from .registry_ops import (
     RegistryEntry,
     forget_repo,
@@ -744,6 +745,24 @@ def build_parser() -> argparse.ArgumentParser:
     )
     repo_forget_cmd.add_argument(
         "--repo", required=True, help="GitHub repo (owner/repo)"
+    )
+    repo_discover_cmd = repo_sub.add_parser(
+        "discover",
+        help="Discover GitHub repos visible to your token and optionally register them",
+    )
+    repo_discover_cmd.add_argument(
+        "--org",
+        help="Scope discovery to a specific GitHub org/user (default: authenticated user)",
+    )
+    repo_discover_cmd.add_argument(
+        "--register",
+        action="store_true",
+        help="Bulk-register all discovered repos into the local registry",
+    )
+    repo_discover_cmd.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation before registering",
     )
 
     sync_cmd = subparsers.add_parser(
@@ -2144,6 +2163,45 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Error: repo not registered: {ns.repo}", file=sys.stderr)
             return 2
         print(f"Removed {ns.repo} from the registry.")
+        return 0
+
+    if ns.mode == "repo" and ns.repo_command == "discover":
+        token = token_from_repo(Path.cwd())
+        if not token:
+            client_id = os.environ.get("GITHUB_CLIENT_ID")
+            try:
+                token = prompt_for_token(client_id)
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+                return 2
+            upsert_env_var("GH_TOKEN", token, Path.cwd() / ".env")
+            print("Token saved to .env")
+        try:
+            all_repos = discover_repos(token, org=getattr(ns, "org", None))
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        registered = set(load_registry().keys())
+        new_repos = [r for r in all_repos if r not in registered]
+        if not new_repos:
+            print("No new repos found (all visible repos are already registered).")
+            return 0
+        print(f"Found {len(new_repos)} repo(s) not yet registered:")
+        for r in new_repos:
+            print(f"  {r}")
+        if not ns.register:
+            print("\nRun with --register to add them to the local registry.")
+            return 0
+        if not ns.yes:
+            answer = input(
+                f"Register all {len(new_repos)} repos? [y/N] "
+            ).strip().lower()
+            if answer != "y":
+                print("Aborted.")
+                return 0
+        for r in new_repos:
+            register_repo(r, "")
+            print(f"Registered {r}")
         return 0
 
     if ns.mode == "sync" and ns.sync_command == "rules":

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -80,7 +80,9 @@ from .registry_ops import (
     RegistryEntry,
     forget_repo,
     list_registry,
+    load_registry,
     register_repo,
+    save_registry,
 )
 from .project_ops import (
     ProjectItemsSummary,
@@ -2193,14 +2195,17 @@ def main(argv: list[str] | None = None) -> int:
             print("\nRun with --register to add them to the local registry.")
             return 0
         if not ns.yes:
-            answer = input(
-                f"Register all {len(new_repos)} repos? [y/N] "
-            ).strip().lower()
+            answer = (
+                input(f"Register all {len(new_repos)} repos? [y/N] ").strip().lower()
+            )
             if answer != "y":
                 print("Aborted.")
                 return 0
+        reg = load_registry()
         for r in new_repos:
-            register_repo(r, "")
+            reg[r] = RegistryEntry(repo=r, local_path="", notes="discovered")
+        save_registry(reg)
+        for r in new_repos:
             print(f"Registered {r}")
         return 0
 

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -75,7 +75,12 @@ from .generator import (
 )
 from .overwrite_policy import ApplySummary, OverwritePolicy, apply_files
 from .project_config import resolve_languages
-from .discover_ops import discover_repos, prompt_for_token, upsert_env_var
+from .discover_ops import (
+    discover_repos,
+    parse_repo_selection,
+    prompt_for_token,
+    upsert_env_var,
+)
 from .registry_ops import (
     RegistryEntry,
     forget_repo,
@@ -2189,23 +2194,28 @@ def main(argv: list[str] | None = None) -> int:
             print("No new repos found (all visible repos are already registered).")
             return 0
         print(f"Found {len(new_repos)} repo(s) not yet registered:")
-        for r in new_repos:
-            print(f"  {r}")
+        for i, r in enumerate(new_repos, 1):
+            print(f"  [{i:>3}] {r}")
         if not ns.register:
-            print("\nRun with --register to add them to the local registry.")
+            print("\nRun with --register to choose which to add to the local registry.")
             return 0
-        if not ns.yes:
-            answer = (
-                input(f"Register all {len(new_repos)} repos? [y/N] ").strip().lower()
-            )
-            if answer != "y":
-                print("Aborted.")
+        if ns.yes:
+            selected = list(new_repos)
+        else:
+            print()
+            answer = input(
+                'Enter numbers to register (e.g. 1,3,5-8), "all", or press Enter to skip: '
+            ).strip()
+            indices = parse_repo_selection(answer, len(new_repos))
+            if not indices:
+                print("Nothing registered.")
                 return 0
+            selected = [new_repos[i] for i in indices]
         reg = load_registry()
-        for r in new_repos:
+        for r in selected:
             reg[r] = RegistryEntry(repo=r, local_path="", notes="discovered")
         save_registry(reg)
-        for r in new_repos:
+        for r in selected:
             print(f"Registered {r}")
         return 0
 

--- a/src/repo_scaffold/discover_ops.py
+++ b/src/repo_scaffold/discover_ops.py
@@ -141,3 +141,35 @@ def discover_repos(token: str, org: str | None = None) -> list[str]:
         )
     items = _get_paginated(token, url)
     return sorted(str(item["full_name"]) for item in items if item.get("full_name"))
+
+
+def parse_repo_selection(answer: str, total: int) -> list[int]:
+    """Parse a selection string into 0-based indices.
+
+    Accepts: "all", "", "none", "1,3", "1-3", "1,3-5,7".
+    Input numbers are 1-based; returned indices are 0-based.
+    Out-of-range numbers are silently ignored.
+    """
+    answer = answer.strip().lower()
+    if not answer or answer == "none":
+        return []
+    if answer == "all":
+        return list(range(total))
+    indices: set[int] = set()
+    for part in answer.split(","):
+        part = part.strip()
+        if "-" in part:
+            lo_str, _, hi_str = part.partition("-")
+            try:
+                lo, hi = int(lo_str), int(hi_str)
+                indices.update(i - 1 for i in range(lo, hi + 1) if 1 <= i <= total)
+            except ValueError:
+                pass
+        else:
+            try:
+                n = int(part)
+                if 1 <= n <= total:
+                    indices.add(n - 1)
+            except ValueError:
+                pass
+    return sorted(indices)

--- a/src/repo_scaffold/discover_ops.py
+++ b/src/repo_scaffold/discover_ops.py
@@ -1,0 +1,142 @@
+"""GitHub repo discovery, Device Flow auth, and .env token management."""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+_GITHUB_API = "https://api.github.com"
+_DEVICE_AUTH_URL = "https://github.com/login/device/code"
+_DEVICE_TOKEN_URL = "https://github.com/login/oauth/access_token"
+_DEVICE_SCOPE = "repo"
+_DEVICE_TIMEOUT = 300  # 5 minutes
+
+
+def _post_form(url: str, data: dict[str, str]) -> dict[str, object]:
+    body = urllib.parse.urlencode(data).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return dict(json.loads(resp.read().decode()))
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode() if exc.fp else ""
+        raise RuntimeError(raw or str(exc)) from exc
+
+
+def _parse_next(link: str) -> str:
+    for part in link.split(","):
+        part = part.strip()
+        if 'rel="next"' in part:
+            return part.split(";")[0].strip().strip("<>")
+    return ""
+
+
+def _get_paginated(token: str, url: str) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    while url:
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                results.extend(json.loads(resp.read().decode()))
+                url = _parse_next(resp.headers.get("Link", ""))
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode() if exc.fp else ""
+            raise RuntimeError(raw or str(exc)) from exc
+    return results
+
+
+def device_flow_auth(client_id: str) -> str:
+    """Run GitHub Device Flow and return the access token."""
+    resp = _post_form(
+        _DEVICE_AUTH_URL, {"client_id": client_id, "scope": _DEVICE_SCOPE}
+    )
+    device_code = str(resp["device_code"])
+    user_code = str(resp["user_code"])
+    verification_uri = str(resp.get("verification_uri", "https://github.com/login/device"))
+    interval = int(resp.get("interval", 5))
+
+    print(f"\nOpen: {verification_uri}")
+    print(f"Enter code: {user_code}\n")
+    print("Waiting for authorization...", flush=True)
+
+    deadline = time.monotonic() + _DEVICE_TIMEOUT
+    while time.monotonic() < deadline:
+        time.sleep(interval)
+        token_resp = _post_form(
+            _DEVICE_TOKEN_URL,
+            {
+                "client_id": client_id,
+                "device_code": device_code,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            },
+        )
+        if "access_token" in token_resp:
+            return str(token_resp["access_token"])
+        error = str(token_resp.get("error", ""))
+        if error == "authorization_pending":
+            continue
+        if error == "slow_down":
+            interval += 5
+            continue
+        desc = str(token_resp.get("error_description", ""))
+        raise RuntimeError(f"Device Flow failed: {error} -- {desc}")
+
+    raise RuntimeError("Device Flow timed out. Run repo discover again to retry.")
+
+
+def prompt_for_token(client_id: str | None) -> str:
+    """Prompt interactively for a GitHub token; use Device Flow if client_id is available."""
+    print("No GitHub token found.")
+    if client_id:
+        choice = input(
+            "Paste a GitHub token, or press Enter to authenticate via browser: "
+        ).strip()
+        if choice:
+            return choice
+        return device_flow_auth(client_id)
+    token = input(
+        "Paste your GitHub token"
+        " (set GITHUB_CLIENT_ID in .env to enable browser-based auth): "
+    ).strip()
+    if not token:
+        raise RuntimeError(
+            "No token provided. Set GH_TOKEN in .env and retry."
+        )
+    return token
+
+
+def upsert_env_var(key: str, value: str, path: Path) -> None:
+    """Write or update KEY=value in the .env file at *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+    prefix = f"{key}="
+    updated = [line for line in existing if not line.startswith(prefix)]
+    updated.append(f"{key}={value}")
+    path.write_text("\n".join(updated) + "\n", encoding="utf-8")
+
+
+def discover_repos(token: str, org: str | None = None) -> list[str]:
+    """Return sorted list of 'owner/repo' strings visible to *token*."""
+    if org:
+        url = f"{_GITHUB_API}/orgs/{org}/repos?per_page=100&type=all&sort=full_name"
+    else:
+        url = (
+            f"{_GITHUB_API}/user/repos"
+            "?per_page=100&affiliation=owner,collaborator,organization_member&sort=full_name"
+        )
+    items = _get_paginated(token, url)
+    return sorted(str(item["full_name"]) for item in items if item.get("full_name"))

--- a/src/repo_scaffold/discover_ops.py
+++ b/src/repo_scaffold/discover_ops.py
@@ -66,8 +66,11 @@ def device_flow_auth(client_id: str) -> str:
     )
     device_code = str(resp["device_code"])
     user_code = str(resp["user_code"])
-    verification_uri = str(resp.get("verification_uri", "https://github.com/login/device"))
-    interval = int(resp.get("interval", 5))
+    verification_uri = str(
+        resp.get("verification_uri", "https://github.com/login/device")
+    )
+    _raw_interval = resp.get("interval", 5)
+    interval = int(_raw_interval) if isinstance(_raw_interval, int) else 5
 
     print(f"\nOpen: {verification_uri}")
     print(f"Enter code: {user_code}\n")
@@ -113,9 +116,7 @@ def prompt_for_token(client_id: str | None) -> str:
         " (set GITHUB_CLIENT_ID in .env to enable browser-based auth): "
     ).strip()
     if not token:
-        raise RuntimeError(
-            "No token provided. Set GH_TOKEN in .env and retry."
-        )
+        raise RuntimeError("No token provided. Set GH_TOKEN in .env and retry.")
     return token
 
 

--- a/tests/test_discover_ops.py
+++ b/tests/test_discover_ops.py
@@ -25,13 +25,17 @@ class TestDeviceFlowAuth:
                 {"access_token": "gho_real"},
             ]
         )
-        monkeypatch.setattr(discover_ops, "_post_form", lambda url, data: next(responses))
+        monkeypatch.setattr(
+            discover_ops, "_post_form", lambda url, data: next(responses)
+        )
         monkeypatch.setattr(time, "sleep", lambda _: None)
         monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
 
         assert discover_ops.device_flow_auth("client_id") == "gho_real"
 
-    def test_slow_down_increases_interval(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_slow_down_increases_interval(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         intervals: list[float] = []
         responses = iter(
             [
@@ -46,7 +50,9 @@ class TestDeviceFlowAuth:
                 {"access_token": "tok"},
             ]
         )
-        monkeypatch.setattr(discover_ops, "_post_form", lambda url, data: next(responses))
+        monkeypatch.setattr(
+            discover_ops, "_post_form", lambda url, data: next(responses)
+        )
         monkeypatch.setattr(time, "sleep", intervals.append)
         monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
 
@@ -66,7 +72,9 @@ class TestDeviceFlowAuth:
                 {"error": "access_denied", "error_description": "User denied"},
             ]
         )
-        monkeypatch.setattr(discover_ops, "_post_form", lambda url, data: next(responses))
+        monkeypatch.setattr(
+            discover_ops, "_post_form", lambda url, data: next(responses)
+        )
         monkeypatch.setattr(time, "sleep", lambda _: None)
         monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
 
@@ -135,7 +143,9 @@ class TestDiscoverRepos:
         monkeypatch.setattr(discover_ops, "_get_paginated", lambda token, url: repos)
         assert discover_ops.discover_repos("tok") == ["acme/alpha", "acme/beta"]
 
-    def test_uses_user_repos_url_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_uses_user_repos_url_by_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         captured: list[str] = []
         monkeypatch.setattr(
             discover_ops,
@@ -155,7 +165,9 @@ class TestDiscoverRepos:
         discover_ops.discover_repos("tok", org="acme")
         assert "/orgs/acme/repos" in captured[0]
 
-    def test_filters_items_without_full_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_filters_items_without_full_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         repos = [{"full_name": "ok/repo"}, {"id": 99}, {"full_name": ""}]
         monkeypatch.setattr(discover_ops, "_get_paginated", lambda token, url: repos)
         assert discover_ops.discover_repos("tok") == ["ok/repo"]
@@ -164,7 +176,9 @@ class TestDiscoverRepos:
 class TestParseNext:
     def test_extracts_next_url(self) -> None:
         link = '<https://api.github.com/user/repos?page=2>; rel="next", <https://api.github.com/user/repos?page=5>; rel="last"'
-        assert discover_ops._parse_next(link) == "https://api.github.com/user/repos?page=2"
+        assert (
+            discover_ops._parse_next(link) == "https://api.github.com/user/repos?page=2"
+        )
 
     def test_returns_empty_when_no_next(self) -> None:
         link = '<https://api.github.com/user/repos?page=1>; rel="prev"'

--- a/tests/test_discover_ops.py
+++ b/tests/test_discover_ops.py
@@ -2,12 +2,33 @@
 
 from __future__ import annotations
 
+import io
+import json
 import time
+import urllib.error
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from repo_scaffold import discover_ops
+
+
+class _FakeResp:
+    """Minimal urllib response stub for urlopen context manager."""
+
+    def __init__(self, body: bytes, link: str = "") -> None:
+        self._body = body
+        self.headers: dict[str, str] = {"Link": link}
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        pass
+
+    def read(self) -> bytes:
+        return self._body
 
 
 class TestDeviceFlowAuth:
@@ -186,3 +207,106 @@ class TestParseNext:
 
     def test_returns_empty_for_empty_string(self) -> None:
         assert discover_ops._parse_next("") == ""
+
+
+class TestPostForm:
+    def test_success_returns_parsed_json(self) -> None:
+        payload = {"access_token": "gho_tok"}
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_FakeResp(json.dumps(payload).encode()),
+        ):
+            result = discover_ops._post_form("https://example.com", {"k": "v"})
+        assert result == payload
+
+    def test_http_error_with_body_raises_runtime_error(self) -> None:
+        exc = urllib.error.HTTPError(
+            "https://example.com", 401, "Unauthorized", {}, io.BytesIO(b"bad token")
+        )
+        with patch("urllib.request.urlopen", side_effect=exc):
+            with pytest.raises(RuntimeError, match="bad token"):
+                discover_ops._post_form("https://example.com", {"k": "v"})
+
+    def test_http_error_no_body_uses_str_repr(self) -> None:
+        exc = urllib.error.HTTPError("https://example.com", 403, "Forbidden", {}, None)
+        with patch("urllib.request.urlopen", side_effect=exc):
+            with pytest.raises(RuntimeError):
+                discover_ops._post_form("https://example.com", {"k": "v"})
+
+
+class TestGetPaginated:
+    def test_single_page_no_link_header(self) -> None:
+        items = [{"full_name": "a/b"}, {"full_name": "c/d"}]
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_FakeResp(json.dumps(items).encode()),
+        ):
+            result = discover_ops._get_paginated(
+                "tok", "https://api.github.com/user/repos"
+            )
+        assert result == items
+
+    def test_two_pages_follows_link_header(self) -> None:
+        page1 = [{"full_name": "a/b"}]
+        page2 = [{"full_name": "c/d"}]
+        calls: list[int] = []
+
+        def fake_urlopen(req: object) -> _FakeResp:
+            calls.append(1)
+            if len(calls) == 1:
+                return _FakeResp(
+                    json.dumps(page1).encode(),
+                    link='<https://api.github.com/user/repos?page=2>; rel="next"',
+                )
+            return _FakeResp(json.dumps(page2).encode())
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            result = discover_ops._get_paginated(
+                "tok", "https://api.github.com/user/repos"
+            )
+        assert result == page1 + page2
+        assert len(calls) == 2
+
+    def test_http_error_raises_runtime_error(self) -> None:
+        exc = urllib.error.HTTPError(
+            "https://api.github.com/user/repos",
+            403,
+            "Forbidden",
+            {},
+            io.BytesIO(b"denied"),
+        )
+        with patch("urllib.request.urlopen", side_effect=exc):
+            with pytest.raises(RuntimeError, match="denied"):
+                discover_ops._get_paginated("tok", "https://api.github.com/user/repos")
+
+
+class TestPromptForToken:
+    def test_with_client_id_returns_pasted_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "gho_pasted")
+        monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+        assert discover_ops.prompt_for_token("client_id") == "gho_pasted"
+
+    def test_with_client_id_empty_input_triggers_device_flow(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+        monkeypatch.setattr(discover_ops, "device_flow_auth", lambda cid: "gho_device")
+        assert discover_ops.prompt_for_token("client_id") == "gho_device"
+
+    def test_without_client_id_returns_pasted_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "gho_manual")
+        monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+        assert discover_ops.prompt_for_token(None) == "gho_manual"
+
+    def test_without_client_id_empty_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+        with pytest.raises(RuntimeError, match="No token provided"):
+            discover_ops.prompt_for_token(None)

--- a/tests/test_discover_ops.py
+++ b/tests/test_discover_ops.py
@@ -310,3 +310,38 @@ class TestPromptForToken:
         monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
         with pytest.raises(RuntimeError, match="No token provided"):
             discover_ops.prompt_for_token(None)
+
+
+class TestParseRepoSelection:
+    def test_empty_returns_nothing(self) -> None:
+        assert discover_ops.parse_repo_selection("", 5) == []
+
+    def test_none_returns_nothing(self) -> None:
+        assert discover_ops.parse_repo_selection("none", 5) == []
+
+    def test_all_returns_all_indices(self) -> None:
+        assert discover_ops.parse_repo_selection("all", 3) == [0, 1, 2]
+
+    def test_single_number(self) -> None:
+        assert discover_ops.parse_repo_selection("2", 5) == [1]
+
+    def test_comma_separated(self) -> None:
+        assert discover_ops.parse_repo_selection("1,3,5", 5) == [0, 2, 4]
+
+    def test_range(self) -> None:
+        assert discover_ops.parse_repo_selection("2-4", 5) == [1, 2, 3]
+
+    def test_mixed_range_and_singles(self) -> None:
+        assert discover_ops.parse_repo_selection("1,3-5,7", 8) == [0, 2, 3, 4, 6]
+
+    def test_out_of_range_ignored(self) -> None:
+        assert discover_ops.parse_repo_selection("0,3,99", 5) == [2]
+
+    def test_deduplicates(self) -> None:
+        assert discover_ops.parse_repo_selection("1,1,2", 5) == [0, 1]
+
+    def test_whitespace_tolerated(self) -> None:
+        assert discover_ops.parse_repo_selection(" 1 , 3 ", 5) == [0, 2]
+
+    def test_invalid_token_ignored(self) -> None:
+        assert discover_ops.parse_repo_selection("1,abc,3", 5) == [0, 2]

--- a/tests/test_discover_ops.py
+++ b/tests/test_discover_ops.py
@@ -1,0 +1,174 @@
+"""Unit tests for discover_ops."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from repo_scaffold import discover_ops
+
+
+class TestDeviceFlowAuth:
+    def test_success_after_pending(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        responses = iter(
+            [
+                {
+                    "device_code": "DC",
+                    "user_code": "ABCD-1234",
+                    "verification_uri": "https://github.com/login/device",
+                    "interval": 1,
+                    "expires_in": 900,
+                },
+                {"error": "authorization_pending"},
+                {"access_token": "gho_real"},
+            ]
+        )
+        monkeypatch.setattr(discover_ops, "_post_form", lambda url, data: next(responses))
+        monkeypatch.setattr(time, "sleep", lambda _: None)
+        monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+
+        assert discover_ops.device_flow_auth("client_id") == "gho_real"
+
+    def test_slow_down_increases_interval(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        intervals: list[float] = []
+        responses = iter(
+            [
+                {
+                    "device_code": "D",
+                    "user_code": "U",
+                    "verification_uri": "https://x",
+                    "interval": 2,
+                    "expires_in": 900,
+                },
+                {"error": "slow_down"},
+                {"access_token": "tok"},
+            ]
+        )
+        monkeypatch.setattr(discover_ops, "_post_form", lambda url, data: next(responses))
+        monkeypatch.setattr(time, "sleep", intervals.append)
+        monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+
+        discover_ops.device_flow_auth("cid")
+        assert intervals == [2, 7]
+
+    def test_access_denied_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        responses = iter(
+            [
+                {
+                    "device_code": "D",
+                    "user_code": "U",
+                    "verification_uri": "https://x",
+                    "interval": 1,
+                    "expires_in": 900,
+                },
+                {"error": "access_denied", "error_description": "User denied"},
+            ]
+        )
+        monkeypatch.setattr(discover_ops, "_post_form", lambda url, data: next(responses))
+        monkeypatch.setattr(time, "sleep", lambda _: None)
+        monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+
+        with pytest.raises(RuntimeError, match="access_denied"):
+            discover_ops.device_flow_auth("cid")
+
+    def test_timeout_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            discover_ops,
+            "_post_form",
+            lambda url, data: {
+                "device_code": "D",
+                "user_code": "U",
+                "verification_uri": "https://x",
+                "interval": 1,
+                "expires_in": 1,
+            },
+        )
+        call_n = [0]
+
+        def fake_monotonic() -> float:
+            call_n[0] += 1
+            return 0.0 if call_n[0] == 1 else 1e9
+
+        monkeypatch.setattr(time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(time, "sleep", lambda _: None)
+        monkeypatch.setattr(discover_ops, "_DEVICE_TIMEOUT", 100)
+        monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+
+        with pytest.raises(RuntimeError, match="timed out"):
+            discover_ops.device_flow_auth("cid")
+
+
+class TestUpsertEnvVar:
+    def test_creates_new_file(self, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env"
+        discover_ops.upsert_env_var("GH_TOKEN", "tok123", env_file)
+        assert "GH_TOKEN=tok123" in env_file.read_text()
+
+    def test_appends_to_existing(self, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("FOO=bar\n")
+        discover_ops.upsert_env_var("GH_TOKEN", "tok123", env_file)
+        content = env_file.read_text()
+        assert "FOO=bar" in content
+        assert "GH_TOKEN=tok123" in content
+
+    def test_replaces_existing_key(self, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("GH_TOKEN=old\nFOO=bar\n")
+        discover_ops.upsert_env_var("GH_TOKEN", "new", env_file)
+        content = env_file.read_text()
+        assert "GH_TOKEN=new" in content
+        assert "GH_TOKEN=old" not in content
+        assert "FOO=bar" in content
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        env_file = tmp_path / "nested" / "dir" / ".env"
+        discover_ops.upsert_env_var("KEY", "val", env_file)
+        assert env_file.exists()
+
+
+class TestDiscoverRepos:
+    def test_returns_sorted_full_names(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        repos = [{"full_name": "acme/beta"}, {"full_name": "acme/alpha"}]
+        monkeypatch.setattr(discover_ops, "_get_paginated", lambda token, url: repos)
+        assert discover_ops.discover_repos("tok") == ["acme/alpha", "acme/beta"]
+
+    def test_uses_user_repos_url_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[str] = []
+        monkeypatch.setattr(
+            discover_ops,
+            "_get_paginated",
+            lambda token, url: captured.append(url) or [{"full_name": "a/b"}],
+        )
+        discover_ops.discover_repos("tok")
+        assert "/user/repos" in captured[0]
+
+    def test_uses_org_url_when_org_given(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[str] = []
+        monkeypatch.setattr(
+            discover_ops,
+            "_get_paginated",
+            lambda token, url: captured.append(url) or [{"full_name": "acme/x"}],
+        )
+        discover_ops.discover_repos("tok", org="acme")
+        assert "/orgs/acme/repos" in captured[0]
+
+    def test_filters_items_without_full_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        repos = [{"full_name": "ok/repo"}, {"id": 99}, {"full_name": ""}]
+        monkeypatch.setattr(discover_ops, "_get_paginated", lambda token, url: repos)
+        assert discover_ops.discover_repos("tok") == ["ok/repo"]
+
+
+class TestParseNext:
+    def test_extracts_next_url(self) -> None:
+        link = '<https://api.github.com/user/repos?page=2>; rel="next", <https://api.github.com/user/repos?page=5>; rel="last"'
+        assert discover_ops._parse_next(link) == "https://api.github.com/user/repos?page=2"
+
+    def test_returns_empty_when_no_next(self) -> None:
+        link = '<https://api.github.com/user/repos?page=1>; rel="prev"'
+        assert discover_ops._parse_next(link) == ""
+
+    def test_returns_empty_for_empty_string(self) -> None:
+        assert discover_ops._parse_next("") == ""


### PR DESCRIPTION
## 🧾 Title
feat(discover): GitHub auth flow and repo discovery (#173)

## 🧠 Description
Adds the `repo discover` subcommand, Device Flow browser-based auth, PAT paste
fallback, and interactive repo selection. Users can now authenticate and discover
all GitHub repos visible to their token, then pick which ones to register locally
via a numbered selection prompt.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [x] Added/updated documentation

## 🎯 Purpose
Enables first-time setup: a user with no `GH_TOKEN` can authenticate via PAT
paste or Device Flow (if `GITHUB_CLIENT_ID` is configured), discover all their
visible repos, and selectively register the ones they want to manage.

## 🔗 Related Issues / Epics
- **Epic:** #48
- **Issue:** #173
- Closes #173

## 🧪 Testing
1. Copy `.env` to the worktree or let the token prompt fire on first run
2. `poetry run repo-scaffold repo discover` -- lists all unregistered repos with numbers
3. `poetry run repo-scaffold repo discover --register` -- shows numbered list, prompts for selection (e.g. `1,3,5-8`, `all`, or Enter to skip)
4. `poetry run repo-scaffold repo discover --register --yes` -- registers all without prompting
5. `poetry run repo-scaffold repo discover --org <orgname>` -- scopes to a specific org
6. Verify selected repos appear in the local registry

## 🧰 Developer Notes
- `discover_ops.py`: new module for `_post_form`, `_get_paginated`, `device_flow_auth`, `prompt_for_token`, `upsert_env_var`, `discover_repos`, `parse_repo_selection`
- `parse_repo_selection` handles comma/range notation (`1,3-5,7`), deduplicates, ignores out-of-range values
- Device Flow requires a `GITHUB_CLIENT_ID` in `.env` (OAuth App client ID); PAT paste works without it
- Token is always saved as `GH_TOKEN` in `.env`
- Follow-up: #233 tracks the GitHub App installation flow for graphical repo selection
