### PR TITLE
fix(create): warn when --path/--out breaks the established layout convention (#305)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,18 @@ Override the location with `REPO_SCAFFOLD_REGISTRY_PATH` if needed. An existing
 `~/.repo-scaffold/registry.json` from before this change is migrated automatically the
 first time any registry command runs, with a one-time warning printed to stderr.
 
+### Local layout convention warning
+
+`create --path` and `init --out` compare their target directory against the layout
+pattern the registry's existing `local_path` entries already follow (e.g. `<wrapper>/src/<repo-name>/`,
+the pattern most repos on a given machine tend to use). If at least 3 registered repos have
+a `local_path` and 70% or more of them share a parent-directory nesting pattern that the
+new target doesn't match, a suggested conventional-equivalent path is printed to stderr.
+This is advisory only -- it never blocks, never prompts, and never fails the command. It
+stays silent with too few registry entries to infer a pattern confidently, so a repo-scaffold
+user with no established convention yet never sees it. It reads the registry without
+triggering the legacy-registry migration above (`create`/`init` are not registry commands).
+
 ---
 
 ## Docker dev environment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,13 @@ All GitHub operations (repos, issues, PRs, projects, backlog) are implemented vi
 than a home-directory file. Override with `REPO_SCAFFOLD_REGISTRY_PATH`. An existing
 `~/.repo-scaffold/registry.json` is migrated automatically on first use.
 
+`create --path` and `init --out` compare their target against the layout pattern the
+registry's existing `local_path` entries already follow (e.g. `<wrapper>/src/<repo-name>/`).
+With at least 3 registered repos where 70%+ share a nesting pattern the new target doesn't
+match, a suggested conventional-equivalent path is printed to stderr -- advisory only, never
+blocking, silent with too few entries to infer a pattern. Reads the registry without
+triggering the legacy-registry migration (these are not registry commands).
+
 
 # Branch Workflow
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Defaults:
 - default branch policy uses a ruleset baseline: PR required, `0` approvals, conversation resolution, squash-only, linear history, no force-push, no delete, CodeQL merge protection, and automatic Copilot review on new pushes
 - also attempts to enable secret scanning, push protection, Dependabot alerts, automated security updates, and public-repo private vulnerability reporting (best-effort; warnings only if plan/policy blocks them)
 - supports `--dry-run`
+- both `init --out` and `create --path` compare the target against the layout pattern the registry's existing `local_path` entries already follow, and print a suggested conventional-equivalent path to stderr on a mismatch -- advisory only, never blocking
 
 Tip: avoid shell-expanding possibly-unset vars in `--repo` (for example `--repo "$GITHUB_ORG/$TEST_REPO"`).
 If you keep repo metadata in `.env`, omit `--repo` and let `repo-scaffold` resolve it.

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -366,7 +366,7 @@ def _warn_if_breaks_layout_convention(repo_dir: Path, repo_name: str) -> None:
     established local convention yet.
     """
     try:
-        entries = list(load_registry().values())
+        entries = list(load_registry(migrate=False).values())
     except Exception:
         return
 
@@ -383,7 +383,7 @@ def _warn_if_breaks_layout_convention(repo_dir: Path, repo_name: str) -> None:
     if resolved.parent.name == "src":
         return
 
-    suggested = resolved.parent / "src" / repo_name
+    suggested = resolved / "src" / repo_name
     print(
         f"warning: {resolved} does not match the local layout convention used by "
         f"{len(nested)}/{len(paths)} registered repos (<wrapper>/src/<repo-name>/). "

--- a/src/repo_scaffold/cli.py
+++ b/src/repo_scaffold/cli.py
@@ -353,6 +353,45 @@ def _resolve_output_path(name: str) -> Path:
     return Path(name)
 
 
+_LAYOUT_MIN_SAMPLE = 3
+_LAYOUT_MAJORITY_THRESHOLD = 0.7
+
+
+def _warn_if_breaks_layout_convention(repo_dir: Path, repo_name: str) -> None:
+    """Compare repo_dir against the nesting pattern the registry's existing
+    local_path entries already follow, and warn (never block) on a mismatch.
+
+    Stays silent with too few registry entries to infer a pattern confidently,
+    so this never fires spuriously for a repo-scaffold user with no
+    established local convention yet.
+    """
+    try:
+        entries = list(load_registry().values())
+    except Exception:
+        return
+
+    paths = [Path(e.local_path) for e in entries if e.local_path]
+    if len(paths) < _LAYOUT_MIN_SAMPLE:
+        return
+
+    nested = [p for p in paths if p.parent.name == "src"]
+    ratio = len(nested) / len(paths)
+    if ratio < _LAYOUT_MAJORITY_THRESHOLD:
+        return
+
+    resolved = repo_dir.resolve()
+    if resolved.parent.name == "src":
+        return
+
+    suggested = resolved.parent / "src" / repo_name
+    print(
+        f"warning: {resolved} does not match the local layout convention used by "
+        f"{len(nested)}/{len(paths)} registered repos (<wrapper>/src/<repo-name>/). "
+        f"Consider: {suggested}",
+        file=sys.stderr,
+    )
+
+
 def _seed_env_for_parsed_mode(ns: argparse.Namespace) -> None:
     _seed_env_from_dotenv(Path.cwd() / ".env")
     if ns.mode == "create" and getattr(ns, "path", None):
@@ -1897,6 +1936,8 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 2
 
+        _warn_if_breaks_layout_convention(repo_dir, repo_name_hint)
+
         needs_init = not repo_dir.exists()
         if repo_dir.exists() and repo_dir.is_dir():
             needs_init = not any(repo_dir.iterdir())
@@ -2039,6 +2080,8 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 2
+
+        _warn_if_breaks_layout_convention(out_dir, init_name)
 
         cfg = ScaffoldConfig(
             name=init_name,

--- a/src/repo_scaffold/registry_ops.py
+++ b/src/repo_scaffold/registry_ops.py
@@ -80,9 +80,14 @@ def _migrate_legacy_registry(target: Path) -> Path:
     return target
 
 
-def load_registry(path: Path | None = None) -> dict[str, RegistryEntry]:
+def load_registry(
+    path: Path | None = None, *, migrate: bool = True
+) -> dict[str, RegistryEntry]:
     target = path or registry_path()
-    target = _migrate_legacy_registry(target)
+    if migrate:
+        target = _migrate_legacy_registry(target)
+    elif not target.exists() and target != _LEGACY_REGISTRY_PATH:
+        target = _LEGACY_REGISTRY_PATH
     if not target.exists():
         return {}
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4583,7 +4583,7 @@ def test_layout_warning_fires_on_mismatch(
     ]
     monkeypatch.setattr(
         "repo_scaffold.cli.load_registry",
-        lambda: {e.repo: e for e in _registry_entries(nested)},
+        lambda **_: {e.repo: e for e in _registry_entries(nested)},
     )
 
     flat_target = tmp_path / "NewProj"
@@ -4591,7 +4591,7 @@ def test_layout_warning_fires_on_mismatch(
 
     stderr = capsys.readouterr().err
     assert "does not match the local layout convention" in stderr
-    suggested = flat_target.resolve().parent / "src" / "new-proj"
+    suggested = flat_target.resolve() / "src" / "new-proj"
     assert str(suggested) in stderr
 
 
@@ -4605,7 +4605,7 @@ def test_layout_warning_silent_when_path_matches(
     ]
     monkeypatch.setattr(
         "repo_scaffold.cli.load_registry",
-        lambda: {e.repo: e for e in _registry_entries(nested)},
+        lambda **_: {e.repo: e for e in _registry_entries(nested)},
     )
 
     matching_target = tmp_path / "NewProj" / "src" / "new-proj"
@@ -4618,7 +4618,7 @@ def test_layout_warning_silent_when_path_matches(
 def test_layout_warning_silent_with_empty_registry(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:
-    monkeypatch.setattr("repo_scaffold.cli.load_registry", lambda: {})
+    monkeypatch.setattr("repo_scaffold.cli.load_registry", lambda **_: {})
 
     cli_module._warn_if_breaks_layout_convention(tmp_path / "NewProj", "new-proj")
 
@@ -4636,7 +4636,7 @@ def test_layout_warning_silent_with_mixed_registry(
     ]
     monkeypatch.setattr(
         "repo_scaffold.cli.load_registry",
-        lambda: {e.repo: e for e in _registry_entries(mixed)},
+        lambda **_: {e.repo: e for e in _registry_entries(mixed)},
     )
 
     cli_module._warn_if_breaks_layout_convention(tmp_path / "NewProj", "new-proj")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4563,3 +4563,83 @@ def test_sync_configs_opens_pr_for_drifted_repo(
     assert rc == 0
     stdout = capsys.readouterr().out
     assert "sync PRs opened: 1" in stdout
+
+
+def _registry_entries(paths: list[str]) -> list:
+    from repo_scaffold.registry_ops import RegistryEntry
+
+    return [
+        RegistryEntry(repo=f"acme/repo{i}", local_path=p) for i, p in enumerate(paths)
+    ]
+
+
+def test_layout_warning_fires_on_mismatch(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    nested = [
+        str(tmp_path / "ProjA" / "src" / "repo-a"),
+        str(tmp_path / "ProjB" / "src" / "repo-b"),
+        str(tmp_path / "ProjC" / "src" / "repo-c"),
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.load_registry",
+        lambda: {e.repo: e for e in _registry_entries(nested)},
+    )
+
+    flat_target = tmp_path / "NewProj"
+    cli_module._warn_if_breaks_layout_convention(flat_target, "new-proj")
+
+    stderr = capsys.readouterr().err
+    assert "does not match the local layout convention" in stderr
+    suggested = flat_target.resolve().parent / "src" / "new-proj"
+    assert str(suggested) in stderr
+
+
+def test_layout_warning_silent_when_path_matches(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    nested = [
+        str(tmp_path / "ProjA" / "src" / "repo-a"),
+        str(tmp_path / "ProjB" / "src" / "repo-b"),
+        str(tmp_path / "ProjC" / "src" / "repo-c"),
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.load_registry",
+        lambda: {e.repo: e for e in _registry_entries(nested)},
+    )
+
+    matching_target = tmp_path / "NewProj" / "src" / "new-proj"
+    cli_module._warn_if_breaks_layout_convention(matching_target, "new-proj")
+
+    stderr = capsys.readouterr().err
+    assert stderr == ""
+
+
+def test_layout_warning_silent_with_empty_registry(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setattr("repo_scaffold.cli.load_registry", lambda: {})
+
+    cli_module._warn_if_breaks_layout_convention(tmp_path / "NewProj", "new-proj")
+
+    stderr = capsys.readouterr().err
+    assert stderr == ""
+
+
+def test_layout_warning_silent_with_mixed_registry(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    mixed = [
+        str(tmp_path / "ProjA" / "src" / "repo-a"),
+        str(tmp_path / "repo-b"),
+        str(tmp_path / "repo-c"),
+    ]
+    monkeypatch.setattr(
+        "repo_scaffold.cli.load_registry",
+        lambda: {e.repo: e for e in _registry_entries(mixed)},
+    )
+
+    cli_module._warn_if_breaks_layout_convention(tmp_path / "NewProj", "new-proj")
+
+    stderr = capsys.readouterr().err
+    assert stderr == ""

--- a/tests/test_registry_ops.py
+++ b/tests/test_registry_ops.py
@@ -62,6 +62,40 @@ def test_load_registry_migrates_legacy_home_dir_registry(
     assert "Migrated registry" in capsys.readouterr().err
 
 
+def test_load_registry_migrate_false_does_not_write_or_print(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    legacy = tmp_path / "legacy" / "registry.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(
+        json.dumps({"acme/repo": {"local_path": "/old/path", "notes": ""}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(registry_ops, "_LEGACY_REGISTRY_PATH", legacy)
+
+    target = tmp_path / "new" / "registry.json"
+    entries = load_registry(target, migrate=False)
+
+    assert "acme/repo" in entries
+    assert not target.exists()
+    assert capsys.readouterr().err == ""
+
+
+def test_load_registry_migrate_false_with_no_legacy_and_no_target_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        registry_ops, "_LEGACY_REGISTRY_PATH", tmp_path / "no-such-legacy.json"
+    )
+
+    target = tmp_path / "new" / "registry.json"
+    entries = load_registry(target, migrate=False)
+
+    assert entries == {}
+    assert not target.exists()
+    assert capsys.readouterr().err == ""
+
+
 def test_load_registry_skips_migration_when_target_already_exists(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## 🧾 Title
warn when --path/--out breaks the established local layout convention

## 🧠 Description
create --path and init --out use whatever path they're given completely literally -- there's no concept anywhere in the tool of a project-wrapper directory. Every repo already registered in this machine's registry.json follows `ProjectName\src\repo-name\`, but nothing checked a new target against that pattern before creating a repo there. Surfaced live when create --path put blairg23/marquee and blairg23/signet directly at `Active\Marquee\` and `Active\Signet\` instead of nested one level into `src/`, breaking the convention every other registered repo follows.

## 🧩 Changes Included
- [x] Implemented new feature or enhancement
- [ ] Added/updated documentation
- [ ] Refactored existing code
- [ ] Improved error handling or logging
- [ ] Updated environment configuration
- [ ] Other (specify)

## 🎯 Purpose
Catch a target path that breaks the user's established local repo layout before writing anything there, instead of only catching it after the fact by comparing against the registry manually.

## 🔗 Related Issues / Epics
- **Issue:** #305
- Closes #305

## 🧪 Testing
1. `tox -e precommit` -- black, ruff, mypy, coverage all pass
2. Four new unit tests in test_cli.py: warning fires on mismatch, silent when target already matches, silent with an empty registry, silent with a mixed/inconsistent registry (no false positives)
3. Manual: with this machine's real registry.json (9 entries, 8 nested under src/), pointing `create --path` at a flat target now prints a warning with the suggested nested-equivalent path; pointing it at an already-nested target prints nothing

## 🧰 Developer Notes
- Non-blocking by design: prints to stderr and continues, never prompts, never fails the command -- must stay usable from a headless/scripted agent
- Convention is derived empirically from the registry ( entries,  sharing a `src/` parent), not hardcoded, so this never fires for a repo-scaffold user with no established convention yet
- Related: #115 (established the registry/local_path convention), #235 (registry schema redesign, same convention via a different code path)