### PR TITLE
chore: add dependabot version updates config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## 🧾 Title
Add Dependabot version updates config

## 🧠 Description
This branch is protected and requires a PR for changes to the default branch, so `repo-scaffold apply rules` opened this PR automatically instead of committing directly to `main`.

## 🎯 Purpose
Adds `.github/dependabot.yml` so Dependabot checks for version updates on a schedule.