### PR TITLE
feat(docker): add macOS support to Docker auto-start (#270)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,12 +32,17 @@ Each active branch gets its own container (`{repo-name}-{branch-slug}`). All con
 share a base image built once from the Dockerfile in the repo root. Credentials are
 passed as env vars at runtime -- never baked into the image.
 
-**Windows:** `repo-scaffold docker shell`/`spin-up`/`build-base` auto-start Docker
+**Windows/macOS:** `repo-scaffold docker shell`/`spin-up`/`build-base` auto-start Docker
 Desktop if it isn't already running (launches it, then polls the daemon for up to 90s
 before proceeding) and fail with a clear error if it can't come up in time. No manual
 "start Docker Desktop first" step is needed for these commands. This does not apply to
 the Compose-based flow in the [README](README.md#docker-dev-environment), which still
 requires Docker Desktop to already be running.
+
+**Linux:** no auto-start. Docker there normally runs as a systemd service, and starting
+a stopped one needs sudo (`systemctl start docker`) -- a real privilege-escalation step,
+not just launching a user-space app. Most Linux dev/CI environments already have
+`dockerd` running as a service; if yours doesn't, start it yourself first.
 
 ### Per-repo container workflow (preferred)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,8 +183,9 @@ All GitHub operations (repos, issues, PRs, projects, backlog) are implemented vi
 
 Each branch gets its own isolated Docker container. The container clones the branch
 and installs deps on startup. Your code is at `/{repo-name}` inside the container.
-On Windows, Docker Desktop is auto-started if it isn't already running -- no manual
-start step needed before `docker shell`.
+On Windows/macOS, Docker Desktop is auto-started if it isn't already running -- no
+manual start step needed before `docker shell`. On Linux, start `dockerd` yourself
+first (no auto-start there -- it's normally a sudo-gated systemd service, not an app).
 
 ```bash
 # Get a shell in a branch container (builds image if needed, replaces any existing container)

--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ Integration) to use `docker` commands from a WSL terminal.
 
 The preferred per-repo container workflow (`repo-scaffold docker shell`/`spin-up`/
 `build-base`, see [AGENTS.md](AGENTS.md#docker-dev-environment)) auto-starts Docker
-Desktop on Windows if it isn't already running and waits for the daemon before
+Desktop on Windows/macOS if it isn't already running and waits for the daemon before
 proceeding -- this manual-start requirement is specific to the Compose flow above.
+On Linux there's no auto-start either way (Docker is normally a systemd service
+there, not an app).
 
 ## Commands
 

--- a/src/repo_scaffold/docker_ops.py
+++ b/src/repo_scaffold/docker_ops.py
@@ -74,7 +74,18 @@ _DOCKER_DESKTOP_POLL_INTERVAL_SECONDS = 5
 
 def _is_docker_unreachable(exc: Exception) -> bool:
     text = str(exc).lower()
-    return "pipe" in text or "connectionrefused" in text or "connection refused" in text
+    # "pipe" / "connection refused" cover Windows (named pipe) and an actively
+    # rejected socket connection. On macOS a stopped Docker Desktop typically
+    # presents as the socket *file* being absent instead -- a FileNotFoundError
+    # for the default docker.sock path/symlink, not a connection-level error --
+    # so that needs its own check or auto-start never triggers there.
+    return (
+        "pipe" in text
+        or "connectionrefused" in text
+        or "connection refused" in text
+        or "no such file or directory" in text
+        or "docker.sock" in text
+    )
 
 
 def _find_docker_desktop_windows_exe() -> str | None:

--- a/src/repo_scaffold/docker_ops.py
+++ b/src/repo_scaffold/docker_ops.py
@@ -50,11 +50,23 @@ def image_name(repo: str) -> str:
 # Docker client (lazy import so missing SDK gives a clear error at call time)
 # ---------------------------------------------------------------------------
 
-# Windows-only: Docker Desktop is not running as a service, so a stopped
-# daemon needs the GUI app launched before its API socket comes up.
-_DOCKER_DESKTOP_CANDIDATE_PATHS = [
+# Windows and macOS only: Docker Desktop on both platforms is a background GUI
+# app, not a system service, so a stopped daemon needs the app launched before
+# its API socket comes up.
+#
+# Linux is intentionally excluded. Docker there normally runs as a systemd
+# service, and starting a stopped one means `systemctl start docker` (or
+# `service docker start`) -- a real privilege-escalation step, not just
+# launching a user-space app. Most Linux dev/CI environments already have
+# dockerd running as a service. Auto-`sudo`-ing on a user's behalf is a
+# materially different risk than opening an app, so this stays out of scope
+# here (see #270).
+_DOCKER_DESKTOP_WINDOWS_CANDIDATE_PATHS = [
     r"C:\Program Files\Docker\Docker\Docker Desktop.exe",
     r"C:\ProgramData\DockerDesktop\Docker Desktop.exe",
+]
+_DOCKER_DESKTOP_MACOS_APP_PATHS = [
+    "/Applications/Docker.app",
 ]
 _DOCKER_DESKTOP_START_TIMEOUT_SECONDS = 90
 _DOCKER_DESKTOP_POLL_INTERVAL_SECONDS = 5
@@ -65,8 +77,15 @@ def _is_docker_unreachable(exc: Exception) -> bool:
     return "pipe" in text or "connectionrefused" in text or "connection refused" in text
 
 
-def _find_docker_desktop_exe() -> str | None:
-    for candidate in _DOCKER_DESKTOP_CANDIDATE_PATHS:
+def _find_docker_desktop_windows_exe() -> str | None:
+    for candidate in _DOCKER_DESKTOP_WINDOWS_CANDIDATE_PATHS:
+        if Path(candidate).exists():
+            return candidate
+    return None
+
+
+def _find_docker_desktop_macos_app() -> str | None:
+    for candidate in _DOCKER_DESKTOP_MACOS_APP_PATHS:
         if Path(candidate).exists():
             return candidate
     return None
@@ -85,21 +104,36 @@ def _wait_for_docker_ready(timeout: float) -> bool:
     return False
 
 
+def _docker_desktop_launch_args() -> list[str] | None:
+    """Return the subprocess args to launch Docker Desktop, or None if this
+    platform isn't supported or the app isn't installed at a known location."""
+    system = platform.system()
+
+    if system == "Windows":
+        exe = _find_docker_desktop_windows_exe()
+        return None if exe is None else [exe]
+
+    if system == "Darwin":
+        app = _find_docker_desktop_macos_app()
+        return None if app is None else ["open", "-a", "Docker"]
+
+    return None
+
+
 def _try_auto_start_docker_desktop() -> bool:
-    """Best-effort: launch Docker Desktop on Windows and wait for the daemon.
-
-    Returns True if the daemon became reachable, False otherwise. Never
-    raises -- callers fall back to the original connection error on failure.
-    """
-    if platform.system() != "Windows":
-        return False
-
-    exe = _find_docker_desktop_exe()
-    if exe is None:
+    """Best-effort: launch Docker Desktop on Windows/macOS and wait for the
+    daemon. Returns True if the daemon became reachable, False otherwise.
+    Never raises -- callers fall back to the original connection error on
+    failure. No-op on Linux and any platform without a known install path
+    (see the module-level comment above for why Linux is excluded)."""
+    launch_args = _docker_desktop_launch_args()
+    if launch_args is None:
         return False
 
     try:
-        subprocess.Popen([exe], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.Popen(
+            launch_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
     except Exception:
         return False
 

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -502,6 +502,23 @@ def test_is_docker_unreachable_unrelated_error() -> None:
     assert _is_docker_unreachable(Exception("permission denied")) is False
 
 
+def test_is_docker_unreachable_macos_missing_socket() -> None:
+    from repo_scaffold.docker_ops import _is_docker_unreachable
+
+    exc = Exception(
+        "Error while fetching server API version: "
+        "FileNotFoundError(2, 'No such file or directory')"
+    )
+    assert _is_docker_unreachable(exc) is True
+
+
+def test_is_docker_unreachable_docker_sock_mention() -> None:
+    from repo_scaffold.docker_ops import _is_docker_unreachable
+
+    exc = Exception("[Errno 2] No such file or directory: '/var/run/docker.sock'")
+    assert _is_docker_unreachable(exc) is True
+
+
 def test_find_docker_desktop_windows_exe_found() -> None:
     from repo_scaffold.docker_ops import (
         _DOCKER_DESKTOP_WINDOWS_CANDIDATE_PATHS,

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -501,36 +502,114 @@ def test_is_docker_unreachable_unrelated_error() -> None:
     assert _is_docker_unreachable(Exception("permission denied")) is False
 
 
-def test_find_docker_desktop_exe_found() -> None:
+def test_find_docker_desktop_windows_exe_found() -> None:
     from repo_scaffold.docker_ops import (
-        _DOCKER_DESKTOP_CANDIDATE_PATHS,
-        _find_docker_desktop_exe,
+        _DOCKER_DESKTOP_WINDOWS_CANDIDATE_PATHS,
+        _find_docker_desktop_windows_exe,
     )
 
     with patch("repo_scaffold.docker_ops.Path.exists", return_value=True):
-        assert _find_docker_desktop_exe() == _DOCKER_DESKTOP_CANDIDATE_PATHS[0]
+        assert (
+            _find_docker_desktop_windows_exe()
+            == _DOCKER_DESKTOP_WINDOWS_CANDIDATE_PATHS[0]
+        )
 
 
-def test_find_docker_desktop_exe_not_found() -> None:
-    from repo_scaffold.docker_ops import _find_docker_desktop_exe
+def test_find_docker_desktop_windows_exe_not_found() -> None:
+    from repo_scaffold.docker_ops import _find_docker_desktop_windows_exe
 
     with patch("repo_scaffold.docker_ops.Path.exists", return_value=False):
-        assert _find_docker_desktop_exe() is None
+        assert _find_docker_desktop_windows_exe() is None
 
 
-def test_auto_start_noop_on_non_windows() -> None:
-    from repo_scaffold.docker_ops import _try_auto_start_docker_desktop
+def test_find_docker_desktop_macos_app_found() -> None:
+    from repo_scaffold.docker_ops import (
+        _DOCKER_DESKTOP_MACOS_APP_PATHS,
+        _find_docker_desktop_macos_app,
+    )
+
+    with patch("repo_scaffold.docker_ops.Path.exists", return_value=True):
+        assert _find_docker_desktop_macos_app() == _DOCKER_DESKTOP_MACOS_APP_PATHS[0]
+
+
+def test_find_docker_desktop_macos_app_not_found() -> None:
+    from repo_scaffold.docker_ops import _find_docker_desktop_macos_app
+
+    with patch("repo_scaffold.docker_ops.Path.exists", return_value=False):
+        assert _find_docker_desktop_macos_app() is None
+
+
+def test_launch_args_windows_found() -> None:
+    from repo_scaffold.docker_ops import _docker_desktop_launch_args
+
+    with patch(
+        "repo_scaffold.docker_ops.platform.system", return_value="Windows"
+    ), patch(
+        "repo_scaffold.docker_ops._find_docker_desktop_windows_exe",
+        return_value="C:\\fake.exe",
+    ):
+        assert _docker_desktop_launch_args() == ["C:\\fake.exe"]
+
+
+def test_launch_args_windows_not_found() -> None:
+    from repo_scaffold.docker_ops import _docker_desktop_launch_args
+
+    with patch(
+        "repo_scaffold.docker_ops.platform.system", return_value="Windows"
+    ), patch(
+        "repo_scaffold.docker_ops._find_docker_desktop_windows_exe", return_value=None
+    ):
+        assert _docker_desktop_launch_args() is None
+
+
+def test_launch_args_macos_found() -> None:
+    from repo_scaffold.docker_ops import _docker_desktop_launch_args
+
+    with patch(
+        "repo_scaffold.docker_ops.platform.system", return_value="Darwin"
+    ), patch(
+        "repo_scaffold.docker_ops._find_docker_desktop_macos_app",
+        return_value="/Applications/Docker.app",
+    ):
+        assert _docker_desktop_launch_args() == ["open", "-a", "Docker"]
+
+
+def test_launch_args_macos_not_found() -> None:
+    from repo_scaffold.docker_ops import _docker_desktop_launch_args
+
+    with patch(
+        "repo_scaffold.docker_ops.platform.system", return_value="Darwin"
+    ), patch(
+        "repo_scaffold.docker_ops._find_docker_desktop_macos_app", return_value=None
+    ):
+        assert _docker_desktop_launch_args() is None
+
+
+def test_launch_args_linux_unsupported() -> None:
+    from repo_scaffold.docker_ops import _docker_desktop_launch_args
 
     with patch("repo_scaffold.docker_ops.platform.system", return_value="Linux"):
+        assert _docker_desktop_launch_args() is None
+
+
+def test_auto_start_noop_on_linux_never_calls_popen() -> None:
+    from repo_scaffold.docker_ops import _try_auto_start_docker_desktop
+
+    with patch("repo_scaffold.docker_ops.platform.system", return_value="Linux"), patch(
+        "repo_scaffold.docker_ops.subprocess.Popen"
+    ) as popen_mock:
         assert _try_auto_start_docker_desktop() is False
+        popen_mock.assert_not_called()
 
 
-def test_auto_start_noop_when_exe_missing() -> None:
+def test_auto_start_noop_when_windows_exe_missing() -> None:
     from repo_scaffold.docker_ops import _try_auto_start_docker_desktop
 
     with patch(
         "repo_scaffold.docker_ops.platform.system", return_value="Windows"
-    ), patch("repo_scaffold.docker_ops._find_docker_desktop_exe", return_value=None):
+    ), patch(
+        "repo_scaffold.docker_ops._find_docker_desktop_windows_exe", return_value=None
+    ):
         assert _try_auto_start_docker_desktop() is False
 
 
@@ -540,26 +619,53 @@ def test_auto_start_returns_false_when_popen_fails() -> None:
     with patch(
         "repo_scaffold.docker_ops.platform.system", return_value="Windows"
     ), patch(
-        "repo_scaffold.docker_ops._find_docker_desktop_exe", return_value="C:\\fake.exe"
+        "repo_scaffold.docker_ops._find_docker_desktop_windows_exe",
+        return_value="C:\\fake.exe",
     ), patch(
         "repo_scaffold.docker_ops.subprocess.Popen", side_effect=OSError("nope")
     ):
         assert _try_auto_start_docker_desktop() is False
 
 
-def test_auto_start_launches_and_waits() -> None:
+def test_auto_start_launches_and_waits_on_windows() -> None:
     from repo_scaffold.docker_ops import _try_auto_start_docker_desktop
 
     with patch(
         "repo_scaffold.docker_ops.platform.system", return_value="Windows"
     ), patch(
-        "repo_scaffold.docker_ops._find_docker_desktop_exe", return_value="C:\\fake.exe"
+        "repo_scaffold.docker_ops._find_docker_desktop_windows_exe",
+        return_value="C:\\fake.exe",
     ), patch(
         "repo_scaffold.docker_ops.subprocess.Popen"
-    ), patch(
+    ) as popen_mock, patch(
         "repo_scaffold.docker_ops._wait_for_docker_ready", return_value=True
     ) as wait_mock:
         assert _try_auto_start_docker_desktop() is True
+        popen_mock.assert_called_once_with(
+            ["C:\\fake.exe"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        wait_mock.assert_called_once()
+
+
+def test_auto_start_launches_and_waits_on_macos() -> None:
+    from repo_scaffold.docker_ops import _try_auto_start_docker_desktop
+
+    with patch(
+        "repo_scaffold.docker_ops.platform.system", return_value="Darwin"
+    ), patch(
+        "repo_scaffold.docker_ops._find_docker_desktop_macos_app",
+        return_value="/Applications/Docker.app",
+    ), patch(
+        "repo_scaffold.docker_ops.subprocess.Popen"
+    ) as popen_mock, patch(
+        "repo_scaffold.docker_ops._wait_for_docker_ready", return_value=True
+    ) as wait_mock:
+        assert _try_auto_start_docker_desktop() is True
+        popen_mock.assert_called_once_with(
+            ["open", "-a", "Docker"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         wait_mock.assert_called_once()
 
 


### PR DESCRIPTION
## 🧾 Title
Add macOS support to Docker auto-start, document Linux exclusion

## 🧠 Description
#266/#267 added Docker Desktop auto-start on connection failure, but it was Windows-only. macOS has the identical failure class -- Docker Desktop there is also a background GUI app, not a system service -- so the same launch-and-poll pattern applies via `open -a Docker`.

## 🧩 Changes Included
- [x] Added/updated documentation
- [x] Implemented new feature or enhancement
- [x] Refactored existing code
- [ ] Improved error handling or logging
- [ ] Updated environment configuration
- [ ] Other (specify)

## 🎯 Purpose
Close the portability gap CLAUDE.md's non-negotiable Portability section calls out ("Works on Windows, Linux, and Mac equally"). Renamed the Windows-only helpers and introduced `_docker_desktop_launch_args()` so the Windows/macOS/Linux dispatch lives in one place instead of being bolted onto Windows-specific names.

Linux is intentionally excluded, not silently skipped: Docker there is normally a systemd service, and starting a stopped one needs sudo (`systemctl start docker`) -- a real privilege-escalation step, not just launching a user-space app. Documented this explicitly in both code and docs.

## 🔗 Related Issues / Epics
- **Epic:** #48 (Agent Orchestrator Enablement)
- **Issue:** #270
- Closes #270

## 🧪 Testing
1. `poetry run pytest tests/test_docker_ops.py -q` -- full suite including new macOS launch/dispatch tests and a Linux no-op-never-calls-Popen test.
2. `poetry run tox -e coverage` -- `docker_ops.py` at 100%.
3. `poetry run tox -e precommit` -- full gate (format/lint/type/coverage) passes.

## 🧰 Developer Notes
- [x] Verify environment variables are configured properly
- [x] Ensure code runs under both local and CI/CD environments
- Can't test the actual macOS launch path on this (Windows) machine -- covered via mocked `platform.system()`/`subprocess.Popen`, mirroring the existing Windows test pattern from #267.
