### PR TITLE
feat(cli): add repo archive command for GitHub repo lifecycle management (#241)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,10 @@ poetry run repo-scaffold apply templates --path . --name NAME --owner OWNER
 
 # Check branch protection rules
 poetry run repo-scaffold check rules --repo OWNER/REPO
+
+# Archive a repo (read-only; reversible via the GitHub UI)
+# Prompts for confirmation unless --yes is passed; refuses in a non-interactive shell without --yes.
+poetry run repo-scaffold repo archive --repo OWNER/REPO [--yes]
 ```
 
 **Supported languages:** `go`, `gin`, `python`, `react`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,10 @@ poetry run repo-scaffold apply templates --path . --name NAME --owner OWNER
 poetry run repo-scaffold create --repo OWNER/REPO --visibility public --path /path/to/code
 
 poetry run repo-scaffold check rules --repo OWNER/REPO
+
+# Archive a repo (read-only; reversible via the GitHub UI). Prompts for confirmation
+# unless --yes is passed; refuses in a non-interactive shell without --yes.
+poetry run repo-scaffold repo archive --repo OWNER/REPO [--yes]
 ```
 
 ## PR Conventions

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -51,6 +51,7 @@ from .github_api import (
     pr_reviews,
     pr_update,
     pr_view,
+    repo_archive,
     token_from_repo,
 )
 from .backlog_import import build_backlog_import_file
@@ -770,6 +771,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--yes",
         action="store_true",
         help="Skip confirmation before registering",
+    )
+    repo_archive_cmd = repo_sub.add_parser(
+        "archive",
+        help="Archive a GitHub repository (read-only; reversible via the GitHub UI)",
+    )
+    repo_archive_cmd.add_argument(
+        "--repo", required=True, help="GitHub repo (owner/repo)"
+    )
+    repo_archive_cmd.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt",
     )
 
     sync_cmd = subparsers.add_parser(
@@ -2170,6 +2183,35 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Error: repo not registered: {ns.repo}", file=sys.stderr)
             return 2
         print(f"Removed {ns.repo} from the registry.")
+        return 0
+
+    if ns.mode == "repo" and ns.repo_command == "archive":
+        if not ns.yes:
+            if not sys.stdin.isatty():
+                print(
+                    "Non-interactive shell detected and --yes not set; refusing to archive.",
+                    file=sys.stderr,
+                )
+                return 2
+            reply = (
+                input(
+                    f"Archive {ns.repo}? This makes it read-only (reversible via the GitHub UI). [y/N] "
+                )
+                .strip()
+                .lower()
+            )
+            if reply not in {"y", "yes"}:
+                print("Aborted.")
+                return 0
+        token = token_from_repo(Path.cwd())
+        if not token:
+            print("Error: no GH_TOKEN found.", file=sys.stderr)
+            return 2
+        cp = repo_archive(ns.repo, token)
+        if cp.returncode not in (0, 200):
+            print(f"Error: {cp.stderr.strip()}", file=sys.stderr)
+            return 1
+        print(f"Archived {ns.repo}.")
         return 0
 
     if ns.mode == "repo" and ns.repo_command == "discover":

--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -882,6 +882,11 @@ def repo_create(
     return rest("POST", endpoint, token, payload)
 
 
+def repo_archive(repo: str, token: str) -> subprocess.CompletedProcess[str]:
+    """Archive a GitHub repo via REST API, making it read-only."""
+    return rest("PATCH", f"/repos/{repo}", token, {"archived": True})
+
+
 def _is_org(owner: str, token: str) -> bool:
     cp = rest("GET", f"/users/{owner}", token)
     if cp.returncode != 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3216,6 +3216,46 @@ def test_repo_forget_missing_repo_errors(
     assert "not registered" in stderr
 
 
+def test_repo_archive_with_yes_flag_skips_prompt(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import subprocess
+
+    monkeypatch.setattr("repo_scaffold.cli.token_from_repo", lambda _: "tok")
+    monkeypatch.setattr(
+        "repo_scaffold.cli.repo_archive",
+        lambda repo, token: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='{"archived": true}', stderr=""
+        ),
+    )
+    rc = main(["repo", "archive", "--repo", "acme/repo", "--yes"])
+    assert rc == 0
+    assert "Archived acme/repo." in capsys.readouterr().out
+
+
+def test_repo_archive_refuses_without_yes_in_non_interactive_shell(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "repo_scaffold.cli.sys.stdin", SimpleNamespace(isatty=lambda: False)
+    )
+    rc = main(["repo", "archive", "--repo", "acme/repo"])
+    assert rc == 2
+    assert "refusing to archive" in capsys.readouterr().err
+
+
+def test_repo_archive_prompts_and_aborts_on_no(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "repo_scaffold.cli.sys.stdin", SimpleNamespace(isatty=lambda: True)
+    )
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    rc = main(["repo", "archive", "--repo", "acme/repo"])
+    assert rc == 0
+    assert "Aborted." in capsys.readouterr().out
+
+
 def test_apply_rules_with_repos_flag_uses_registry_paths(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -316,6 +316,42 @@ def test_repo_create_user() -> None:
 
 
 # ---------------------------------------------------------------------------
+# repo_archive
+# ---------------------------------------------------------------------------
+
+
+def test_repo_archive_sends_patch_with_archived_true() -> None:
+    repo_data = json.dumps({"full_name": "alice/myrepo", "archived": True})
+    captured: dict[str, object] = {}
+
+    def _fake_urlopen(req: urllib.request.Request) -> MagicMock:
+        captured["method"] = req.get_method()
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode())
+        return _mock_resp(200, repo_data)
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        cp = github_api.repo_archive("alice/myrepo", "token")
+
+    assert cp.returncode == 0
+    assert json.loads(cp.stdout)["archived"] is True
+    assert captured["method"] == "PATCH"
+    assert captured["url"] == "https://api.github.com/repos/alice/myrepo"
+    assert captured["body"] == {"archived": True}
+
+
+def test_repo_archive_returns_error_on_failure() -> None:
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=_http_error(404, '{"message":"Not Found"}'),
+    ):
+        cp = github_api.repo_archive("alice/ghost-repo", "token")
+
+    assert cp.returncode == 404
+    assert "Not Found" in cp.stderr
+
+
+# ---------------------------------------------------------------------------
 # validate_token / get_authenticated_login
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 🧾 Title
Add repo archive command for GitHub repo lifecycle management

## 🧠 Description
There was no way to archive a GitHub repository through repo-scaffold, which came up
while consolidating mobile-backup, rename-images-to-datetime, and files-in-folder into
one project -- the two standalone repos need archiving once that lands. Per the
standing rule, this is implemented in repo-scaffold rather than shelling out to raw
API calls.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [x] Added/updated documentation

## 🎯 Purpose
Adds `repo-scaffold repo archive --repo OWNER/REPO` alongside the existing
register/list/forget/discover subcommands. Sends a PATCH to set `archived: true`
via the same urllib + GH_TOKEN pattern as the rest of github_api.py. Requires --yes
or an interactive confirmation prompt; refuses outright in a non-interactive shell
without --yes, since archiving is hard to reverse casually (makes the repo read-only,
disables issues/PRs/pushes).

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #241
- Closes #241

## 🧪 Testing
1. `poetry run pytest -k archive` -- 5 new tests covering the API call, the success/error paths, and the confirmation gate (--yes, non-interactive refusal, interactive abort)
2. `poetry run tox -e precommit` -- full gate (format, lint, type, coverage) passes
3. Manual: `poetry run repo-scaffold repo archive --repo OWNER/REPO` prompts for confirmation; `--yes` skips it

## 🧰 Developer Notes
- [x] Verify environment variables are configured properly (no new env vars; uses the existing GH_TOKEN resolution)
- [x] Ensure code runs under both local and CI/CD environments
- Unarchiving, deleting, and transferring ownership are explicitly out of scope for this ticket
