### PR TITLE
fix(dev): stop poetry adopting a shared in-project .venv across OSes (#282)

### DIFF
--- a/.claude/prompt.md
+++ b/.claude/prompt.md
@@ -5,17 +5,51 @@ You are an autonomous coding agent working on repo-scaffold tickets.
 For each ticket:
 
 1. Read the issue: `poetry run repo-scaffold issue view --repo OWNER/REPO --issue-number N`
-2. Create a worktree: `poetry run repo-scaffold workspace create --repo OWNER/REPO --branch type/NNN-short-description`
-3. Work inside `repos/{owner}/{repo}/type-NNN-short-description/` -- no approval needed, use any tool
-4. Run the full gate: `poetry run tox -e precommit`
-5. Commit with a subject + blank line + body (verbose, no one-liners)
-6. Push: `git push origin type/NNN-short-description`
-7. Open PR: `poetry run repo-scaffold pr create --repo OWNER/REPO --title "type(scope): description (#NNN)" --head type/NNN-short-description --body-file .github/pull_request_template.md`
-8. Add issue to project: `poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N`
-9. Link issue to parent epic: `poetry run repo-scaffold issue add-sub-issue --repo OWNER/REPO --parent EPIC_N --child N`
-10. Keep the PR in your active queue until it is merged -- do not consider a ticket done at push.
+2. Create the branch: `poetry run repo-scaffold branch create --repo OWNER/REPO --name type/NNN-short-description --from main`
+3. Spin up a container for it: `poetry run repo-scaffold docker spin-up --repo OWNER/REPO --branch type/NNN-short-description`
+4. Work inside the container (see "Container workflow" below) -- no approval needed, use any tool
+5. Run the full gate inside the container: `docker exec CONTAINER_NAME bash -c "cd /{repo-name} && poetry run tox -e precommit"`
+6. Commit inside the container with a subject + blank line + body (verbose, no one-liners)
+7. Push from inside the container: `docker exec CONTAINER_NAME bash -c "cd /{repo-name} && git push origin type/NNN-short-description"`
+8. Tear down the container: `poetry run repo-scaffold docker spin-down --repo OWNER/REPO --branch type/NNN-short-description`
+9. Open PR (safe to run locally, see below): `poetry run repo-scaffold pr create --repo OWNER/REPO --title "type(scope): description (#NNN)" --head type/NNN-short-description --body-file .github/pull_request_template.md`
+10. Add issue to project (safe locally): `poetry run repo-scaffold project item-add --project-title "TITLE" --repo OWNER/REPO --issue-number N`
+11. Link issue to parent epic (safe locally): `poetry run repo-scaffold issue add-sub-issue --repo OWNER/REPO --parent EPIC_N --child N`
+12. Keep the PR in your active queue until it is merged -- do not consider a ticket done at push.
 
 See [AGENTS.md](../AGENTS.md) for branch naming, PR title format, and review SOP -- it is the canonical reference.
+
+## What's safe to run locally (no container needed)
+
+The local checkout stays on `main` at all times -- never `git checkout -b` a feature
+branch on it directly. Pure GitHub API calls and Docker lifecycle commands never
+touch which branch is checked out locally, so they're safe to run directly against
+the local checkout: all `issue`/`pr`/`project` commands, `branch create`/`delete`/
+`rename`, and `docker build-base`/`spin-up`/`spin-down`/`list`.
+
+Only actual file edits, tests, commits, and pushes on a branch need to happen inside
+a container.
+
+## Container workflow (headless agents)
+
+`docker shell` execs into an interactive `-it` session and can't be driven
+turn-by-turn by a headless agent. Use the lifecycle commands directly instead:
+
+```bash
+poetry run repo-scaffold docker spin-up --repo OWNER/REPO --branch BRANCH
+
+# Run commands non-interactively
+docker exec CONTAINER_NAME bash -c "cd /{repo-name} && <command>"
+
+# Move files in/out -- the container has no host bind-mount (it cloned its own
+# copy), so file edits go through docker cp
+docker cp local_file.py CONTAINER_NAME:/{repo-name}/path/to/file.py
+docker cp CONTAINER_NAME:/{repo-name}/path/to/file.py local_file.py
+
+poetry run repo-scaffold docker spin-down --repo OWNER/REPO --branch BRANCH
+```
+
+Container names: `{repo-slug}-{branch-slug}`.
 
 ## PR Queue Monitoring (every session)
 
@@ -32,16 +66,16 @@ For each open PR:
 3. Check CI: `poetry run repo-scaffold pr checks --repo OWNER/REPO --pr-number N --json`
 4. For any failing check -- read annotations, fix, push.
 5. Check merge status: `poetry run repo-scaffold pr view --repo OWNER/REPO --pr-number N --json`
-6. If merged -- run `poetry run repo-scaffold workspace delete --repo OWNER/REPO --branch BRANCH` to clean up.
+6. If merged -- run `poetry run repo-scaffold docker spin-down --repo OWNER/REPO --branch BRANCH` to clean up, if a container is still running for it.
 
 A ticket is only done when `pr view` shows `merged_at` is set. Until then, it stays in the queue.
 
 ## Merge Conflict Resolution
 
-When `pr view` shows `mergeable: false` / `mergeable_state: dirty`, rebase the branch against main inside the worktree:
+When `pr view` shows `mergeable: false` / `mergeable_state: dirty`, rebase inside the container:
 
 ```bash
-# Inside repos/{owner}/{repo}/{branch-slug}/
+# Inside the container, at /{repo-name}
 git fetch origin
 git rebase origin/main
 # Fix any conflicts, then:
@@ -58,8 +92,8 @@ Rules:
 
 ## Rules
 
-- Work autonomously inside worktrees. The PR is the gate -- never ask permission for
-  edits, test runs, or git operations inside a worktree.
+- Work autonomously inside containers. The PR is the gate -- never ask permission for
+  edits, test runs, or git operations inside a container.
 - Never merge or close PRs. Only the repo owner does that.
 - Never use `gh` CLI. Use `poetry run repo-scaffold` for all GitHub operations.
 - Always use issue/PR templates (ticket.md, epic.md, pull_request_template.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,25 @@ a stopped one needs sudo (`systemctl start docker`) -- a real privilege-escalati
 not just launching a user-space app. Most Linux dev/CI environments already have
 `dockerd` running as a service; if yours doesn't, start it yourself first.
 
+### What needs a container (and what doesn't)
+
+Only actual branch work -- editing files, running tests, committing, pushing on a
+specific branch -- needs a container. The local checkout stays on `main`/`master`
+at all times; it's never checked out to a feature branch directly.
+
+Everything else is a pure GitHub API call or a Docker container-lifecycle command,
+neither of which touches which branch is checked out locally, so it's safe to run
+directly from the local checkout:
+
+- All `issue`/`pr`/`project` commands (create, view, list, comment, label, etc.)
+- `branch create`/`branch delete`/`branch rename` (these hit GitHub's API directly;
+  they don't touch local git state at all)
+- `docker build-base`/`docker spin-up`/`docker spin-down`/`docker list` (managing a
+  container's lifecycle doesn't require being inside one, or having the target
+  branch checked out locally)
+
+Only reach for a container once you're actually changing code.
+
 ### Per-repo container workflow (preferred)
 
 One command to get a shell inside an isolated container for any branch:
@@ -91,11 +110,48 @@ Both are host-side tools. Inside your container, your branch is already checked 
 `/{repo-name}`. Just work there: edit files, run tests, commit, push. No worktrees,
 no new containers, no workspace create.
 
+### Headless / non-interactive agents
+
+`docker shell` execs into an interactive `-it` session -- built for a human at a
+terminal, not something a scripted/headless agent can drive turn-by-turn. For
+headless agents, drive the container's lifecycle commands directly instead:
+
+```bash
+# Start the container (clones the branch, installs deps) without exec-ing in
+poetry run repo-scaffold docker spin-up --repo OWNER/REPO --branch BRANCH
+
+# Run commands non-interactively
+docker exec CONTAINER_NAME bash -c "cd /{repo-name} && poetry run pytest -q"
+
+# Move files in/out -- the container has no host bind-mount (it cloned its own
+# copy), so file edits go through docker cp, not a shared filesystem path
+docker cp local_file.py CONTAINER_NAME:/{repo-name}/path/to/file.py
+docker cp CONTAINER_NAME:/{repo-name}/path/to/file.py local_file.py
+
+# Commit and push from inside the container -- it has its own GH_TOKEN
+docker exec CONTAINER_NAME bash -c "cd /{repo-name} && git add -A && git commit -m '...' && git push origin BRANCH"
+
+# Tear down when done
+poetry run repo-scaffold docker spin-down --repo OWNER/REPO --branch BRANCH
+```
+
+Container names follow `{repo-slug}-{branch-slug}` (see below).
+
 ### Compose-based container (legacy)
 
-The Compose stack (`docker-compose.yml` + optional `docker-compose.override.yml`) runs
-a single long-lived container for the repo root. Prefer the per-repo container workflow
-above for branch work; the Compose stack is useful for quick interactive exploration.
+This is a different mechanism solving a different problem than the per-branch
+containers above. The Compose stack (`docker-compose.yml` + optional
+`docker-compose.override.yml`) runs a single long-lived container for the repo
+root, with the project bind-mounted so host edits are visible immediately -- it
+exists for running *all* tool execution inside one clean Linux environment with
+zero host-side poetry involvement at all. `poetry.toml` (`virtualenvs.in-project
+= false`, see `pyproject.toml`'s neighbor) already solves the specific
+Windows/WSL venv-collision problem this was originally built to work around, so
+plain `poetry run` on the host is fine for the "safe to run locally" commands
+above. Reach for Compose when you want a fully clean environment with no local
+Python/poetry involvement at all, not as the default.
+
+Prefer the per-repo container workflow above for actual branch work.
 
 ```bash
 docker compose build       # build the image

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,12 +324,13 @@ The issue number at the end is required so the PR is immediately traceable to it
 ## How to contribute
 
 1. Create or pick an issue from the [repo-scaffold Roadmap](https://github.com/users/blairg23/projects/6). Note the issue number (`NNN`).
-2. Branch off `main` using the `type/NNN-short-description` format:
+2. Create the branch (safe to run locally -- this hits GitHub's API directly, it doesn't touch the local checkout) and open a container for it:
    ```bash
-   git checkout main && git pull
-   git checkout -b feat/NNN-short-description
+   poetry run repo-scaffold branch create --repo blairg23/repo-scaffold --name feat/NNN-short-description --from main
+   poetry run repo-scaffold docker shell --repo blairg23/repo-scaffold --branch feat/NNN-short-description
    ```
-3. Make changes. Run the gate before committing:
+   The local checkout stays on `main` throughout -- see "What needs a container (and what doesn't)" above.
+3. Inside the container, make changes. Run the gate before committing:
    ```bash
    poetry run tox -e precommit
    ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,11 +330,14 @@ The issue number at the end is required so the PR is immediately traceable to it
    poetry run repo-scaffold docker shell --repo blairg23/repo-scaffold --branch feat/NNN-short-description
    ```
    The local checkout stays on `main` throughout -- see "What needs a container (and what doesn't)" above.
-3. Inside the container, make changes. Run the gate before committing:
+3. Inside the container, make changes and commit as usual. The `pre-commit`
+   hook (installed via `poetry run pre-commit install`, see README.md setup)
+   runs the full gate automatically:
    ```bash
-   poetry run tox -e precommit
+   poetry run tox -e precommit              # what the hook runs
    ```
-   If Black reformats files, re-stage them and re-run.
+   To get faster feedback before attempting a commit, run it manually first.
+   If Black reformats files, re-stage them and re-run (either way).
 4. Commit with a subject + blank line + body (see recent commits for style). No one-liners.
 5. Open a PR using the PR template. Title must follow `type(scope): description (#NNN)`:
    ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,17 @@ All GitHub operations (repos, issues, PRs, projects, backlog) are implemented vi
 
 # Branch Workflow
 
+## What needs a container vs. what's safe locally
+
+Only actual branch work -- editing files, running tests, committing, pushing on a
+specific branch -- needs a container. The local checkout stays on `main`/`master`
+always; never `git checkout -b` a feature branch directly on it.
+
+Everything else is a pure GitHub API call or a Docker lifecycle command and is
+safe to run directly against the local checkout: all `issue`/`pr`/`project`
+commands, `branch create`/`delete`/`rename`, and `docker build-base`/`spin-up`/
+`spin-down`/`list`. None of these touch which branch is checked out locally.
+
 ## How to work on branches
 
 Each branch gets its own isolated Docker container. The container clones the branch
@@ -197,6 +208,18 @@ poetry run repo-scaffold docker shell --repo OWNER/REPO --branch BRANCH
 
 # Add --rebuild if the Dockerfile changed
 poetry run repo-scaffold docker shell --repo OWNER/REPO --branch BRANCH --rebuild
+```
+
+`docker shell` execs into an interactive `-it` session -- it's built for a human at
+a terminal and can't be driven turn-by-turn by a headless/scripted agent. If you
+are a headless agent, use the lifecycle commands directly instead:
+
+```bash
+poetry run repo-scaffold docker spin-up --repo OWNER/REPO --branch BRANCH
+docker exec CONTAINER_NAME bash -c "cd /{repo-name} && poetry run pytest -q"
+docker cp local_file.py CONTAINER_NAME:/{repo-name}/path/to/file.py
+docker exec CONTAINER_NAME bash -c "cd /{repo-name} && git add -A && git commit -m '...' && git push origin BRANCH"
+poetry run repo-scaffold docker spin-down --repo OWNER/REPO --branch BRANCH
 ```
 
 All editing, testing, committing, and pushing happens inside the container.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,20 @@ poetry install
 
 ## Docker dev environment
 
-A Docker dev container provides a clean Linux environment for all tool execution,
-eliminating Windows/WSL venv conflicts. Credentials are bind-mounted at runtime --
-never baked into the image.
+There are two distinct Docker mechanisms in this repo -- don't confuse them:
+
+- **Per-branch containers** (`repo-scaffold docker shell`/`spin-up`/`build-base`,
+  see [AGENTS.md](AGENTS.md#docker-dev-environment)) -- one isolated container per
+  branch, for actual code changes. This is the default for branch work.
+- **This Compose-based single dev container** -- one long-lived container for the
+  whole repo root, useful when you want *all* tool execution to happen inside a
+  clean Linux environment with zero local Python/poetry involvement. It originally
+  existed to work around Windows/WSL venv collisions; `poetry.toml`
+  (`virtualenvs.in-project = false`) now fixes that at the source, so plain
+  `poetry run` on the host works fine for read-only/API commands too -- reach for
+  Compose when you specifically want a fully clean environment, not by default.
+
+Credentials are bind-mounted at runtime -- never baked into the image.
 
 **One-time setup:**
 
@@ -77,10 +88,8 @@ docker exec -it repo-scaffold-dev poetry run pytest -q                   # tests
   are visible inside the container immediately; no rebuild needed.
 - `.env` is accessible (and writable) inside the container via the root bind-mount.
   `GH_TOKEN` and all other env vars load automatically via `_seed_env_from_dotenv`.
-- Repo worktrees (`repos/`) are stored in a named volume (`repo-worktrees`) that persists
-  across `docker compose down` / `up` cycles.
 - Multiple agents can `docker exec` into the same running container concurrently -- all
-  persistent state lives on the host or in the named volume, not in the container layer.
+  persistent state lives on the host bind-mount, not in the container layer.
 
 **Windows note:** Docker Desktop for Windows must already be running for this
 Compose-based flow (raw `docker compose`/`docker exec`, not run through `repo-scaffold`).

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,7 +1,7 @@
 # Copy this file to docker-compose.override.yml (which is gitignored).
 # Bind-mounts the project root into /workspace so source edits are visible
-# inside the container without rebuilding. The named volume for repos/ is
-# preserved by the second entry. GH_TOKEN is read from .env via the root mount.
+# inside the container without rebuilding. GH_TOKEN is read from .env via
+# the root mount.
 #
 # Usage:
 #   cp docker-compose.override.yml.example docker-compose.override.yml
@@ -13,5 +13,4 @@ services:
   dev:
     volumes:
       - .:/workspace                    # live source edits + .env readable/writable
-      - repo-worktrees:/workspace/repos # named volume wins for git worktrees
       - /var/run/docker.sock:/var/run/docker.sock  # Docker socket passthrough for docker commands

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,6 @@ services:
     build: .
     image: repo-scaffold-dev:latest
     container_name: repo-scaffold-dev
-    volumes:
-      - repo-worktrees:/workspace/repos
     stdin_open: true
     tty: true
     command: bash
-
-volumes:
-  repo-worktrees:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,11 @@ services:
     stdin_open: true
     tty: true
     command: bash
+
+volumes:
+  # Kept for compatibility with any pre-existing local docker-compose.override.yml
+  # (gitignored) that still mounts this from before the repos/ worktree model was
+  # deprecated in favor of per-branch Docker containers (#238). No service in this
+  # tracked file references it anymore -- it's only declared so an old override
+  # referencing it doesn't fail Compose's undefined-volume validation.
+  repo-worktrees:

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,17 @@
+# Force poetry to always use its own OS-specific global cache
+# (%LOCALAPPDATA%\pypoetry\Cache\virtualenvs on Windows,
+# ~/.cache/pypoetry/virtualenvs under Linux/WSL/macOS) instead of ever
+# creating or adopting an in-project .venv/.
+#
+# This repo is worked on from more than one OS context against the same
+# physical files on disk (native Windows + WSL both pointed at the same
+# directory). A venv is not portable across that boundary -- it pins an
+# absolute interpreter path and platform-specific binaries. Poetry's default
+# fallback is to adopt whatever .venv/ already exists in the project root
+# regardless of this setting, so once any one OS creates it, every other OS
+# context that touches the repo corrupts it for the others. Forcing
+# in-project = false here means every OS keeps its own venv, keyed by
+# project name + path hash in poetry's own cache, and none of them ever
+# share a folder to collide on. See #282.
+[virtualenvs]
+in-project = false


### PR DESCRIPTION
## 🧾 Title
Stop poetry from adopting a shared in-project .venv across Windows/WSL boundaries

## 🧠 Description
This repo is worked on from more than one OS context against the same physical
files on disk -- native Windows and WSL both pointed at the same directory.
Poetry's fallback behavior is to adopt whatever `.venv/` already exists in the
project root, regardless of the `virtualenvs.in-project` setting. A venv pins an
absolute interpreter path and platform-specific binaries, so it isn't portable
across that boundary -- whichever OS touched the shared `.venv/` last broke it
for the other.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [x] Added/updated documentation
- [x] Refactored existing code

- Added `poetry.toml` (`virtualenvs.in-project = false`) so poetry always uses
  its own OS-specific global cache, keyed by project name + path hash, instead
  of ever creating or adopting an in-project `.venv/`.
- Updated AGENTS.md/CLAUDE.md/README.md to separate what's safe to run directly
  against the local checkout (pure GitHub API commands, Docker lifecycle
  commands -- none touch which branch is checked out locally) from what
  actually needs a per-branch container (file edits, tests, commits, pushes on
  a branch). Documented that `docker shell` is interactive-only and can't be
  driven by a headless agent, with the `spin-up` + `exec`/`cp` pattern as the
  alternative -- exactly what was used live to fix #272, #274, and #275 this
  session.
- Rewrote `.claude/prompt.md`, which was still written entirely around the
  `workspace`/git-worktree model #238 deprecated and was never updated.
- Removed the `repo-worktrees` named volume from `docker-compose.yml` and
  `docker-compose.override.yml.example` -- dead config for the same
  deprecated worktree model.

## 🎯 Purpose
Let both OS contexts (and any container-based agent) run `poetry run
repo-scaffold ...` directly against the local checkout without corrupting each
other's environment, and make the docs accurately describe what actually needs
container isolation vs. what doesn't.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #282
- Closes #282

## 🧪 Testing
1. `poetry run tox -e precommit` inside a fresh container -- format/lint/type/
   coverage all green
2. Manually verified: `poetry.toml` present, no in-project `.venv/` in a fresh
   clone
3. Grepped `tests/` for any reference to the removed compose volume or
   `.claude/prompt.md` content -- none found, nothing depends on either

## 🧰 Developer Notes
- Local cleanup (not part of this PR, can't be -- it's gitignored): the
  existing in-project `.venv/` on the repo owner's Windows checkout needs a
  one-time manual delete after this merges, so it stops being picked up.
