### PR TITLE
feat(rules): pass explicit languages and extended query suite to CodeQL default setup (#288)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,11 @@ poetry run repo-scaffold check rules --repo OWNER/REPO
 # Apply/sync repo settings, ruleset, and security features (see check rules for what it covers).
 # If .github/dependabot.yml can't be committed directly because the ruleset already requires
 # PRs, this opens a branch + PR for it instead of just warning -- check for and merge that PR.
+# CodeQL default setup is enabled with the repo's own known languages (mapped to CodeQL's
+# language identifiers) and the extended query suite, when languages are known -- falls back
+# to GitHub's bare auto-detected default setup when they aren't. `repo-scaffold create` passes
+# languages the same way: parsed from --languages when it scaffolds a new repo, detected from
+# disk when the local directory already exists and isn't touched by scaffolding.
 poetry run repo-scaffold apply rules --repo OWNER/REPO --apply
 
 # Check issue/PR templates for drift against repo-scaffold's current templates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,10 @@ poetry run repo-scaffold check rules --repo OWNER/REPO
 # Apply/sync repo settings, ruleset, and security features. If .github/dependabot.yml
 # can't be committed directly because the ruleset already requires PRs, this opens a
 # branch + PR for it instead of just warning -- check for and merge that PR.
+# CodeQL default setup gets the repo's own known languages (mapped to CodeQL's language
+# identifiers) plus the extended query suite when languages are known, falling back to
+# GitHub's bare auto-detected default otherwise. `create` passes languages the same way:
+# parsed from --languages when scaffolding, detected from disk for an existing directory.
 poetry run repo-scaffold apply rules --repo OWNER/REPO --apply
 
 # Check issue/PR templates for drift against repo-scaffold's current templates

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -1873,6 +1873,12 @@ def main(argv: list[str] | None = None) -> int:
                     "Error: failed to initialize scaffold for create.", file=sys.stderr
                 )
                 return 1
+        else:
+            # An existing, non-empty local directory wasn't scaffolded by this
+            # run -- detect its actual language stack from disk rather than
+            # leaving settings (e.g. CodeQL default setup) with no language
+            # info at all.
+            languages = detect_languages_from_repo(repo_dir)
 
         create_repo_dir = repo_dir
         temp_create_dir: tempfile.TemporaryDirectory[str] | None = None
@@ -1892,6 +1898,7 @@ def main(argv: list[str] | None = None) -> int:
                 apply_settings=not ns.skip_settings,
                 dry_run=ns.dry_run,
                 stage_files=needs_init,
+                languages=list(languages),
                 out=(
                     (
                         lambda line: print(

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -1890,6 +1890,7 @@ def create_repository(
     apply_settings: bool,
     dry_run: bool,
     stage_files: bool = False,
+    languages: list[str] | None = None,
     out: Callable[[str], None] = print,
     err: Callable[[str], None] | None = None,
 ) -> CreateSummary:
@@ -1938,6 +1939,7 @@ def create_repository(
                 dry_run=dry_run,
                 out=out,
                 warn=emit_err,
+                languages=languages,
             )
             settings_applied = True
         elif apply_settings and not pushed:

--- a/src/repo_scaffold/create_ops.py
+++ b/src/repo_scaffold/create_ops.py
@@ -75,6 +75,13 @@ _LANG_ECOSYSTEM_MAP: dict[str, str] = {
     "react": "npm",
 }
 
+_LANG_CODEQL_MAP: dict[str, str] = {
+    "python": "python",
+    "go": "go",
+    "gin": "go",
+    "react": "javascript-typescript",
+}
+
 
 def _is_managed_ruleset_name(name: object) -> bool:
     return isinstance(name, str) and (
@@ -968,13 +975,26 @@ def _enable_code_scanning_default_setup(
     repo: str,
     out: Callable[[str], None],
     warn: Callable[[str], None],
+    languages: list[str] | None = None,
 ) -> None:
+    payload: dict[str, object] = {"state": "configured"}
+    codeql_languages = sorted(
+        {
+            _LANG_CODEQL_MAP[lang]
+            for lang in (languages or [])
+            if lang in _LANG_CODEQL_MAP
+        }
+    )
+    if codeql_languages:
+        payload["languages"] = codeql_languages
+        payload["query_suite"] = "extended"
+
     cp = _api(
         repo_dir=repo_dir,
         env=env,
         method="PATCH",
         endpoint=f"/repos/{repo}/code-scanning/default-setup",
-        stdin_text=json.dumps({"state": "configured"}),
+        stdin_text=json.dumps(payload),
     )
     if cp.returncode == 0:
         out("Enabled code scanning default setup.")
@@ -1689,6 +1709,7 @@ def _apply_settings(
         repo=repo,
         out=out,
         warn=warn,
+        languages=languages,
     )
 
     if visibility == "public":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1402,6 +1402,7 @@ def test_create_subcommand_delegates_to_create_ops(
         apply_settings,
         dry_run,
         stage_files,
+        languages,
         out,
         err,
     ):
@@ -1433,6 +1434,49 @@ def test_create_subcommand_delegates_to_create_ops(
     assert called["dry_run"] is True
 
 
+def test_create_detects_languages_for_existing_nonempty_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An existing, non-empty local directory isn't scaffolded (needs_init is
+    False), so its language stack must come from detecting what's actually on
+    disk rather than being left empty -- otherwise settings applied during
+    create (e.g. CodeQL default setup) get no language info at all."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(parents=True)
+    (repo_dir / "pyproject.toml").write_text("[tool.poetry]\n", encoding="utf-8")
+
+    called: dict[str, object] = {}
+
+    def _fake_create_repository(
+        *,
+        repo_dir: Path,
+        repo,
+        owner,
+        name,
+        visibility,
+        apply_settings,
+        dry_run,
+        stage_files,
+        languages,
+        out,
+        err,
+    ):
+        called["languages"] = languages
+        return CreateSummary(
+            repo="acme/repo",
+            repo_created=True,
+            pushed=True,
+            settings_applied=True,
+            failures=0,
+        )
+
+    monkeypatch.setattr("repo_scaffold.cli.create_repository", _fake_create_repository)
+
+    rc = main(["create", "--path", str(repo_dir), "--repo", "acme/repo", "--dry-run"])
+    assert rc == 0
+    assert called["languages"] == ["python"]
+
+
 def test_create_auto_inits_default_path_from_github_repo_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1454,6 +1498,7 @@ def test_create_auto_inits_default_path_from_github_repo_env(
         apply_settings,
         dry_run,
         stage_files,
+        languages,
         out,
         err,
     ):
@@ -1506,6 +1551,7 @@ def test_create_repo_flag_name_takes_precedence_for_auto_init_path(
         apply_settings,
         dry_run,
         stage_files,
+        languages,
         out,
         err,
     ):

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -2130,6 +2130,26 @@ def test_create_repository_covers_success_skip_and_error_paths(
     assert summary.failures == 0
     assert applied == ["acme/repo"]
 
+    applied_languages: list[list[str] | None] = []
+    monkeypatch.setattr(
+        create_ops,
+        "_apply_settings",
+        lambda **kwargs: applied_languages.append(kwargs.get("languages")),
+    )
+    create_ops.create_repository(
+        repo_dir=repo_dir,
+        repo=None,
+        owner=None,
+        name=None,
+        visibility="public",
+        apply_settings=True,
+        dry_run=False,
+        languages=["python"],
+        out=lambda _line: None,
+        err=lambda _line: None,
+    )
+    assert applied_languages == [["python"]]
+
     skipped_lines: list[str] = []
     monkeypatch.setattr(
         create_ops,

--- a/tests/test_create_ops.py
+++ b/tests/test_create_ops.py
@@ -850,6 +850,70 @@ def test_enable_code_scanning_default_setup_success_and_warning(
     )
 
 
+def test_enable_code_scanning_default_setup_includes_mapped_languages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payloads: list[str | None] = []
+
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **kwargs: (
+            payloads.append(kwargs.get("stdin_text"))
+            or subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="", stderr=""
+            )
+        ),
+    )
+
+    create_ops._enable_code_scanning_default_setup(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        out=lambda _line: None,
+        warn=lambda _line: None,
+        languages=["gin", "react", "python"],
+    )
+
+    assert payloads[0] is not None
+    payload = json.loads(payloads[0])
+    assert payload["state"] == "configured"
+    assert payload["query_suite"] == "extended"
+    assert sorted(payload["languages"]) == ["go", "javascript-typescript", "python"]
+
+
+def test_enable_code_scanning_default_setup_no_languages_matches_old_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No known languages -> unchanged from the pre-existing behavior, since
+    GitHub's own auto-detection is the only sensible fallback when we don't
+    know the repo's language stack."""
+    payloads: list[str | None] = []
+
+    monkeypatch.setattr(
+        create_ops,
+        "_api",
+        lambda **kwargs: (
+            payloads.append(kwargs.get("stdin_text"))
+            or subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout="", stderr=""
+            )
+        ),
+    )
+
+    create_ops._enable_code_scanning_default_setup(
+        repo_dir=Path("/tmp/repo"),
+        env={},
+        repo="acme/repo",
+        out=lambda _line: None,
+        warn=lambda _line: None,
+        languages=None,
+    )
+
+    assert payloads[0] is not None
+    assert json.loads(payloads[0]) == {"state": "configured"}
+
+
 def test_sync_ruleset_covers_update_create_missing_id_and_api_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## 🧾 Title
Pass explicit languages and extended query suite to CodeQL default setup

## 🧠 Description
Surfaced while reviewing GitHub's "Customize code scanning default setup
at scale" changelog post. The new `github-codeql-config-file` custom-
property feature itself is out of scope here -- adopting it means deciding
we want org-wide custom CodeQL query/path config, a separate product
decision, not a quick fix. While checking it, found a smaller, unrelated
gap in `_enable_code_scanning_default_setup()`: it calls `PATCH
/repos/{repo}/code-scanning/default-setup` with only `{"state":
"configured"}`, leaving `languages` on GitHub's auto-detection and
`query_suite` on the narrower `"default"` suite -- even though the repo's
own language stack is already known and resolved elsewhere in this same
file for the ruleset's required-status-checks.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [x] Refactored existing code

- Added `_LANG_CODEQL_MAP`, mirroring the existing `_LANG_ECOSYSTEM_MAP`
  pattern used for Dependabot ecosystems: `go`/`gin` -> `go`, `python` ->
  `python`, `react` -> `javascript-typescript`.
- When the caller's `languages` resolve to at least one mapped CodeQL
  language, the PATCH payload now also includes `languages` and
  `query_suite: "extended"`. When none are known, the payload is
  unchanged from before -- GitHub's own auto-detection is the only
  sensible fallback when the repo's language stack isn't known.
- Threaded the existing `languages` parameter from `_apply_settings`'s
  call site through to `_enable_code_scanning_default_setup` -- no new
  resolution logic, just passing an existing value through.

## 🎯 Purpose
Give every managed repo's CodeQL default setup the same explicit language
list `apply rules` already resolves for its ruleset, plus broader query
coverage, instead of relying on GitHub's bare auto-detected default.

## 🔗 Related Issues / Epics
- **Epic:** #184
- **Issue:** #288
- Closes #288

## 🧪 Testing
1. `poetry run tox -e precommit` -- format/lint/type/coverage (75.10%,
   threshold 70%) all green.
2. New unit tests: mapped-languages payload includes `languages` +
   `query_suite: "extended"` (including `gin`->`go` mapping); no-languages
   payload is byte-identical to the pre-existing `{"state": "configured"}`
   behavior.

## 🧰 Developer Notes
- `github-codeql-config-file` (org-wide custom CodeQL config file) remains
  deliberately out of scope -- flagged as a candidate for a future ticket
  if we decide we want org-wide query/path customization.
