### PR TITLE
fix(ci): sync repo-scaffold's own validate-pr.yml with the fixed template (#259)

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -15,15 +15,10 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const body = context.payload.pull_request.body || "";
             const number = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user?.login || "";
 
-            const required = ["## 🧾 Title"];
-            const missing = required.filter(h => !body.includes(h));
-
-            if (missing.length === 0) {
-              core.info(`PR #${number} body looks good.`);
-              // Remove needs-format if it was added by a previous failed check
+            const removeStaleLabel = async () => {
               try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
@@ -33,6 +28,22 @@ jobs:
                 });
                 core.info(`Removed needs-format label from PR #${number}.`);
               } catch (_) {}
+            };
+
+            if (author === "dependabot[bot]") {
+              core.info(`PR #${number} is from Dependabot; skipping body-format check.`);
+              // Clear any needs-format label left over from before this skip existed.
+              await removeStaleLabel();
+              return;
+            }
+
+            const body = context.payload.pull_request.body || "";
+            const required = ["## 🧾 Title"];
+            const missing = required.filter(h => !body.includes(h));
+
+            if (missing.length === 0) {
+              core.info(`PR #${number} body looks good.`);
+              await removeStaleLabel();
               return;
             }
 


### PR DESCRIPTION
## 🧾 Title
Sync repo-scaffold's own validate-pr.yml with the fixed template

## 🧠 Description
#244 fixed the Dependabot-skip logic in the *template*, used when scaffolding
other repos. That same fix was separately applied to mobile-backup's live
workflow (mobile-backup#41), but never to repo-scaffold's own live
`.github/workflows/validate-pr.yml` -- so every new Dependabot PR on this repo
(#250-258) kept getting flagged with `needs-format` despite #244 being merged.

## 🧩 Changes Included
- [x] Improved error handling or logging

## 🎯 Purpose
`.github/workflows/validate-pr.yml` now matches the template byte-for-byte.
Audited the other workflow/template pairs too -- only this one had drifted.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #259
- Closes #259

## 🧪 Testing
1. `diff .github/workflows/validate-pr.yml src/repo_scaffold/templates/github/workflows/validate-pr.yml` shows no difference
2. `poetry run tox -e precommit` passes
3. Follow-up (after merge): confirm a live Dependabot PR stops getting flagged

## 🧰 Developer Notes
- [x] Verify environment variables are configured properly (no env vars involved)
- [x] Ensure code runs under both local and CI/CD environments
