### PR TITLE
chore: sync issue/PR templates from repo-scaffold

### DIFF
--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -54,6 +54,13 @@ jobs:
               labels: ["needs-format"],
             });
 
+            // Relative markdown links in a comment resolve against the comment's
+            // own URL (.../issues/<n>), not the repo root, so a plain relative
+            // path 404s instead of opening the template. Build an absolute blob
+            // URL against the actual default branch instead (see #299).
+            const ref = context.payload.repository.default_branch;
+            const repoBlobUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${ref}`;
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -62,6 +69,6 @@ jobs:
                 "This issue is missing required template sections:",
                 ...missing.map(h => `- \`${h}\``),
                 "",
-                "Please update the body to match the [epic template](../.github/ISSUE_TEMPLATE/epic.md) or [ticket template](../.github/ISSUE_TEMPLATE/ticket.md).",
+                `Please update the body to match the [epic template](${repoBlobUrl}/.github/ISSUE_TEMPLATE/epic.md) or [ticket template](${repoBlobUrl}/.github/ISSUE_TEMPLATE/ticket.md).`,
               ].join("\n"),
             });

--- a/.github/workflows/validate-pr-sop.yml
+++ b/.github/workflows/validate-pr-sop.yml
@@ -41,6 +41,47 @@ jobs:
               return;
             }
 
+            // The SOP's prescribed reply form is "Fixed in <hash>. <sentence>."
+            // (see AGENTS.md Review thread SOP step 2) -- anchor to that phrase
+            // instead of matching a bare hex-looking token anywhere in the
+            // comment, which false-positives on ordinary words built entirely
+            // from hex letters (e.g. "defaced"). See #263 (original bug) and
+            // the follow-up review on #307 (this anchoring fix).
+            const REPLY_RE = /\bfixed in\s+[0-9a-f]{7,40}\b/i;
+
+            // A thread's own comments connection can in principle exceed one
+            // page too, same as the outer reviewThreads connection -- fetch
+            // whatever's left with a follow-up query scoped to that thread.
+            async function fetchRemainingComments(threadId, after) {
+              const comments = [];
+              while (true) {
+                const data = await github.graphql(`
+                  query($threadId: ID!, $after: String) {
+                    node(id: $threadId) {
+                      ... on PullRequestReviewThread {
+                        comments(first: 50, after: $after) {
+                          pageInfo { hasNextPage endCursor }
+                          nodes {
+                            databaseId
+                            body
+                            reactionGroups {
+                              content
+                              reactors { totalCount }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                `, { threadId, after });
+                const page = data.node.comments;
+                comments.push(...page.nodes);
+                if (!page.pageInfo.hasNextPage) break;
+                after = page.pageInfo.endCursor;
+              }
+              return comments;
+            }
+
             const threads = [];
             let after = null;
             while (true) {
@@ -54,11 +95,13 @@ jobs:
                           id
                           isResolved
                           comments(first: 50) {
+                            pageInfo { hasNextPage endCursor }
                             nodes {
                               databaseId
-                              author { login }
-                              reactions(first: 30) {
-                                nodes { content }
+                              body
+                              reactionGroups {
+                                content
+                                reactors { totalCount }
                               }
                             }
                           }
@@ -87,12 +130,23 @@ jobs:
 
             const failing = [];
             for (const thread of threads) {
-              const comments = thread.comments.nodes;
-              const hasReply = comments.length > 1;
+              let comments = thread.comments.nodes;
+              if (thread.comments.pageInfo.hasNextPage) {
+                comments = comments.concat(
+                  await fetchRemainingComments(thread.id, thread.comments.pageInfo.endCursor)
+                );
+              }
+
+              const hasReply = comments.slice(1).some(c => REPLY_RE.test(c.body || ""));
               const isResolved = thread.isResolved;
               const firstComment = comments[0] || {};
-              const reactions = (firstComment.reactions?.nodes) || [];
-              const hasPlusOne = reactions.some(r => r.content === "THUMBS_UP");
+              // reactionGroups gives an aggregate count per reaction type in
+              // one shot -- no pagination needed, unlike the raw `reactions`
+              // connection this replaced (see #303).
+              const reactionGroups = firstComment.reactionGroups || [];
+              const hasPlusOne = reactionGroups.some(
+                g => g.content === "THUMBS_UP" && g.reactors.totalCount > 0
+              );
 
               if (!hasReply || !isResolved || !hasPlusOne) {
                 const missing = [];

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
 
     steps:
       - name: Check PR body and flag if malformed
@@ -17,6 +18,7 @@ jobs:
           script: |
             const number = context.payload.pull_request.number;
             const author = context.payload.pull_request.user?.login || "";
+            const MISSING_SECTIONS_MARKER = "This PR is missing required body sections:";
 
             const removeStaleLabel = async () => {
               try {
@@ -47,7 +49,11 @@ jobs:
               return;
             }
 
-            // Create needs-format label if it does not exist yet (422 = already exists)
+            // Create needs-format label if it does not exist yet (422 = already
+            // exists). Any other failure (e.g. a permissions regression) is
+            // surfaced instead of swallowed, so it shows up in the Actions log
+            // rather than silently preventing the label -- and therefore the
+            // explanatory comment below -- from ever landing (see #302).
             try {
               await github.rest.issues.createLabel({
                 owner: context.repo.owner,
@@ -56,7 +62,11 @@ jobs:
                 color: "e11d48",
                 description: "Issue body does not match the required template format",
               });
-            } catch (_) {}
+            } catch (err) {
+              if (err.status !== 422) {
+                core.warning(`Failed to create needs-format label: ${err.message}`);
+              }
+            }
 
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -65,14 +75,37 @@ jobs:
               labels: ["needs-format"],
             });
 
+            // Avoid posting a duplicate notice on every push while the PR stays
+            // malformed -- only comment once, when the notice isn't already
+            // there (see #301).
+            const existingComments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+            });
+            const alreadyNotified = existingComments.some(
+              c => c.user?.type === "Bot" && (c.body || "").includes(MISSING_SECTIONS_MARKER)
+            );
+            if (alreadyNotified) {
+              core.info(`PR #${number} already has the missing-sections notice; skipping duplicate comment.`);
+              return;
+            }
+
+            // Relative markdown links in a comment resolve against the comment's
+            // own URL (.../pull/<n>), not the repo root, so a plain relative path
+            // 404s instead of opening the template. Build an absolute blob URL
+            // against the actual default branch instead (see #299).
+            const ref = context.payload.repository.default_branch;
+            const templateUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${ref}/.github/pull_request_template.md`;
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: number,
               body: [
-                "This PR is missing required body sections:",
+                MISSING_SECTIONS_MARKER,
                 ...missing.map(h => `- \`${h}\``),
                 "",
-                "Please update the PR description to match the [pull request template](../.github/pull_request_template.md).",
+                `Please update the PR description to match the [pull request template](${templateUrl}).`,
               ].join("\n"),
             });


### PR DESCRIPTION
## 🧾 Title
Sync issue/PR templates from repo-scaffold

## 🧠 Description
This PR was opened automatically by `repo-scaffold sync templates` because one or more of this repo's issue/PR templates have drifted from the current canonical versions repo-scaffold generates.

## 🧩 Changes Included
- [x] Added/updated documentation

## 🎯 Purpose
Keep downstream templates current with repo-scaffold's own canonical versions, the same way Dependabot keeps dependencies current -- never committed directly to the default branch.

## 🔗 Files Changed
- `.github/workflows/validate-issue.yml`
- `.github/workflows/validate-pr-sop.yml`
- `.github/workflows/validate-pr.yml`