### PR TITLE
docs(agents): add explicit Execution SOP for ticket -> PR ordering (#278)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,6 +326,16 @@ be checked manually.
 
 ---
 
+## Execution SOP
+
+Deciding to execute means, in this order: **create a ticket -> work the ticket -> open a PR -> link both.**
+
+- No implementation work starts without an issue to trace it to. If one doesn't exist, file it first (after searching open AND closed issues for overlap, per Standing rules).
+- The PR that implements a ticket must reference it in both places: the PR title ends with `(#NNN)`, and the PR body links it via `Closes #NNN` (or `Related Issues / Epics` in the target repo's own template).
+- This holds even for small or "obvious" fixes -- there is no size threshold below which the ticket step is skipped.
+
+---
+
 ## Review thread SOP
 
 For every review thread on a PR you are working on, complete ALL four steps in order:
@@ -401,7 +411,7 @@ poetry run repo-scaffold issue label --repo OWNER/REPO --issue-number N --add ep
 poetry run repo-scaffold issue sync-hierarchy --repo OWNER/REPO --apply
 ```
 
-This file is the canonical agent reference. All other docs (CLAUDE.md, docs/WORKFLOW.md, .claude/prompt.md) defer to it for branch naming, PR conventions, and review SOP.
+This file is the canonical agent reference. All other docs (CLAUDE.md, docs/WORKFLOW.md, .claude/prompt.md) defer to it for branch naming, PR conventions, execution SOP, and review SOP.
 
 See [CLAUDE.md](CLAUDE.md) for portability and agnosticism requirements.
 See [examples/README.md](examples/README.md) for backlog and ticket format examples.


### PR DESCRIPTION
## 🧾 Title
docs(agents): add explicit Execution SOP for ticket -> PR ordering

## 🧠 Description
AGENTS.md's "How to contribute" section implies ticket-before-PR ordering through its step numbering, and WORKFLOW.md's Golden rules has "One issue = one PR" -- but neither states outright, as a standalone non-negotiable rule, that a ticket must exist *before* any implementation work or PR is opened. This PR adds that as its own explicit section.

## 🧩 Changes Included
- [x] Added/updated documentation

## 🎯 Purpose
Make the ticket -> work -> PR -> link ordering an explicit, unambiguous rule in AGENTS.md rather than something only inferable from step numbering elsewhere -- so it reads the same way the other non-negotiable SOPs/Standing rules do.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #278
- Closes #278

## 🧪 Testing
1. Read AGENTS.md top to bottom.
2. Confirm the new `## Execution SOP` section appears between `## Reading all PR feedback`/`## Review thread SOP`, grouped with the other procedural SOP.
3. Confirm it doesn't duplicate or contradict "How to contribute" or "Standing rules" -- it's a short explicit statement of an ordering that was previously only implied.
4. Confirm the closing canonical-reference line now also mentions "execution SOP".

## 🧰 Developer Notes
- Docs-only change, no source touched -- `tox -e precommit` passes (74.98% coverage, no drop).
