### PR TITLE
fix(docker): recognize Windows CreateFile error as unreachable daemon (#272)

### DIFF
--- a/src/repo_scaffold/docker_ops.py
+++ b/src/repo_scaffold/docker_ops.py
@@ -79,12 +79,20 @@ def _is_docker_unreachable(exc: Exception) -> bool:
     # presents as the socket *file* being absent instead -- a FileNotFoundError
     # for the default docker.sock path/symlink, not a connection-level error --
     # so that needs its own check or auto-start never triggers there.
+    #
+    # The exact "cannot find the file specified" phrasing (not a bare
+    # "createfile" match) is required: pywin32's win32file.CreateFile() also
+    # raises for unrelated failures like access-denied pipe permissions, and a
+    # broad match would misdiagnose those as a stopped daemon, burning the
+    # full auto-start timeout on a problem restarting Docker Desktop can't fix.
+    # e.g.: "(2, 'CreateFile', 'The system cannot find the file specified.')"
     return (
         "pipe" in text
         or "connectionrefused" in text
         or "connection refused" in text
         or "no such file or directory" in text
         or "docker.sock" in text
+        or "the system cannot find the file specified" in text
     )
 
 

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -502,6 +502,30 @@ def test_is_docker_unreachable_unrelated_error() -> None:
     assert _is_docker_unreachable(Exception("permission denied")) is False
 
 
+def test_is_docker_unreachable_windows_createfile_error() -> None:
+    from repo_scaffold.docker_ops import _is_docker_unreachable
+
+    exc = Exception(
+        "Error while fetching server API version: "
+        "(2, 'CreateFile', 'The system cannot find the file specified.')"
+    )
+    assert _is_docker_unreachable(exc) is True
+
+
+def test_is_docker_unreachable_windows_createfile_access_denied_not_matched() -> None:
+    """A CreateFile failure that isn't "file not found" (e.g. a pipe
+    permissions problem) must not be misdiagnosed as a stopped daemon --
+    restarting Docker Desktop won't fix an access-denied error, and treating
+    it as unreachable just burns the full auto-start timeout."""
+    from repo_scaffold.docker_ops import _is_docker_unreachable
+
+    exc = Exception(
+        "Error while fetching server API version: "
+        "(5, 'CreateFile', 'Access is denied.')"
+    )
+    assert _is_docker_unreachable(exc) is False
+
+
 def test_is_docker_unreachable_macos_missing_socket() -> None:
     from repo_scaffold.docker_ops import _is_docker_unreachable
 


### PR DESCRIPTION
## 🧾 Title
Recognize Windows CreateFile error as unreachable daemon

## 🧠 Description
`_is_docker_unreachable()` recognizes several daemon-down error shapes but not
pywin32 `win32file.CreateFile()` failures against the Docker Desktop named pipe --
a different message shape than the generic pipe/connection-refused text already
handled:

```
Error while fetching server API version: (2, 'CreateFile', 'The system cannot find the file specified.')
```

Reproduced live: Docker Desktop had stopped running mid-session, and every
`repo-scaffold docker` command hit this exact error and raised immediately without
ever attempting `_try_auto_start_docker_desktop()` -- defeating the whole point of
the auto-start feature from #266/#267.

## 🧩 Changes Included
- [x] Refactored existing code (one additional OR branch in `_is_docker_unreachable`)

## 🎯 Purpose
Make Windows auto-start actually fire for this real, reproduced failure mode.

## 🔗 Related Issues / Epics
- **Epic:** #48
- **Issue:** #272
- Closes #272

## 🧪 Testing
1. New unit test with the exact reproduced error text
2. `poetry run tox -e precommit` -- black/ruff/mypy/pytest+coverage all green

## 🧰 Developer Notes
- This is the Windows-side equivalent of the macOS socket-not-found fix on the
  still-open #271 (unmerged). Both touch `_is_docker_unreachable`; whichever merges
  second will need a small rebase.
- Built entirely via `docker build-base` + `docker spin-up` + `docker exec`/`docker cp`
  against a container cloned from the real `origin/main` -- local checkout never left
  `main`.
