### PR TITLE
fix(registry): move default registry.json location from ~/.repo-scaffold/ to repo root (#234)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,19 @@ cp .env.example .env
 
 ---
 
+## Local registry
+
+`repo-scaffold repo` commands (`register`, `list`, `forget`, `discover`) track known repos
+in a local `registry.json`. It defaults to `{repo_root}/.repo-scaffold/registry.json` --
+gitignored, local state per working copy -- not a home-directory file, so it travels with
+the checkout instead of being invisible to a fresh clone or container.
+
+Override the location with `REPO_SCAFFOLD_REGISTRY_PATH` if needed. An existing
+`~/.repo-scaffold/registry.json` from before this change is migrated automatically the
+first time any registry command runs, with a one-time warning printed to stderr.
+
+---
+
 ## Docker dev environment
 
 Each active branch gets its own container (`{repo-name}-{branch-slug}`). All containers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,12 @@ Token lives in `.env` as `GH_TOKEN`. Commands pick it up automatically via `_see
 ## Coverage
 All GitHub operations (repos, issues, PRs, projects, backlog) are implemented via GH_TOKEN + urllib. No `gh` CLI required.
 
+## Local registry
+`repo-scaffold repo` commands track known repos in `registry.json`, which defaults to
+`{repo_root}/.repo-scaffold/registry.json` (gitignored, travels with the checkout) rather
+than a home-directory file. Override with `REPO_SCAFFOLD_REGISTRY_PATH`. An existing
+`~/.repo-scaffold/registry.json` is migrated automatically on first use.
+
 
 # Branch Workflow
 

--- a/src/repo_scaffold/registry_ops.py
+++ b/src/repo_scaffold/registry_ops.py
@@ -3,16 +3,23 @@
 Stores only what can't be re-derived live from git/GitHub: a local path and
 free-text notes per repo. Everything else (last commit, owner, status) is one
 git/GitHub call away and isn't worth caching here.
+
+Lives at {repo_root}/.repo-scaffold/registry.json (gitignored -- local state
+per working copy) so it's visible to any container or agent that has this
+repo checked out, unlike the old ~/.repo-scaffold/registry.json home-dir
+location a Docker container or fresh clone would never see.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 _REGISTRY_ENV_VAR = "REPO_SCAFFOLD_REGISTRY_PATH"
+_LEGACY_REGISTRY_PATH = Path.home() / ".repo-scaffold" / "registry.json"
 
 
 @dataclass(frozen=True)
@@ -22,15 +29,46 @@ class RegistryEntry:
     notes: str = ""
 
 
+def _repo_root() -> Path:
+    """Directory containing pyproject.toml, walking up from this file.
+
+    Falls back to the current working directory if none is found (e.g. this
+    module was somehow imported outside a repo-scaffold checkout).
+    """
+    current = Path(__file__).resolve().parent
+    for candidate in (current, *current.parents):
+        if (candidate / "pyproject.toml").exists():
+            return candidate
+    return Path.cwd()
+
+
 def registry_path() -> Path:
     override = os.environ.get(_REGISTRY_ENV_VAR)
     if override:
         return Path(override)
-    return Path.home() / ".repo-scaffold" / "registry.json"
+    return _repo_root() / ".repo-scaffold" / "registry.json"
+
+
+def _migrate_legacy_registry(target: Path) -> None:
+    """One-time copy of ~/.repo-scaffold/registry.json to the new location."""
+    if target.exists() or not _LEGACY_REGISTRY_PATH.exists():
+        return
+    if _LEGACY_REGISTRY_PATH.resolve() == target.resolve():
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        _LEGACY_REGISTRY_PATH.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    print(
+        f"Migrated registry from {_LEGACY_REGISTRY_PATH} to {target} "
+        "(the old location is no longer used and can be deleted).",
+        file=sys.stderr,
+    )
 
 
 def load_registry(path: Path | None = None) -> dict[str, RegistryEntry]:
     target = path or registry_path()
+    _migrate_legacy_registry(target)
     if not target.exists():
         return {}
     try:

--- a/src/repo_scaffold/registry_ops.py
+++ b/src/repo_scaffold/registry_ops.py
@@ -49,26 +49,40 @@ def registry_path() -> Path:
     return _repo_root() / ".repo-scaffold" / "registry.json"
 
 
-def _migrate_legacy_registry(target: Path) -> None:
-    """One-time copy of ~/.repo-scaffold/registry.json to the new location."""
+def _migrate_legacy_registry(target: Path) -> Path:
+    """One-time copy of ~/.repo-scaffold/registry.json to the new location.
+
+    Returns the path to actually read: `target` normally, or the legacy path
+    itself if the copy failed (e.g. a read-only checkout) so existing state
+    is still usable even though it can't be persisted at the new location.
+    """
     if target.exists() or not _LEGACY_REGISTRY_PATH.exists():
-        return
+        return target
     if _LEGACY_REGISTRY_PATH.resolve() == target.resolve():
-        return
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(
-        _LEGACY_REGISTRY_PATH.read_text(encoding="utf-8"), encoding="utf-8"
-    )
+        return target
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            _LEGACY_REGISTRY_PATH.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+    except OSError as exc:
+        print(
+            f"Warning: could not migrate registry to {target} ({exc}); "
+            f"reading from legacy location {_LEGACY_REGISTRY_PATH} instead.",
+            file=sys.stderr,
+        )
+        return _LEGACY_REGISTRY_PATH
     print(
         f"Migrated registry from {_LEGACY_REGISTRY_PATH} to {target} "
         "(the old location is no longer used and can be deleted).",
         file=sys.stderr,
     )
+    return target
 
 
 def load_registry(path: Path | None = None) -> dict[str, RegistryEntry]:
     target = path or registry_path()
-    _migrate_legacy_registry(target)
+    target = _migrate_legacy_registry(target)
     if not target.exists():
         return {}
     try:

--- a/tests/test_registry_ops.py
+++ b/tests/test_registry_ops.py
@@ -2,15 +2,100 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import pytest
+
+import repo_scaffold.registry_ops as registry_ops
 from repo_scaffold.registry_ops import (
     forget_repo,
     list_registry,
     load_registry,
     register_repo,
+    registry_path,
     save_registry,
 )
+
+# ---------------------------------------------------------------------------
+# registry_path()
+# ---------------------------------------------------------------------------
+
+
+def test_registry_path_defaults_to_repo_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REPO_SCAFFOLD_REGISTRY_PATH", raising=False)
+    path = registry_path()
+    assert path.name == "registry.json"
+    assert path.parent.name == ".repo-scaffold"
+    assert (path.parent.parent / "pyproject.toml").exists()
+
+
+def test_registry_path_env_var_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    override = tmp_path / "custom" / "registry.json"
+    monkeypatch.setenv("REPO_SCAFFOLD_REGISTRY_PATH", str(override))
+    assert registry_path() == override
+
+
+# ---------------------------------------------------------------------------
+# Legacy ~/.repo-scaffold/registry.json migration
+# ---------------------------------------------------------------------------
+
+
+def test_load_registry_migrates_legacy_home_dir_registry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    legacy = tmp_path / "legacy" / "registry.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(
+        json.dumps({"acme/repo": {"local_path": "/old/path", "notes": ""}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(registry_ops, "_LEGACY_REGISTRY_PATH", legacy)
+
+    target = tmp_path / "new" / "registry.json"
+    entries = load_registry(target)
+
+    assert "acme/repo" in entries
+    assert target.exists()
+    assert "Migrated registry" in capsys.readouterr().err
+
+
+def test_load_registry_skips_migration_when_target_already_exists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    legacy = tmp_path / "legacy" / "registry.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(
+        json.dumps({"legacy/repo": {"local_path": "/old", "notes": ""}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(registry_ops, "_LEGACY_REGISTRY_PATH", legacy)
+
+    target = tmp_path / "new" / "registry.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        json.dumps({"current/repo": {"local_path": "/new", "notes": ""}}),
+        encoding="utf-8",
+    )
+
+    entries = load_registry(target)
+    assert "current/repo" in entries
+    assert "legacy/repo" not in entries
+
+
+def test_load_registry_no_migration_when_legacy_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        registry_ops,
+        "_LEGACY_REGISTRY_PATH",
+        tmp_path / "nonexistent" / "registry.json",
+    )
+    target = tmp_path / "new" / "registry.json"
+    assert load_registry(target) == {}
+    assert not target.exists()
 
 
 def test_load_registry_missing_file_returns_empty(tmp_path: Path) -> None:

--- a/tests/test_registry_ops.py
+++ b/tests/test_registry_ops.py
@@ -85,6 +85,32 @@ def test_load_registry_skips_migration_when_target_already_exists(
     assert "legacy/repo" not in entries
 
 
+def test_load_registry_falls_back_to_legacy_when_migration_write_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A read-only checkout must not crash commands that could otherwise still
+    read the existing legacy registry -- it should just skip persisting."""
+    legacy = tmp_path / "legacy" / "registry.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(
+        json.dumps({"acme/repo": {"local_path": "/old/path", "notes": ""}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(registry_ops, "_LEGACY_REGISTRY_PATH", legacy)
+
+    def _raise_mkdir(*args: object, **kwargs: object) -> None:
+        raise PermissionError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "mkdir", _raise_mkdir)
+
+    target = tmp_path / "new" / "registry.json"
+    entries = load_registry(target)
+
+    assert "acme/repo" in entries
+    assert not target.exists()
+    assert "could not migrate" in capsys.readouterr().err
+
+
 def test_load_registry_no_migration_when_legacy_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## 🧾 Title
Move registry.json default location from ~/.repo-scaffold/ to repo root

## 🧠 Description
`registry.json` defaulted to `~/.repo-scaffold/registry.json` (the home directory), which is invisible to any Docker container, fresh clone, or agent that only has this repo checked out -- every repo had to be re-registered from scratch each time.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [x] Added/updated documentation (module docstring)

- `registry_path()` now defaults to `{repo_root}/.repo-scaffold/registry.json`, resolved by walking up from this module's own file location to find `pyproject.toml`
- `REPO_SCAFFOLD_REGISTRY_PATH` env-var override still works, unchanged
- `.repo-scaffold/` was already gitignored -- no change needed there
- `load_registry()` now does a one-time migration: if the resolved target doesn't exist but `~/.repo-scaffold/registry.json` does, it copies the old file over and prints a deprecation warning to stderr
- No other docs/comments referenced the old path -- searched, only the code itself did

## 🎯 Purpose
Registry state should travel with the working copy, not live somewhere only the host machine's home directory can see.

## 🔗 Related Issues / Epics
- **Issue:** #234
- Closes #234

## 🧪 Testing
1. `poetry run tox -e precommit` -- green, `registry_ops.py` at 93% coverage
2. New tests: default path resolution, env-var override, legacy-registry migration (with and without an existing target, and with no legacy file at all)

## 🧰 Developer Notes
- [x] Verify environment variables are configured properly
- The bind-mount-based Compose dev container (see README.md) will now share the exact same registry file as the host, since the path resolves relative to the repo root wherever it's mounted. The newer per-branch git-clone container model (#238/#297) still has no shared filesystem with the host by design -- that's an existing, documented tradeoff, unrelated to this fix.
