### PR TITLE
feat(docker): auto-start Docker Desktop before docker commands on Windows (#266)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,13 @@ Each active branch gets its own container (`{repo-name}-{branch-slug}`). All con
 share a base image built once from the Dockerfile in the repo root. Credentials are
 passed as env vars at runtime -- never baked into the image.
 
+**Windows:** `repo-scaffold docker shell`/`spin-up`/`build-base` auto-start Docker
+Desktop if it isn't already running (launches it, then polls the daemon for up to 90s
+before proceeding) and fail with a clear error if it can't come up in time. No manual
+"start Docker Desktop first" step is needed for these commands. This does not apply to
+the Compose-based flow in the [README](README.md#docker-dev-environment), which still
+requires Docker Desktop to already be running.
+
 ### Per-repo container workflow (preferred)
 
 One command to get a shell inside an isolated container for any branch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,8 @@ All GitHub operations (repos, issues, PRs, projects, backlog) are implemented vi
 
 Each branch gets its own isolated Docker container. The container clones the branch
 and installs deps on startup. Your code is at `/{repo-name}` inside the container.
+On Windows, Docker Desktop is auto-started if it isn't already running -- no manual
+start step needed before `docker shell`.
 
 ```bash
 # Get a shell in a branch container (builds image if needed, replaces any existing container)

--- a/README.md
+++ b/README.md
@@ -82,9 +82,15 @@ docker exec -it repo-scaffold-dev poetry run pytest -q                   # tests
 - Multiple agents can `docker exec` into the same running container concurrently -- all
   persistent state lives on the host or in the named volume, not in the container layer.
 
-**Windows note:** Docker Desktop for Windows must be running. WSL integration must be
-enabled for your distro (Docker Desktop → Resources → WSL Integration) to use `docker`
-commands from a WSL terminal.
+**Windows note:** Docker Desktop for Windows must already be running for this
+Compose-based flow (raw `docker compose`/`docker exec`, not run through `repo-scaffold`).
+WSL integration must be enabled for your distro (Docker Desktop → Resources → WSL
+Integration) to use `docker` commands from a WSL terminal.
+
+The preferred per-repo container workflow (`repo-scaffold docker shell`/`spin-up`/
+`build-base`, see [AGENTS.md](AGENTS.md#docker-dev-environment)) auto-starts Docker
+Desktop on Windows if it isn't already running and waits for the daemon before
+proceeding -- this manual-start requirement is specific to the Compose flow above.
 
 ## Commands
 

--- a/src/repo_scaffold/docker_ops.py
+++ b/src/repo_scaffold/docker_ops.py
@@ -11,8 +11,10 @@ Each active branch gets its own container started from that image.
 from __future__ import annotations
 
 import os
+import platform
 import re
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -48,17 +50,83 @@ def image_name(repo: str) -> str:
 # Docker client (lazy import so missing SDK gives a clear error at call time)
 # ---------------------------------------------------------------------------
 
+# Windows-only: Docker Desktop is not running as a service, so a stopped
+# daemon needs the GUI app launched before its API socket comes up.
+_DOCKER_DESKTOP_CANDIDATE_PATHS = [
+    r"C:\Program Files\Docker\Docker\Docker Desktop.exe",
+    r"C:\ProgramData\DockerDesktop\Docker Desktop.exe",
+]
+_DOCKER_DESKTOP_START_TIMEOUT_SECONDS = 90
+_DOCKER_DESKTOP_POLL_INTERVAL_SECONDS = 5
+
+
+def _is_docker_unreachable(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return "pipe" in text or "connectionrefused" in text or "connection refused" in text
+
+
+def _find_docker_desktop_exe() -> str | None:
+    for candidate in _DOCKER_DESKTOP_CANDIDATE_PATHS:
+        if Path(candidate).exists():
+            return candidate
+    return None
+
+
+def _wait_for_docker_ready(timeout: float) -> bool:
+    import docker  # type: ignore[import]
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            docker.from_env().ping()
+            return True
+        except Exception:
+            time.sleep(_DOCKER_DESKTOP_POLL_INTERVAL_SECONDS)
+    return False
+
+
+def _try_auto_start_docker_desktop() -> bool:
+    """Best-effort: launch Docker Desktop on Windows and wait for the daemon.
+
+    Returns True if the daemon became reachable, False otherwise. Never
+    raises -- callers fall back to the original connection error on failure.
+    """
+    if platform.system() != "Windows":
+        return False
+
+    exe = _find_docker_desktop_exe()
+    if exe is None:
+        return False
+
+    try:
+        subprocess.Popen([exe], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        return False
+
+    return _wait_for_docker_ready(_DOCKER_DESKTOP_START_TIMEOUT_SECONDS)
+
 
 def _client():  # type: ignore[return]
     try:
         import docker  # type: ignore[import]
-
-        return docker.from_env()
     except ImportError:
         raise RuntimeError("The 'docker' package is required: poetry add docker")
+
+    try:
+        return docker.from_env()
     except Exception as exc:
+        if not _is_docker_unreachable(exc):
+            raise RuntimeError(f"Cannot connect to Docker daemon: {exc}")
+
+        if _try_auto_start_docker_desktop():
+            try:
+                return docker.from_env()
+            except Exception as retry_exc:
+                exc = retry_exc
+
         raise RuntimeError(
-            f"Cannot connect to Docker daemon -- is Docker running? ({exc})"
+            "Cannot connect to Docker daemon -- is Docker running? "
+            f"Auto-start was attempted and did not bring it up in time. ({exc})"
         )
 
 

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -475,3 +475,140 @@ def test_shell_raises_on_spinup_failure(tmp_path: Path) -> None:
     with patch("repo_scaffold.docker_ops._client", return_value=client):
         with pytest.raises(RuntimeError, match="Failed to start container"):
             docker_shell("owner/myrepo", "main", "tok", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Windows Docker Desktop auto-start
+# ---------------------------------------------------------------------------
+
+
+def test_is_docker_unreachable_pipe_error() -> None:
+    from repo_scaffold.docker_ops import _is_docker_unreachable
+
+    exc = Exception("open //./pipe/dockerDesktopLinuxEngine: not found")
+    assert _is_docker_unreachable(exc) is True
+
+
+def test_is_docker_unreachable_connection_refused() -> None:
+    from repo_scaffold.docker_ops import _is_docker_unreachable
+
+    assert _is_docker_unreachable(Exception("Connection refused")) is True
+
+
+def test_is_docker_unreachable_unrelated_error() -> None:
+    from repo_scaffold.docker_ops import _is_docker_unreachable
+
+    assert _is_docker_unreachable(Exception("permission denied")) is False
+
+
+def test_find_docker_desktop_exe_found() -> None:
+    from repo_scaffold.docker_ops import (
+        _DOCKER_DESKTOP_CANDIDATE_PATHS,
+        _find_docker_desktop_exe,
+    )
+
+    with patch("repo_scaffold.docker_ops.Path.exists", return_value=True):
+        assert _find_docker_desktop_exe() == _DOCKER_DESKTOP_CANDIDATE_PATHS[0]
+
+
+def test_find_docker_desktop_exe_not_found() -> None:
+    from repo_scaffold.docker_ops import _find_docker_desktop_exe
+
+    with patch("repo_scaffold.docker_ops.Path.exists", return_value=False):
+        assert _find_docker_desktop_exe() is None
+
+
+def test_auto_start_noop_on_non_windows() -> None:
+    from repo_scaffold.docker_ops import _try_auto_start_docker_desktop
+
+    with patch("repo_scaffold.docker_ops.platform.system", return_value="Linux"):
+        assert _try_auto_start_docker_desktop() is False
+
+
+def test_auto_start_noop_when_exe_missing() -> None:
+    from repo_scaffold.docker_ops import _try_auto_start_docker_desktop
+
+    with patch(
+        "repo_scaffold.docker_ops.platform.system", return_value="Windows"
+    ), patch("repo_scaffold.docker_ops._find_docker_desktop_exe", return_value=None):
+        assert _try_auto_start_docker_desktop() is False
+
+
+def test_auto_start_returns_false_when_popen_fails() -> None:
+    from repo_scaffold.docker_ops import _try_auto_start_docker_desktop
+
+    with patch(
+        "repo_scaffold.docker_ops.platform.system", return_value="Windows"
+    ), patch(
+        "repo_scaffold.docker_ops._find_docker_desktop_exe", return_value="C:\\fake.exe"
+    ), patch(
+        "repo_scaffold.docker_ops.subprocess.Popen", side_effect=OSError("nope")
+    ):
+        assert _try_auto_start_docker_desktop() is False
+
+
+def test_auto_start_launches_and_waits() -> None:
+    from repo_scaffold.docker_ops import _try_auto_start_docker_desktop
+
+    with patch(
+        "repo_scaffold.docker_ops.platform.system", return_value="Windows"
+    ), patch(
+        "repo_scaffold.docker_ops._find_docker_desktop_exe", return_value="C:\\fake.exe"
+    ), patch(
+        "repo_scaffold.docker_ops.subprocess.Popen"
+    ), patch(
+        "repo_scaffold.docker_ops._wait_for_docker_ready", return_value=True
+    ) as wait_mock:
+        assert _try_auto_start_docker_desktop() is True
+        wait_mock.assert_called_once()
+
+
+def test_wait_for_docker_ready_success() -> None:
+    from repo_scaffold.docker_ops import _wait_for_docker_ready
+
+    mock_docker = MagicMock()
+    with patch.dict("sys.modules", {"docker": mock_docker}), patch(
+        "repo_scaffold.docker_ops.time.sleep"
+    ):
+        assert _wait_for_docker_ready(timeout=5) is True
+
+
+def test_wait_for_docker_ready_times_out() -> None:
+    from repo_scaffold.docker_ops import _wait_for_docker_ready
+
+    mock_docker = MagicMock()
+    mock_docker.from_env.side_effect = Exception("still down")
+    with patch.dict("sys.modules", {"docker": mock_docker}), patch(
+        "repo_scaffold.docker_ops.time.sleep"
+    ), patch("repo_scaffold.docker_ops.time.monotonic", side_effect=[0, 1, 100]):
+        assert _wait_for_docker_ready(timeout=5) is False
+
+
+def test_client_auto_starts_and_recovers() -> None:
+    from repo_scaffold.docker_ops import _client
+
+    mock_docker = MagicMock()
+    mock_docker.from_env.side_effect = [
+        Exception("open //./pipe/dockerDesktopLinuxEngine: not found"),
+        MagicMock(),
+    ]
+    with patch.dict("sys.modules", {"docker": mock_docker}), patch(
+        "repo_scaffold.docker_ops._try_auto_start_docker_desktop", return_value=True
+    ):
+        _client()
+
+    assert mock_docker.from_env.call_count == 2
+
+
+def test_client_raises_with_auto_start_context_when_recovery_fails() -> None:
+    from repo_scaffold.docker_ops import _client
+
+    mock_docker = MagicMock()
+    mock_docker.from_env.side_effect = Exception(
+        "open //./pipe/dockerDesktopLinuxEngine: not found"
+    )
+    with patch.dict("sys.modules", {"docker": mock_docker}), patch(
+        "repo_scaffold.docker_ops._try_auto_start_docker_desktop", return_value=False
+    ):
+        with pytest.raises(RuntimeError, match="Auto-start was attempted"):
+            _client()

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -600,6 +600,23 @@ def test_client_auto_starts_and_recovers() -> None:
     assert mock_docker.from_env.call_count == 2
 
 
+def test_client_auto_starts_but_retry_still_fails() -> None:
+    from repo_scaffold.docker_ops import _client
+
+    mock_docker = MagicMock()
+    mock_docker.from_env.side_effect = [
+        Exception("open //./pipe/dockerDesktopLinuxEngine: not found"),
+        Exception("still unreachable after auto-start"),
+    ]
+    with patch.dict("sys.modules", {"docker": mock_docker}), patch(
+        "repo_scaffold.docker_ops._try_auto_start_docker_desktop", return_value=True
+    ):
+        with pytest.raises(RuntimeError, match="still unreachable after auto-start"):
+            _client()
+
+    assert mock_docker.from_env.call_count == 2
+
+
 def test_client_raises_with_auto_start_context_when_recovery_fails() -> None:
     from repo_scaffold.docker_ops import _client
 


### PR DESCRIPTION
## 🧾 Title
Auto-start Docker Desktop before docker commands on Windows

## 🧠 Description
`docker shell`/`spin-up`/`build-base` currently fail with a raw, unhelpful error when Docker Desktop isn't running on Windows (`failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine`). Hit this live while using the per-repo container workflow to push a branch for another managed repo — an agent hitting this has no way to recover without a human manually launching Docker Desktop and waiting for the daemon.

## 🧩 Changes Included
- [ ] Added/updated documentation
- [x] Implemented new feature or enhancement
- [ ] Refactored existing code
- [x] Improved error handling or logging
- [ ] Updated environment configuration
- [ ] Other (specify)

## 🎯 Purpose
`_client()` now detects the specific Docker-unreachable error (named pipe not found / connection refused) and, on Windows, attempts to launch Docker Desktop and poll the daemon until ready (90s bound) before retrying the connection. Falls through to the original clear error if Docker Desktop isn't installed, can't be launched, or doesn't come up in time. No-op on non-Windows platforms, where this class of failure doesn't apply.

## 🔗 Related Issues / Epics
- **Epic:** #48 (Agent Orchestrator Enablement)
- **Issue:** #266
- Closes #266

## 🧪 Testing
1. Stop Docker Desktop, run `poetry run repo-scaffold docker spin-up --repo OWNER/REPO --branch BRANCH` — confirms it auto-launches Docker Desktop, waits for the daemon, and completes successfully.
2. With Docker Desktop already running, confirm no behavior change / no added latency.
3. `poetry run pytest tests/test_docker_ops.py -q` — new tests cover the pipe-error detector, exe discovery, auto-start success/failure paths, and the `_client()` recovery + failure-with-context paths.
4. `poetry run tox -e precommit` — full gate (format/lint/type/coverage) passes at 75% branch coverage.

## 🧰 Developer Notes
- [x] Verify environment variables are configured properly
- [x] Ensure code runs under both local and CI/CD environments
- Windows-only fix by design (`platform.system() != "Windows"` short-circuits to a no-op); Linux/macOS CI is unaffected.
