### PR TITLE
feat(sync): add check/sync templates for downstream template drift (#280)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,14 @@ poetry run repo-scaffold check rules --repo OWNER/REPO
 # PRs, this opens a branch + PR for it instead of just warning -- check for and merge that PR.
 poetry run repo-scaffold apply rules --repo OWNER/REPO --apply
 
+# Check issue/PR templates for drift against repo-scaffold's current templates
+poetry run repo-scaffold check templates --repo OWNER/REPO [--repos a,b | --all]
+
+# For every drifted repo, open a branch + PR with the updated templates -- never commits
+# to the default branch directly, the same way Dependabot always opens a PR rather than
+# pushing to main. These PRs are intentionally ticket-less (see Execution SOP).
+poetry run repo-scaffold sync templates --repo OWNER/REPO [--repos a,b | --all] [--yes]
+
 # Archive a repo (read-only; reversible via the GitHub UI)
 # Prompts for confirmation unless --yes is passed; refuses in a non-interactive shell without --yes.
 poetry run repo-scaffold repo archive --repo OWNER/REPO [--yes]
@@ -333,6 +341,7 @@ Deciding to execute means, in this order: **create a ticket -> work the ticket -
 - No implementation work starts without an issue to trace it to. If one doesn't exist, file it first (after searching open AND closed issues for overlap, per Standing rules).
 - The PR that implements a ticket must reference it in both places: the PR title ends with `(#NNN)`, and the PR body links it via `Closes #NNN` (or `Related Issues / Epics` in the target repo's own template).
 - This holds even for small or "obvious" fixes -- there is no size threshold below which the ticket step is skipped.
+- **Exception: automated maintenance PRs opened directly by repo-scaffold's own tooling** (e.g. `sync templates`, the dependabot.yml PR fallback in `apply rules`) are exempt. These are fully mechanical -- the change is entirely determined by repo-scaffold's own canonical source, no judgment call is being tracked -- the same way Dependabot itself never files a ticket before opening a PR. Agent-driven work is never exempt; this applies only to repo-scaffold's own bot-like automation.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,13 @@ poetry run repo-scaffold check rules --repo OWNER/REPO
 # branch + PR for it instead of just warning -- check for and merge that PR.
 poetry run repo-scaffold apply rules --repo OWNER/REPO --apply
 
+# Check issue/PR templates for drift against repo-scaffold's current templates
+poetry run repo-scaffold check templates --repo OWNER/REPO [--repos a,b | --all]
+
+# Open a branch + PR per drifted repo with updated templates -- never commits directly
+# to the default branch. Ticket-less by design, like Dependabot (see AGENTS.md Execution SOP).
+poetry run repo-scaffold sync templates --repo OWNER/REPO [--repos a,b | --all] [--yes]
+
 # Archive a repo (read-only; reversible via the GitHub UI). Prompts for confirmation
 # unless --yes is passed; refuses in a non-interactive shell without --yes.
 poetry run repo-scaffold repo archive --repo OWNER/REPO [--yes]

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -60,6 +60,7 @@ from .create_ops import (
     CreateSummary,
     SettingsCheckSummary,
     TemplatesCheckSummary,
+    TemplatesSyncResult,
     apply_repository_settings,
     check_repository_settings,
     check_repository_templates,
@@ -2331,16 +2332,22 @@ def main(argv: list[str] | None = None) -> int:
             print(targets_error, file=sys.stderr)
             return 2
         total_drifted = 0
+        errors = 0
         for target_repo, repo_dir in targets:
-            templates_summary: TemplatesCheckSummary = check_repository_templates(
-                repo_dir=repo_dir,
-                repo=target_repo,
-                out=print,
-            )
+            try:
+                templates_summary: TemplatesCheckSummary = check_repository_templates(
+                    repo_dir=repo_dir,
+                    repo=target_repo,
+                    out=print,
+                )
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+                errors += 1
+                continue
             status = "DRIFT" if templates_summary.drifted_files else "PASS"
             print(f"{status}  {target_repo}")
             total_drifted += len(templates_summary.drifted_files)
-        return 1 if total_drifted > 0 else 0
+        return 1 if (total_drifted > 0 or errors) else 0
 
     if ns.mode == "check" and ns.check_command == "settings":
         langs = (
@@ -2551,23 +2558,29 @@ def main(argv: list[str] | None = None) -> int:
             print(targets_error, file=sys.stderr)
             return 2
 
-        drifted_targets: list[tuple[str, Path, TemplatesCheckSummary]] = []
+        drifted_targets: list[tuple[str, Path]] = []
+        errors = 0
         for target_repo, repo_dir in targets:
-            templates_summary = check_repository_templates(
-                repo_dir=repo_dir, repo=target_repo, out=print
-            )
+            try:
+                templates_summary = check_repository_templates(
+                    repo_dir=repo_dir, repo=target_repo, out=print
+                )
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+                errors += 1
+                continue
             print(f"  {target_repo}: {len(templates_summary.drifted_files)} drifted")
             if templates_summary.drifted_files:
-                drifted_targets.append((target_repo, repo_dir, templates_summary))
+                drifted_targets.append((target_repo, repo_dir))
 
         if not drifted_targets:
             print("")
             print("No drift found. Nothing to sync.")
-            return 0
+            return 1 if errors else 0
 
         print("")
         opened = 0
-        for target_repo, repo_dir, _summary in drifted_targets:
+        for target_repo, repo_dir in drifted_targets:
             if not ns.yes:
                 answer = (
                     input(f"Open sync PR for {target_repo}? [y/N] ").strip().lower()
@@ -2575,20 +2588,26 @@ def main(argv: list[str] | None = None) -> int:
                 if answer != "y":
                     print(f"Skipped {target_repo}.")
                     continue
-            sync_repository_templates(
-                repo_dir=repo_dir,
-                repo=target_repo,
-                out=print,
-                warn=lambda line: print(line, file=sys.stderr),
-            )
-            opened += 1
+            try:
+                sync_result: TemplatesSyncResult = sync_repository_templates(
+                    repo_dir=repo_dir,
+                    repo=target_repo,
+                    out=print,
+                    warn=lambda line: print(line, file=sys.stderr),
+                )
+            except RuntimeError as exc:
+                print(str(exc), file=sys.stderr)
+                errors += 1
+                continue
+            if sync_result.pr_url is not None:
+                opened += 1
 
         print("")
         print("Summary:")
         print(f"  repos checked: {len(targets)}")
         print(f"  repos drifted: {len(drifted_targets)}")
         print(f"  sync PRs opened: {opened}")
-        return 0
+        return 1 if errors else 0
 
     if ns.mode == "project":
         repo_dir = Path(ns.path)

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -59,10 +59,13 @@ from .backlog_import import build_backlog_import_file
 from .create_ops import (
     CreateSummary,
     SettingsCheckSummary,
+    TemplatesCheckSummary,
     apply_repository_settings,
     check_repository_settings,
+    check_repository_templates,
     create_repository,
     sync_repository_ruleset,
+    sync_repository_templates,
 )
 from .delete_ops import DeleteSummary, delete_repositories
 from .generator import (
@@ -707,7 +710,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     check_sub = check.add_subparsers(
         dest="check_command",
-        metavar="{rules,settings}",
+        metavar="{rules,templates,settings}",
         required=True,
     )
     check_rules = check_sub.add_parser(
@@ -719,6 +722,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--repos", help="Comma-separated registered repos (owner/repo,owner/repo)"
     )
     check_rules.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_repos",
+        help="Target every repo in the local registry",
+    )
+
+    check_templates_cmd = check_sub.add_parser(
+        "templates",
+        help="Check issue/PR templates for drift against repo-scaffold's current templates",
+    )
+    check_templates_cmd.add_argument("--repo", help="Target GitHub repo (owner/repo)")
+    check_templates_cmd.add_argument(
+        "--repos", help="Comma-separated registered repos (owner/repo,owner/repo)"
+    )
+    check_templates_cmd.add_argument(
         "--all",
         action="store_true",
         dest="all_repos",
@@ -808,7 +826,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sync_sub = sync_cmd.add_subparsers(
         dest="sync_command",
-        metavar="{rules}",
+        metavar="{rules,templates}",
         required=True,
     )
     sync_rules_cmd = sync_sub.add_parser(
@@ -829,6 +847,29 @@ def build_parser() -> argparse.ArgumentParser:
         "--yes",
         action="store_true",
         help="Skip the per-repo confirmation prompt and apply all drifted repos",
+    )
+
+    sync_templates_cmd = sync_sub.add_parser(
+        "templates",
+        help=(
+            "Check issue/PR templates for drift, then open a PR per drifted repo "
+            "with the updated templates (never commits to the default branch directly)"
+        ),
+    )
+    sync_templates_cmd.add_argument("--repo", help="Target GitHub repo (owner/repo)")
+    sync_templates_cmd.add_argument(
+        "--repos", help="Comma-separated registered repos (owner/repo,owner/repo)"
+    )
+    sync_templates_cmd.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_repos",
+        help="Target every repo in the local registry",
+    )
+    sync_templates_cmd.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the per-repo confirmation prompt and open PRs for all drifted repos",
     )
 
     project_cmd = subparsers.add_parser(
@@ -2284,6 +2325,23 @@ def main(argv: list[str] | None = None) -> int:
             total_failed += check_summary.failed
         return 1 if total_failed > 0 else 0
 
+    if ns.mode == "check" and ns.check_command == "templates":
+        targets, targets_error = _resolve_repo_targets(ns)
+        if targets_error:
+            print(targets_error, file=sys.stderr)
+            return 2
+        total_drifted = 0
+        for target_repo, repo_dir in targets:
+            templates_summary: TemplatesCheckSummary = check_repository_templates(
+                repo_dir=repo_dir,
+                repo=target_repo,
+                out=print,
+            )
+            status = "DRIFT" if templates_summary.drifted_files else "PASS"
+            print(f"{status}  {target_repo}")
+            total_drifted += len(templates_summary.drifted_files)
+        return 1 if total_drifted > 0 else 0
+
     if ns.mode == "check" and ns.check_command == "settings":
         langs = (
             _parse_languages_or_die(parser, ns.languages)
@@ -2486,6 +2544,51 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  repos drifted: {len(drifted)}")
         print(f"  repos applied: {applied}")
         return 1 if errors else 0
+
+    if ns.mode == "sync" and ns.sync_command == "templates":
+        targets, targets_error = _resolve_repo_targets(ns)
+        if targets_error:
+            print(targets_error, file=sys.stderr)
+            return 2
+
+        drifted_targets: list[tuple[str, Path, TemplatesCheckSummary]] = []
+        for target_repo, repo_dir in targets:
+            templates_summary = check_repository_templates(
+                repo_dir=repo_dir, repo=target_repo, out=print
+            )
+            print(f"  {target_repo}: {len(templates_summary.drifted_files)} drifted")
+            if templates_summary.drifted_files:
+                drifted_targets.append((target_repo, repo_dir, templates_summary))
+
+        if not drifted_targets:
+            print("")
+            print("No drift found. Nothing to sync.")
+            return 0
+
+        print("")
+        opened = 0
+        for target_repo, repo_dir, _summary in drifted_targets:
+            if not ns.yes:
+                answer = (
+                    input(f"Open sync PR for {target_repo}? [y/N] ").strip().lower()
+                )
+                if answer != "y":
+                    print(f"Skipped {target_repo}.")
+                    continue
+            sync_repository_templates(
+                repo_dir=repo_dir,
+                repo=target_repo,
+                out=print,
+                warn=lambda line: print(line, file=sys.stderr),
+            )
+            opened += 1
+
+        print("")
+        print("Summary:")
+        print(f"  repos checked: {len(targets)}")
+        print(f"  repos drifted: {len(drifted_targets)}")
+        print(f"  sync PRs opened: {opened}")
+        return 0
 
     if ns.mode == "project":
         repo_dir = Path(ns.path)

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -20,7 +20,6 @@ from .github_api import (
     rest as _github_rest,
     token_from_repo as _token_from_repo,
 )
-from .overwrite_policy import OverwritePolicy, apply_files
 
 
 @dataclass(frozen=True)
@@ -45,6 +44,12 @@ class SettingsCheckSummary:
 class TemplatesCheckSummary:
     repo: str
     drifted_files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TemplatesSyncResult:
+    summary: TemplatesCheckSummary
+    pr_url: str | None
 
 
 _API_VERSION = "2026-03-10"
@@ -661,49 +666,68 @@ def _ensure_dependabot_version_updates(
 _TEMPLATES_SYNC_BRANCH = "chore/sync-templates"
 
 
+def _normalize_template_content(content: str) -> str:
+    return content.rstrip("\n") + "\n"
+
+
+def _fetch_remote_default_branch(
+    *, repo_dir: Path, env: dict[str, str], repo: str
+) -> str:
+    repo_info = _get_repo_info(repo_dir=repo_dir, env=env, repo=repo)
+    return str(repo_info.get("default_branch") or "main")
+
+
+def _fetch_remote_template_content(
+    *, repo: str, rel_path: str, ref: str, token: str
+) -> str | None:
+    """Fetch a file's content from the given ref via the contents API.
+    Returns None if the file doesn't exist on that ref (or the response
+    can't be decoded), which is treated as drift (would be a CREATE)."""
+    get_cp = _github_rest("GET", f"/repos/{repo}/contents/{rel_path}?ref={ref}", token)
+    if get_cp.returncode not in (0, 200):
+        return None
+    try:
+        payload = json.loads(get_cp.stdout)
+        encoded = str(payload.get("content", "")).replace("\n", "")
+        return base64.b64decode(encoded).decode("utf-8")
+    except (json.JSONDecodeError, AttributeError, UnicodeDecodeError, ValueError):
+        return None
+
+
 def _check_templates(
     *,
     repo_dir: Path,
+    env: dict[str, str],
     repo: str,
+    default_branch: str,
     out: Callable[[str], None],
 ) -> TemplatesCheckSummary:
+    """Compare repo-scaffold's current canonical templates against the
+    target repository's remote default branch -- not the local working
+    tree, which may be stale, on another branch, or carry local edits."""
     owner, _, name = repo.partition("/")
-    resolved_repo_dir = repo_dir.resolve()
-    files = build_template_files(
-        resolved_repo_dir, owner=owner or None, name=name or None
+    files = build_template_files(repo_dir, owner=owner or None, name=name or None)
+    token = (
+        _token_from_repo(repo_dir)
+        or env.get("GH_TOKEN")
+        or env.get("GITHUB_TOKEN")
+        or ""
     )
 
     statuses: dict[str, str] = {}
+    for file in files:
+        rel_path = file.path.relative_to(repo_dir).as_posix()
+        desired = _normalize_template_content(file.content)
+        remote = _fetch_remote_template_content(
+            repo=repo, rel_path=rel_path, ref=default_branch, token=token
+        )
+        statuses[rel_path] = "PASS" if remote == desired else "DRIFT"
 
-    def _capture(line: str) -> None:
-        parts = line.split(None, 1)
-        if len(parts) != 2:
-            return
-        status, rest = parts
-        raw_display = rest.split(" (", 1)[0].strip()
-        try:
-            display = (
-                Path(raw_display).resolve().relative_to(resolved_repo_dir).as_posix()
-            )
-        except ValueError:
-            display = raw_display
-        if status in ("OVERWRITE", "CREATE"):
-            statuses[display] = "DRIFT"
-        elif status == "SKIP":
-            statuses[display] = "PASS"
-
-    apply_files(
-        files,
-        OverwritePolicy(dry_run=True, yes=True),
-        is_tty=False,
-        out=_capture,
-    )
-
-    for display in sorted(statuses):
-        out(f"{statuses[display]:5} template: {display}")
+    for rel_path in sorted(statuses):
+        out(f"{statuses[rel_path]:5} template: {rel_path}")
 
     drifted = tuple(
-        display for display in sorted(statuses) if statuses[display] == "DRIFT"
+        rel_path for rel_path in sorted(statuses) if statuses[rel_path] == "DRIFT"
     )
     return TemplatesCheckSummary(repo=repo, drifted_files=drifted)
 
@@ -835,10 +859,13 @@ def _sync_templates(
     repo: str,
     out: Callable[[str], None],
     warn: Callable[[str], None],
-) -> TemplatesCheckSummary:
-    summary = _check_templates(repo_dir=repo_dir, repo=repo, out=out)
+) -> TemplatesSyncResult:
+    default_branch = _fetch_remote_default_branch(repo_dir=repo_dir, env=env, repo=repo)
+    summary = _check_templates(
+        repo_dir=repo_dir, env=env, repo=repo, default_branch=default_branch, out=out
+    )
     if not summary.drifted_files:
-        return summary
+        return TemplatesSyncResult(summary=summary, pr_url=None)
 
     owner, _, name = repo.partition("/")
     files = build_template_files(repo_dir, owner=owner or None, name=name or None)
@@ -849,10 +876,7 @@ def _sync_templates(
         if rel_path in by_path
     ]
 
-    repo_info = _get_repo_info(repo_dir=repo_dir, env=env, repo=repo)
-    default_branch = str(repo_info.get("default_branch") or "main")
-
-    _open_templates_sync_pr(
+    pr_url = _open_templates_sync_pr(
         repo_dir=repo_dir,
         env=env,
         repo=repo,
@@ -861,7 +885,7 @@ def _sync_templates(
         out=out,
         warn=warn,
     )
-    return summary
+    return TemplatesSyncResult(summary=summary, pr_url=pr_url)
 
 
 def check_repository_templates(
@@ -873,7 +897,11 @@ def check_repository_templates(
     _ensure_tools()
     env = _build_env(repo_dir)
     _ensure_gh_auth(repo_dir, env)
-    return _check_templates(repo_dir=repo_dir.resolve(), repo=repo, out=out)
+    resolved = repo_dir.resolve()
+    default_branch = _fetch_remote_default_branch(repo_dir=resolved, env=env, repo=repo)
+    return _check_templates(
+        repo_dir=resolved, env=env, repo=repo, default_branch=default_branch, out=out
+    )
 
 
 def sync_repository_templates(
@@ -882,7 +910,7 @@ def sync_repository_templates(
     repo: str,
     out: Callable[[str], None] = print,
     warn: Callable[[str], None] | None = None,
-) -> TemplatesCheckSummary:
+) -> TemplatesSyncResult:
     _ensure_tools()
     env = _build_env(repo_dir)
     _ensure_gh_auth(repo_dir, env)

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -11,6 +11,7 @@ from typing import Callable
 from urllib.parse import quote
 
 from .auth_tokens import is_placeholder_token, resolve_gh_token
+from .generator import build_template_files
 from .github_api import (
     branch_create as _github_branch_create,
     branch_get_sha as _github_branch_get_sha,
@@ -19,6 +20,7 @@ from .github_api import (
     rest as _github_rest,
     token_from_repo as _token_from_repo,
 )
+from .overwrite_policy import OverwritePolicy, apply_files
 
 
 @dataclass(frozen=True)
@@ -37,6 +39,12 @@ class SettingsCheckSummary:
     failed: int
     skipped: int
     drifts: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TemplatesCheckSummary:
+    repo: str
+    drifted_files: tuple[str, ...]
 
 
 _API_VERSION = "2026-03-10"
@@ -648,6 +656,240 @@ def _ensure_dependabot_version_updates(
         ):
             return
     warn(f"Warning: could not create {_DEPENDABOT_YML_PATH}: {feature_err}")
+
+
+_TEMPLATES_SYNC_BRANCH = "chore/sync-templates"
+
+
+def _check_templates(
+    *,
+    repo_dir: Path,
+    repo: str,
+    out: Callable[[str], None],
+) -> TemplatesCheckSummary:
+    owner, _, name = repo.partition("/")
+    resolved_repo_dir = repo_dir.resolve()
+    files = build_template_files(
+        resolved_repo_dir, owner=owner or None, name=name or None
+    )
+
+    statuses: dict[str, str] = {}
+
+    def _capture(line: str) -> None:
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            return
+        status, rest = parts
+        raw_display = rest.split(" (", 1)[0].strip()
+        try:
+            display = (
+                Path(raw_display).resolve().relative_to(resolved_repo_dir).as_posix()
+            )
+        except ValueError:
+            display = raw_display
+        if status in ("OVERWRITE", "CREATE"):
+            statuses[display] = "DRIFT"
+        elif status == "SKIP":
+            statuses[display] = "PASS"
+
+    apply_files(
+        files,
+        OverwritePolicy(dry_run=True, yes=True),
+        is_tty=False,
+        out=_capture,
+    )
+
+    for display in sorted(statuses):
+        out(f"{statuses[display]:5} template: {display}")
+
+    drifted = tuple(
+        display for display in sorted(statuses) if statuses[display] == "DRIFT"
+    )
+    return TemplatesCheckSummary(repo=repo, drifted_files=drifted)
+
+
+def _open_templates_sync_pr(
+    *,
+    repo_dir: Path,
+    env: dict[str, str],
+    repo: str,
+    default_branch: str,
+    files: list[tuple[str, str]],
+    out: Callable[[str], None],
+    warn: Callable[[str], None],
+) -> str | None:
+    """Open a branch + PR updating the given (relative_path, content) template
+    files. Never commits directly to the default branch -- mirrors how
+    Dependabot itself always opens a PR rather than pushing to main. Returns
+    the PR URL on success, None on failure."""
+    token = (
+        _token_from_repo(repo_dir)
+        or env.get("GH_TOKEN")
+        or env.get("GITHUB_TOKEN")
+        or ""
+    )
+    branch_name = _TEMPLATES_SYNC_BRANCH
+
+    branch_cp = _github_branch_create(repo, branch_name, token, base=default_branch)
+    already_exists = "already exists" in (branch_cp.stderr or "").lower()
+    if branch_cp.returncode not in (0, 201) and not already_exists:
+        warn(
+            f"Warning: could not create branch {branch_name}: {branch_cp.stderr.strip()}"
+        )
+        return None
+
+    if already_exists:
+        # A leftover branch from a previous run could carry stale commits --
+        # force it back to the current default-branch tip so this run always
+        # starts from a clean, known state instead of reusing whatever is there.
+        base_sha = _github_branch_get_sha(repo, default_branch, token)
+        if not base_sha:
+            warn(
+                f"Warning: could not resolve {default_branch} SHA to reset "
+                f"stale branch {branch_name}."
+            )
+            return None
+        reset_cp = _github_rest(
+            "PATCH",
+            f"/repos/{repo}/git/refs/heads/{branch_name}",
+            token,
+            {"sha": base_sha, "force": True},
+        )
+        if reset_cp.returncode not in (0, 200):
+            warn(
+                f"Warning: could not reset stale branch {branch_name}: {reset_cp.stderr.strip()}"
+            )
+            return None
+
+    changed: list[str] = []
+    for rel_path, content in files:
+        sha = None
+        get_cp = _github_rest(
+            "GET", f"/repos/{repo}/contents/{rel_path}?ref={branch_name}", token
+        )
+        if get_cp.returncode in (0, 200):
+            try:
+                sha = json.loads(get_cp.stdout).get("sha")
+            except (json.JSONDecodeError, AttributeError):
+                sha = None
+
+        payload: dict[str, object] = {
+            "message": "chore: sync issue/PR templates from repo-scaffold",
+            "content": base64.b64encode(content.encode()).decode(),
+            "branch": branch_name,
+        }
+        if sha:
+            payload["sha"] = sha
+
+        file_cp = _github_rest(
+            "PUT", f"/repos/{repo}/contents/{rel_path}", token, payload
+        )
+        if file_cp.returncode not in (0, 201):
+            warn(
+                f"Warning: could not write {rel_path} on {branch_name}: {file_cp.stderr.strip()}"
+            )
+            return None
+        changed.append(rel_path)
+
+    file_list = "\n".join(f"- `{path}`" for path in changed)
+    pr_body = (
+        "## \U0001f9fe Title\n"
+        "Sync issue/PR templates from repo-scaffold\n\n"
+        "## \U0001f9e0 Description\n"
+        "This PR was opened automatically by `repo-scaffold sync templates` because "
+        "one or more of this repo's issue/PR templates have drifted from the current "
+        "canonical versions repo-scaffold generates.\n\n"
+        "## \U0001f9e9 Changes Included\n"
+        "- [x] Added/updated documentation\n\n"
+        "## \U0001f3af Purpose\n"
+        "Keep downstream templates current with repo-scaffold's own templates, the same "
+        "way Dependabot keeps dependencies current -- never committed directly to the "
+        "default branch.\n\n"
+        f"## \U0001f517 Files Changed\n{file_list}"
+    )
+    pr_cp = _github_pr_create(
+        repo,
+        "chore: sync issue/PR templates from repo-scaffold",
+        pr_body,
+        branch_name,
+        default_branch,
+        token,
+    )
+    if pr_cp.returncode not in (0, 201):
+        warn(f"Warning: could not open PR for template sync: {pr_cp.stderr.strip()}")
+        return None
+
+    pr_url = ""
+    try:
+        pr_url = json.loads(pr_cp.stdout).get("html_url", "")
+    except (json.JSONDecodeError, AttributeError):
+        pass
+    out("Opened PR to sync templates" + (f": {pr_url}" if pr_url else "."))
+    return pr_url or ""
+
+
+def _sync_templates(
+    *,
+    repo_dir: Path,
+    env: dict[str, str],
+    repo: str,
+    out: Callable[[str], None],
+    warn: Callable[[str], None],
+) -> TemplatesCheckSummary:
+    summary = _check_templates(repo_dir=repo_dir, repo=repo, out=out)
+    if not summary.drifted_files:
+        return summary
+
+    owner, _, name = repo.partition("/")
+    files = build_template_files(repo_dir, owner=owner or None, name=name or None)
+    by_path = {f.path.relative_to(repo_dir).as_posix(): f for f in files}
+    pairs = [
+        (rel_path, by_path[rel_path].content)
+        for rel_path in summary.drifted_files
+        if rel_path in by_path
+    ]
+
+    repo_info = _get_repo_info(repo_dir=repo_dir, env=env, repo=repo)
+    default_branch = str(repo_info.get("default_branch") or "main")
+
+    _open_templates_sync_pr(
+        repo_dir=repo_dir,
+        env=env,
+        repo=repo,
+        default_branch=default_branch,
+        files=pairs,
+        out=out,
+        warn=warn,
+    )
+    return summary
+
+
+def check_repository_templates(
+    *,
+    repo_dir: Path,
+    repo: str,
+    out: Callable[[str], None] = print,
+) -> TemplatesCheckSummary:
+    _ensure_tools()
+    env = _build_env(repo_dir)
+    _ensure_gh_auth(repo_dir, env)
+    return _check_templates(repo_dir=repo_dir.resolve(), repo=repo, out=out)
+
+
+def sync_repository_templates(
+    *,
+    repo_dir: Path,
+    repo: str,
+    out: Callable[[str], None] = print,
+    warn: Callable[[str], None] | None = None,
+) -> TemplatesCheckSummary:
+    _ensure_tools()
+    env = _build_env(repo_dir)
+    _ensure_gh_auth(repo_dir, env)
+    emit_warn = warn if warn is not None else out
+    return _sync_templates(
+        repo_dir=repo_dir.resolve(), env=env, repo=repo, out=out, warn=emit_warn
+    )
 
 
 def _enable_security_and_analysis_feature(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4212,7 +4212,7 @@ def test_sync_templates_opens_pr_only_for_confirmed_drifted_repos(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     from repo_scaffold.registry_ops import RegistryEntry
-    from repo_scaffold.create_ops import TemplatesCheckSummary
+    from repo_scaffold.create_ops import TemplatesCheckSummary, TemplatesSyncResult
 
     monkeypatch.setattr(
         "repo_scaffold.cli.list_registry",
@@ -4232,8 +4232,11 @@ def test_sync_templates_opens_pr_only_for_confirmed_drifted_repos(
 
     def _fake_sync(*, repo_dir, repo, out, warn=None):
         synced.append(repo)
-        return TemplatesCheckSummary(
+        summary = TemplatesCheckSummary(
             repo=repo, drifted_files=(".github/pull_request_template.md",)
+        )
+        return TemplatesSyncResult(
+            summary=summary, pr_url=f"https://github.com/{repo}/pull/1"
         )
 
     monkeypatch.setattr("repo_scaffold.cli.check_repository_templates", _fake_check)
@@ -4277,3 +4280,110 @@ def test_sync_templates_no_drift_skips_pr(
     assert sync_called is False
     stdout = capsys.readouterr().out
     assert "No drift found" in stdout
+
+
+def test_sync_templates_does_not_count_failed_pr_open(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+    from repo_scaffold.create_ops import TemplatesCheckSummary, TemplatesSyncResult
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [RegistryEntry(repo="acme/drifted", local_path="/local/drifted")],
+    )
+    monkeypatch.setattr(
+        "repo_scaffold.cli.check_repository_templates",
+        lambda *, repo_dir, repo, out: TemplatesCheckSummary(
+            repo=repo, drifted_files=(".github/pull_request_template.md",)
+        ),
+    )
+    monkeypatch.setattr(
+        "repo_scaffold.cli.sync_repository_templates",
+        lambda *, repo_dir, repo, out, warn=None: TemplatesSyncResult(
+            summary=TemplatesCheckSummary(
+                repo=repo, drifted_files=(".github/pull_request_template.md",)
+            ),
+            pr_url=None,  # branch/write/PR-open failed inside sync_repository_templates
+        ),
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = main(["sync", "templates", "--all"])
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "sync PRs opened: 0" in stdout
+
+
+def test_check_templates_continues_after_repo_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+    from repo_scaffold.create_ops import TemplatesCheckSummary
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [
+            RegistryEntry(repo="acme/broken", local_path="/local/broken"),
+            RegistryEntry(repo="acme/clean", local_path="/local/clean"),
+        ],
+    )
+
+    checked: list[str] = []
+
+    def _fake_check(*, repo_dir, repo, out):
+        checked.append(repo)
+        if repo == "acme/broken":
+            raise RuntimeError("could not resolve repository metadata")
+        return TemplatesCheckSummary(repo=repo, drifted_files=())
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_templates", _fake_check)
+
+    rc = main(["check", "templates", "--all"])
+    assert rc == 1
+    assert checked == ["acme/broken", "acme/clean"]
+    stderr = capsys.readouterr().err
+    assert "could not resolve repository metadata" in stderr
+
+
+def test_sync_templates_continues_after_repo_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+    from repo_scaffold.create_ops import TemplatesCheckSummary, TemplatesSyncResult
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [
+            RegistryEntry(repo="acme/broken", local_path="/local/broken"),
+            RegistryEntry(repo="acme/drifted", local_path="/local/drifted"),
+        ],
+    )
+
+    def _fake_check(*, repo_dir, repo, out):
+        if repo == "acme/broken":
+            raise RuntimeError("auth failed")
+        return TemplatesCheckSummary(
+            repo=repo, drifted_files=(".github/pull_request_template.md",)
+        )
+
+    synced: list[str] = []
+
+    def _fake_sync(*, repo_dir, repo, out, warn=None):
+        synced.append(repo)
+        summary = TemplatesCheckSummary(
+            repo=repo, drifted_files=(".github/pull_request_template.md",)
+        )
+        return TemplatesSyncResult(
+            summary=summary, pr_url=f"https://github.com/{repo}/pull/1"
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_templates", _fake_check)
+    monkeypatch.setattr("repo_scaffold.cli.sync_repository_templates", _fake_sync)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = main(["sync", "templates", "--all"])
+    assert rc == 1
+    assert synced == ["acme/drifted"]
+    stdout = capsys.readouterr().out
+    assert "sync PRs opened: 1" in stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4156,3 +4156,124 @@ def test_docker_list_failure(
     rc = main(["docker", "list"])
     assert rc == 1
     assert "Failed to list" in capsys.readouterr().err
+
+
+def test_check_templates_with_all_flag_iterates_registry(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+    from repo_scaffold.create_ops import TemplatesCheckSummary
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [
+            RegistryEntry(repo="acme/drifted", local_path="/local/drifted"),
+            RegistryEntry(repo="acme/clean", local_path="/local/clean"),
+        ],
+    )
+
+    def _fake_check(*, repo_dir, repo, out):
+        drifted = (
+            (".github/pull_request_template.md",) if repo == "acme/drifted" else ()
+        )
+        return TemplatesCheckSummary(repo=repo, drifted_files=drifted)
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_templates", _fake_check)
+
+    rc = main(["check", "templates", "--all"])
+    assert rc == 1
+    stdout = capsys.readouterr().out
+    assert "DRIFT  acme/drifted" in stdout
+    assert "PASS  acme/clean" in stdout
+
+
+def test_check_templates_returns_zero_when_no_drift(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+    from repo_scaffold.create_ops import TemplatesCheckSummary
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [RegistryEntry(repo="acme/clean", local_path="/local/clean")],
+    )
+    monkeypatch.setattr(
+        "repo_scaffold.cli.check_repository_templates",
+        lambda *, repo_dir, repo, out: TemplatesCheckSummary(
+            repo=repo, drifted_files=()
+        ),
+    )
+
+    rc = main(["check", "templates", "--all"])
+    assert rc == 0
+
+
+def test_sync_templates_opens_pr_only_for_confirmed_drifted_repos(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+    from repo_scaffold.create_ops import TemplatesCheckSummary
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [
+            RegistryEntry(repo="acme/drifted", local_path="/local/drifted"),
+            RegistryEntry(repo="acme/clean", local_path="/local/clean"),
+        ],
+    )
+
+    def _fake_check(*, repo_dir, repo, out):
+        drifted = (
+            (".github/pull_request_template.md",) if repo == "acme/drifted" else ()
+        )
+        return TemplatesCheckSummary(repo=repo, drifted_files=drifted)
+
+    synced: list[str] = []
+
+    def _fake_sync(*, repo_dir, repo, out, warn=None):
+        synced.append(repo)
+        return TemplatesCheckSummary(
+            repo=repo, drifted_files=(".github/pull_request_template.md",)
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.check_repository_templates", _fake_check)
+    monkeypatch.setattr("repo_scaffold.cli.sync_repository_templates", _fake_sync)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = main(["sync", "templates", "--all"])
+    assert rc == 0
+    assert synced == ["acme/drifted"]
+    stdout = capsys.readouterr().out
+    assert "sync PRs opened: 1" in stdout
+
+
+def test_sync_templates_no_drift_skips_pr(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from repo_scaffold.registry_ops import RegistryEntry
+    from repo_scaffold.create_ops import TemplatesCheckSummary
+
+    monkeypatch.setattr(
+        "repo_scaffold.cli.list_registry",
+        lambda: [RegistryEntry(repo="acme/clean", local_path="/local/clean")],
+    )
+    monkeypatch.setattr(
+        "repo_scaffold.cli.check_repository_templates",
+        lambda *, repo_dir, repo, out: TemplatesCheckSummary(
+            repo=repo, drifted_files=()
+        ),
+    )
+
+    sync_called = False
+
+    def _fake_sync(**_kwargs):
+        nonlocal sync_called
+        sync_called = True
+
+    monkeypatch.setattr("repo_scaffold.cli.sync_repository_templates", _fake_sync)
+
+    rc = main(["sync", "templates", "--all"])
+    assert rc == 0
+    assert sync_called is False
+    stdout = capsys.readouterr().out
+    assert "No drift found" in stdout

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -2750,39 +2750,127 @@ def test_ensure_dependabot_version_updates_pr_fallback_handles_malformed_respons
     assert not any(line.startswith("WARN:") for line in out_lines)
 
 
-def test_check_templates_reports_drift_for_stale_template(tmp_path: Path) -> None:
-    github_dir = tmp_path / ".github"
-    github_dir.mkdir()
-    (github_dir / "pull_request_template.md").write_text(
-        "stale jira-style content\n", encoding="utf-8"
-    )
+def _fake_contents_get(rel_path_to_content: dict[str, str]) -> object:
+    import base64 as _b64
+
+    def _fake(
+        method: str, endpoint: str, token: str, data: object = None
+    ) -> subprocess.CompletedProcess[str]:
+        assert method == "GET"
+        # endpoint looks like /repos/acme/repo/contents/<rel_path>?ref=main
+        path_and_ref = endpoint.split("/contents/", 1)[1]
+        rel_path = path_and_ref.split("?", 1)[0]
+        if rel_path not in rel_path_to_content:
+            return subprocess.CompletedProcess(
+                args=[], returncode=404, stdout="", stderr="Not Found"
+            )
+        encoded = _b64.b64encode(rel_path_to_content[rel_path].encode()).decode()
+        return subprocess.CompletedProcess(
+            args=[], returncode=200, stdout=f'{{"content": "{encoded}"}}', stderr=""
+        )
+
+    return _fake
+
+
+def test_check_templates_reports_drift_for_stale_remote_template(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repo_scaffold.generator import build_template_files
+
+    files = build_template_files(tmp_path, owner="acme", name="repo")
+    remote = {f.path.relative_to(tmp_path).as_posix(): f.content for f in files}
+    # Simulate a stale remote pull_request_template.md -- everything else current.
+    remote[".github/pull_request_template.md"] = "stale jira-style content\n"
+
+    monkeypatch.setattr(create_ops, "_github_rest", _fake_contents_get(remote))
+    monkeypatch.setattr(create_ops, "_token_from_repo", lambda _: "tok")
 
     out_lines: list[str] = []
     summary = create_ops._check_templates(
-        repo_dir=tmp_path, repo="acme/repo", out=out_lines.append
+        repo_dir=tmp_path,
+        env={},
+        repo="acme/repo",
+        default_branch="main",
+        out=out_lines.append,
     )
 
-    assert ".github/pull_request_template.md" in summary.drifted_files
+    assert summary.drifted_files == (".github/pull_request_template.md",)
     assert any(
         line.startswith("DRIFT") and "pull_request_template.md" in line
         for line in out_lines
     )
 
 
-def test_check_templates_passes_when_up_to_date(tmp_path: Path) -> None:
+def test_check_templates_passes_when_remote_is_up_to_date(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     from repo_scaffold.generator import build_template_files
-    from repo_scaffold.overwrite_policy import OverwritePolicy, apply_files
 
     files = build_template_files(tmp_path, owner="acme", name="repo")
-    apply_files(files, OverwritePolicy(yes=True), is_tty=False, out=lambda _l: None)
+    remote = {f.path.relative_to(tmp_path).as_posix(): f.content for f in files}
+
+    monkeypatch.setattr(create_ops, "_github_rest", _fake_contents_get(remote))
+    monkeypatch.setattr(create_ops, "_token_from_repo", lambda _: "tok")
 
     out_lines: list[str] = []
     summary = create_ops._check_templates(
-        repo_dir=tmp_path, repo="acme/repo", out=out_lines.append
+        repo_dir=tmp_path,
+        env={},
+        repo="acme/repo",
+        default_branch="main",
+        out=out_lines.append,
     )
 
     assert summary.drifted_files == ()
     assert all(line.startswith("PASS") for line in out_lines if line.strip())
+
+
+def test_check_templates_treats_missing_remote_file_as_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No remote files at all -- every template is missing on the default branch.
+    monkeypatch.setattr(create_ops, "_github_rest", _fake_contents_get({}))
+    monkeypatch.setattr(create_ops, "_token_from_repo", lambda _: "tok")
+
+    summary = create_ops._check_templates(
+        repo_dir=tmp_path,
+        env={},
+        repo="acme/repo",
+        default_branch="main",
+        out=lambda _l: None,
+    )
+
+    assert ".github/pull_request_template.md" in summary.drifted_files
+
+
+def test_check_templates_ignores_local_working_tree_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale/uncommitted local checkout must not affect the result --
+    only the remote default branch content matters."""
+    from repo_scaffold.generator import build_template_files
+
+    github_dir = tmp_path / ".github"
+    github_dir.mkdir()
+    (github_dir / "pull_request_template.md").write_text(
+        "totally different local content that would look drifted\n",
+        encoding="utf-8",
+    )
+
+    files = build_template_files(tmp_path, owner="acme", name="repo")
+    remote = {f.path.relative_to(tmp_path).as_posix(): f.content for f in files}
+    monkeypatch.setattr(create_ops, "_github_rest", _fake_contents_get(remote))
+    monkeypatch.setattr(create_ops, "_token_from_repo", lambda _: "tok")
+
+    summary = create_ops._check_templates(
+        repo_dir=tmp_path,
+        env={},
+        repo="acme/repo",
+        default_branch="main",
+        out=lambda _l: None,
+    )
+
+    assert summary.drifted_files == ()
 
 
 def test_open_templates_sync_pr_writes_files_and_opens_pr(
@@ -2918,21 +3006,64 @@ def test_sync_templates_skips_pr_when_no_drift(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from repo_scaffold.generator import build_template_files
-    from repo_scaffold.overwrite_policy import OverwritePolicy, apply_files
 
     files = build_template_files(tmp_path, owner="acme", name="repo")
-    apply_files(files, OverwritePolicy(yes=True), is_tty=False, out=lambda _l: None)
+    remote = {f.path.relative_to(tmp_path).as_posix(): f.content for f in files}
+
+    def _fake_rest(
+        method: str, endpoint: str, token: str, data: object = None
+    ) -> subprocess.CompletedProcess[str]:
+        if method == "GET" and "/contents/" in endpoint:
+            return _fake_contents_get(remote)(method, endpoint, token, data)
+        raise AssertionError(f"unexpected {method} {endpoint} -- should not open a PR")
+
+    monkeypatch.setattr(create_ops, "_github_rest", _fake_rest)
+    monkeypatch.setattr(create_ops, "_token_from_repo", lambda _: "tok")
+    monkeypatch.setattr(
+        create_ops,
+        "_get_repo_info",
+        lambda *, repo_dir, env, repo: {"default_branch": "main"},
+    )
 
     def _fail_if_called(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("should not open a branch/PR when there is no drift")
 
     monkeypatch.setattr(create_ops, "_github_branch_create", _fail_if_called)
 
-    summary = create_ops._sync_templates(
+    result = create_ops._sync_templates(
         repo_dir=tmp_path,
         env={},
         repo="acme/repo",
         out=lambda _l: None,
         warn=lambda _l: None,
     )
-    assert summary.drifted_files == ()
+    assert result.summary.drifted_files == ()
+    assert result.pr_url is None
+
+
+def test_sync_templates_returns_pr_url_when_drifted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No remote files -- everything drifted -- forces the PR path.
+    monkeypatch.setattr(create_ops, "_github_rest", _fake_contents_get({}))
+    monkeypatch.setattr(create_ops, "_token_from_repo", lambda _: "tok")
+    monkeypatch.setattr(
+        create_ops,
+        "_get_repo_info",
+        lambda *, repo_dir, env, repo: {"default_branch": "main"},
+    )
+    monkeypatch.setattr(
+        create_ops,
+        "_open_templates_sync_pr",
+        lambda **_kwargs: "https://github.com/acme/repo/pull/9",
+    )
+
+    result = create_ops._sync_templates(
+        repo_dir=tmp_path,
+        env={},
+        repo="acme/repo",
+        out=lambda _l: None,
+        warn=lambda _l: None,
+    )
+    assert result.summary.drifted_files != ()
+    assert result.pr_url == "https://github.com/acme/repo/pull/9"

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -2748,3 +2748,191 @@ def test_ensure_dependabot_version_updates_pr_fallback_handles_malformed_respons
 
     assert any("opened one for .github/dependabot.yml." in line for line in out_lines)
     assert not any(line.startswith("WARN:") for line in out_lines)
+
+
+def test_check_templates_reports_drift_for_stale_template(tmp_path: Path) -> None:
+    github_dir = tmp_path / ".github"
+    github_dir.mkdir()
+    (github_dir / "pull_request_template.md").write_text(
+        "stale jira-style content\n", encoding="utf-8"
+    )
+
+    out_lines: list[str] = []
+    summary = create_ops._check_templates(
+        repo_dir=tmp_path, repo="acme/repo", out=out_lines.append
+    )
+
+    assert ".github/pull_request_template.md" in summary.drifted_files
+    assert any(
+        line.startswith("DRIFT") and "pull_request_template.md" in line
+        for line in out_lines
+    )
+
+
+def test_check_templates_passes_when_up_to_date(tmp_path: Path) -> None:
+    from repo_scaffold.generator import build_template_files
+    from repo_scaffold.overwrite_policy import OverwritePolicy, apply_files
+
+    files = build_template_files(tmp_path, owner="acme", name="repo")
+    apply_files(files, OverwritePolicy(yes=True), is_tty=False, out=lambda _l: None)
+
+    out_lines: list[str] = []
+    summary = create_ops._check_templates(
+        repo_dir=tmp_path, repo="acme/repo", out=out_lines.append
+    )
+
+    assert summary.drifted_files == ()
+    assert all(line.startswith("PASS") for line in out_lines if line.strip())
+
+
+def test_open_templates_sync_pr_writes_files_and_opens_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch_calls: list[tuple[str, str, str]] = []
+    get_calls: list[str] = []
+    put_calls: list[dict[str, object]] = []
+    pr_calls: list[tuple[str, str, str, str, str]] = []
+
+    def _fake_branch_create(
+        repo: str, name: str, token: str, base: str = "main"
+    ) -> subprocess.CompletedProcess[str]:
+        branch_calls.append((repo, name, base))
+        return subprocess.CompletedProcess(
+            args=[], returncode=201, stdout="{}", stderr=""
+        )
+
+    def _fake_github_rest(
+        method: str, endpoint: str, token: str, data: object = None
+    ) -> subprocess.CompletedProcess[str]:
+        if method == "GET":
+            get_calls.append(endpoint)
+            return subprocess.CompletedProcess(
+                args=[], returncode=200, stdout='{"sha": "abc123"}', stderr=""
+            )
+        put_calls.append({"method": method, "endpoint": endpoint, "data": data})
+        return subprocess.CompletedProcess(
+            args=[], returncode=201, stdout="{}", stderr=""
+        )
+
+    def _fake_pr_create(
+        repo: str, title: str, body: str, head: str, base: str, token: str
+    ) -> subprocess.CompletedProcess[str]:
+        pr_calls.append((repo, title, head, base, body))
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=201,
+            stdout='{"html_url": "https://github.com/acme/repo/pull/42"}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(create_ops, "_github_branch_create", _fake_branch_create)
+    monkeypatch.setattr(create_ops, "_github_rest", _fake_github_rest)
+    monkeypatch.setattr(create_ops, "_github_pr_create", _fake_pr_create)
+    monkeypatch.setattr(create_ops, "_token_from_repo", lambda _: "tok")
+
+    out_lines: list[str] = []
+    result = create_ops._open_templates_sync_pr(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        default_branch="main",
+        files=[(".github/pull_request_template.md", "new content\n")],
+        out=out_lines.append,
+        warn=lambda msg: out_lines.append(f"WARN:{msg}"),
+    )
+
+    assert result == "https://github.com/acme/repo/pull/42"
+    assert branch_calls == [("acme/repo", "chore/sync-templates", "main")]
+    assert (
+        put_calls[0]["endpoint"]
+        == "/repos/acme/repo/contents/.github/pull_request_template.md"
+    )
+    assert put_calls[0]["data"]["sha"] == "abc123"
+    assert pr_calls[0][2] == "chore/sync-templates"
+    assert pr_calls[0][3] == "main"
+
+
+def test_open_templates_sync_pr_resets_stale_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_branch_create(
+        repo: str, name: str, token: str, base: str = "main"
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=[], returncode=422, stdout="", stderr="Reference already exists"
+        )
+
+    def _fake_branch_get_sha(repo: str, branch: str, token: str) -> str:
+        return "def456"
+
+    reset_calls: list[dict[str, object]] = []
+
+    def _fake_github_rest(
+        method: str, endpoint: str, token: str, data: object = None
+    ) -> subprocess.CompletedProcess[str]:
+        if method == "PATCH":
+            reset_calls.append({"endpoint": endpoint, "data": data})
+            return subprocess.CompletedProcess(
+                args=[], returncode=200, stdout="{}", stderr=""
+            )
+        if method == "GET":
+            return subprocess.CompletedProcess(
+                args=[], returncode=200, stdout='{"sha": "abc"}', stderr=""
+            )
+        return subprocess.CompletedProcess(
+            args=[], returncode=201, stdout="{}", stderr=""
+        )
+
+    def _fake_pr_create(
+        repo: str, title: str, body: str, head: str, base: str, token: str
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=[], returncode=201, stdout='{"html_url": "https://x/pr/1"}', stderr=""
+        )
+
+    monkeypatch.setattr(create_ops, "_github_branch_create", _fake_branch_create)
+    monkeypatch.setattr(create_ops, "_github_branch_get_sha", _fake_branch_get_sha)
+    monkeypatch.setattr(create_ops, "_github_rest", _fake_github_rest)
+    monkeypatch.setattr(create_ops, "_github_pr_create", _fake_pr_create)
+    monkeypatch.setattr(create_ops, "_token_from_repo", lambda _: "tok")
+
+    result = create_ops._open_templates_sync_pr(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        default_branch="main",
+        files=[(".github/pull_request_template.md", "content\n")],
+        out=lambda _l: None,
+        warn=lambda _l: None,
+    )
+
+    assert result == "https://x/pr/1"
+    assert (
+        reset_calls[0]["endpoint"]
+        == "/repos/acme/repo/git/refs/heads/chore/sync-templates"
+    )
+    assert reset_calls[0]["data"] == {"sha": "def456", "force": True}
+
+
+def test_sync_templates_skips_pr_when_no_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repo_scaffold.generator import build_template_files
+    from repo_scaffold.overwrite_policy import OverwritePolicy, apply_files
+
+    files = build_template_files(tmp_path, owner="acme", name="repo")
+    apply_files(files, OverwritePolicy(yes=True), is_tty=False, out=lambda _l: None)
+
+    def _fail_if_called(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("should not open a branch/PR when there is no drift")
+
+    monkeypatch.setattr(create_ops, "_github_branch_create", _fail_if_called)
+
+    summary = create_ops._sync_templates(
+        repo_dir=tmp_path,
+        env={},
+        repo="acme/repo",
+        out=lambda _l: None,
+        warn=lambda _l: None,
+    )
+    assert summary.drifted_files == ()


### PR DESCRIPTION
## 🧾 Title
Add check/sync templates for downstream issue/PR template drift

## 🧠 Description
RepoScaffold generates issue templates (`epic.md`, `ticket.md`) and the PR template into every repo it scaffolds, but nothing tracked whether a downstream repo's copies had since drifted from the current canonical versions -- discovered concretely when `gallery-dl-wrapper`'s `pull_request_template.md` turned out to still use an old Jira-style `[GDW-XX]` format RepoScaffold no longer generates. Since RepoScaffold owns/generates these files, it should notice and fix this itself rather than relying on each downstream repo's maintainer to remember to run `apply templates` -- the same way Dependabot opens a PR when a dependency goes stale, never committing directly to the default branch.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement

## 🎯 Purpose
`check templates` / `sync templates` join `check rules` / `sync rules` as the second pair of drift-detect + batch-apply commands, operating across the local registry the same way.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #280
- Closes #280

## 🧪 Testing
1. `check templates --repo blairg23/gallery-dl-wrapper` run against a fresh isolated clone of that repo -- correctly flagged all 8 managed template files (`CODEOWNERS`, `ISSUE_TEMPLATE/{config.yml,epic.md,ticket.md}`, `pull_request_template.md`, 3 `validate-*.yml` workflows) as drifted.
2. `sync templates`/`_open_templates_sync_pr` validated with mocked GitHub API calls only (branch create/reset, contents write with correct `sha` for existing files, PR open) -- **not** run live against any real repo, since that would actually open a PR there.
3. `poetry run tox -e precommit` green: full suite passes, coverage 74.95% (unchanged from baseline, above the 70% floor).

## 🧰 Developer Notes
- `check templates` reuses the existing `build_template_files` + `overwrite_policy.apply_files(dry_run=True)` machinery already used by `apply templates` -- no new diffing logic, the dry-run OVERWRITE/SKIP/CREATE report *is* the drift signal.
- `sync templates` generalizes `_create_dependabot_yml_via_pr`'s branch-create-or-reset-to-current-default-branch-tip + contents-API-write + PR-open pattern to handle N files in one commit/PR instead of one hardcoded file. Unlike the dependabot fallback, there's no "try direct commit first" path -- it always opens a PR, matching real Dependabot behavior.
- New file writes via the contents API fetch the existing file's `sha` on the sync branch first, since these files already exist (unlike `dependabot.yml`, which that helper only ever creates fresh).
- No ticket was filed in `gallery-dl-wrapper` for the template fix itself, and `sync templates` wasn't run against it live in this PR -- intentional per the requesting conversation; this PR is tooling only.
