### PR TITLE
fix(cli): pr check-sop falsely reports missing reply on self-review threads (#261)

### DIFF
--- a/src/repo_scaffold/github_api.py
+++ b/src/repo_scaffold/github_api.py
@@ -1663,15 +1663,14 @@ def pr_check_sop(
         comments = thread.get("comments", {}).get("nodes", [])
         first_comment = comments[0] if comments else {}
         first_comment_id = first_comment.get("databaseId")
-        first_author = first_comment.get("author", {}).get("login", "")
         reactions = first_comment.get("reactions", {}).get("nodes", [])
         has_plus_one = any(r.get("content") == "THUMBS_UP" for r in reactions)
 
-        # A valid SOP reply must come from a different author than the thread opener.
-        # This distinguishes an agent fix-reply from the reviewer adding follow-up comments.
-        has_reply = any(
-            c.get("author", {}).get("login", "") != first_author for c in comments[1:]
-        )
+        # Matches validate-pr-sop.yml's actual enforcement logic exactly: any
+        # additional comment counts as a reply, regardless of author. A same-author
+        # check would misreport self-review threads (reviewer and repo owner sharing
+        # a GitHub login) as missing a reply even when one was genuinely posted.
+        has_reply = len(comments) > 1
 
         missing = []
         if not has_reply:

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1639,13 +1639,18 @@ def test_pr_check_sop_api_error_propagates() -> None:
     assert cp.returncode != 0
 
 
-def test_pr_check_sop_reply_same_author_not_compliant() -> None:
+def test_pr_check_sop_same_author_reply_still_counts() -> None:
+    """Matches validate-pr-sop.yml's actual enforcement exactly: any additional
+    comment counts as a reply, regardless of author. A self-review thread
+    (reviewer and replier sharing a GitHub login, e.g. the repo owner reviewing
+    their own PR) must not be misreported as missing a reply when one was
+    genuinely posted."""
     thread = _make_thread(
         "PRRT_8",
         is_resolved=True,
         num_comments=2,
         first_has_thumbs_up=True,
-        reply_author="reviewer",  # same author as thread opener -- not a valid SOP reply
+        reply_author="reviewer",  # same author as thread opener -- still a valid reply
     )
     with patch.object(
         github_api, "graphql", return_value=github_api._ok(_sop_resp([thread]))
@@ -1653,8 +1658,8 @@ def test_pr_check_sop_reply_same_author_not_compliant() -> None:
         cp = github_api.pr_check_sop("acme", "repo", 8, "tok")
     assert cp.returncode == 0
     report = json.loads(cp.stdout)
-    assert report[0]["has_reply"] is False
-    assert "reply" in report[0]["missing"]
+    assert report[0]["has_reply"] is True
+    assert report[0]["compliant"] is True
 
 
 def test_pr_check_sop_paginates_all_threads() -> None:


### PR DESCRIPTION
## 🧾 Title
Fix pr check-sop falsely reporting missing reply on self-review threads

## 🧠 Description
`pr_check_sop()` required a review-thread reply to come from a different GitHub
login than the thread opener, but that doesn't match the actual enforcement
mechanism: `validate-pr-sop.yml` (the live GitHub Action that gates merging) just
checks `comments.length > 1`, no author check at all.

This gave false negatives on self-review threads -- e.g. the repo owner leaving
review comments on their own PR and an agent replying under that same owner's
token. The actual required status check passed fine the whole time; only the
diagnostic command was wrong.

## 🧩 Changes Included
- [x] Refactored existing code
- [x] Improved error handling or logging

## 🎯 Purpose
`pr_check_sop()` now matches `validate-pr-sop.yml` exactly (`len(comments) > 1`),
so the CLI diagnostic reflects what actually gates merging.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #261
- Closes #261

## 🧪 Testing
1. `poetry run pytest -k check_sop` -- fixed the test that encoded the old wrong assumption, all 9 pass
2. `poetry run tox -e precommit` -- full gate passes

## 🧰 Developer Notes
- [x] Verify environment variables are configured properly (no env vars involved)
- [x] Ensure code runs under both local and CI/CD environments
