### PR TITLE
fix(ci): skip validate-pr body-format check for Dependabot PRs (#243)

### DIFF
--- a/src/repo_scaffold/templates/github/workflows/validate-pr.yml
+++ b/src/repo_scaffold/templates/github/workflows/validate-pr.yml
@@ -18,18 +18,7 @@ jobs:
             const number = context.payload.pull_request.number;
             const author = context.payload.pull_request.user?.login || "";
 
-            if (author === "dependabot[bot]") {
-              core.info(`PR #${number} is from Dependabot; skipping body-format check.`);
-              return;
-            }
-
-            const body = context.payload.pull_request.body || "";
-            const required = ["## 🧾 Title"];
-            const missing = required.filter(h => !body.includes(h));
-
-            if (missing.length === 0) {
-              core.info(`PR #${number} body looks good.`);
-              // Remove needs-format if it was added by a previous failed check
+            const removeStaleLabel = async () => {
               try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
@@ -39,6 +28,22 @@ jobs:
                 });
                 core.info(`Removed needs-format label from PR #${number}.`);
               } catch (_) {}
+            };
+
+            if (author === "dependabot[bot]") {
+              core.info(`PR #${number} is from Dependabot; skipping body-format check.`);
+              // Clear any needs-format label left over from before this skip existed.
+              await removeStaleLabel();
+              return;
+            }
+
+            const body = context.payload.pull_request.body || "";
+            const required = ["## 🧾 Title"];
+            const missing = required.filter(h => !body.includes(h));
+
+            if (missing.length === 0) {
+              core.info(`PR #${number} body looks good.`);
+              await removeStaleLabel();
               return;
             }
 

--- a/src/repo_scaffold/templates/github/workflows/validate-pr.yml
+++ b/src/repo_scaffold/templates/github/workflows/validate-pr.yml
@@ -15,9 +15,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const body = context.payload.pull_request.body || "";
             const number = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user?.login || "";
 
+            if (author === "dependabot[bot]") {
+              core.info(`PR #${number} is from Dependabot; skipping body-format check.`);
+              return;
+            }
+
+            const body = context.payload.pull_request.body || "";
             const required = ["## 🧾 Title"];
             const missing = required.filter(h => !body.includes(h));
 


### PR DESCRIPTION
## 🧾 Title
Skip validate-pr body-format check for Dependabot PRs

## 🧠 Description
Dependabot generates its own fixed-format PR body and can't conform to a repo's
custom pull_request_template.md, so every Dependabot PR was getting flagged with
needs-format and a comment asking it to fix a body it structurally can't fix.
Surfaced when mobile-backup's first Dependabot scan opened 7 PRs, all immediately
flagged.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement

## 🎯 Purpose
validate-pr.yml now returns early when the PR author is dependabot[bot], before
looking at the body at all. check-sop needs no change -- it already passes cleanly
for Dependabot PRs since they have zero review threads.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #243
- Closes #243

## 🧪 Testing
1. `poetry run tox -e precommit` -- full gate passes
2. Manual: read through the updated script logic against the template diff
3. Follow-up: same template will be reapplied to mobile-backup in a separate PR there, since it already has the broken version from the earlier consolidation work

## 🧰 Developer Notes
- [x] Verify environment variables are configured properly (no new env vars)
- [x] Ensure code runs under both local and CI/CD environments
